### PR TITLE
Optimize home stats loading

### DIFF
--- a/database/migrations/008_extend_site_stats.sql
+++ b/database/migrations/008_extend_site_stats.sql
@@ -1,0 +1,26 @@
+-- ==========================================
+-- ポケふた - サイト全体の集計API拡張
+-- ==========================================
+-- 目的: 「画像ありマンホール数」を /api/site-stats に集約する
+
+DROP FUNCTION IF EXISTS public.get_site_stats();
+
+CREATE OR REPLACE FUNCTION public.get_site_stats()
+RETURNS TABLE(
+  total_manhole BIGINT,
+  total_manholes_with_photos BIGINT,
+  total_posts  BIGINT,
+  total_users  BIGINT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    (SELECT COUNT(*) FROM public.manhole)::BIGINT,
+    (SELECT COUNT(DISTINCT manhole_id) FROM public.photo WHERE manhole_id IS NOT NULL)::BIGINT,
+    (SELECT COUNT(*) FROM public.photo)::BIGINT,
+    (SELECT COUNT(*) FROM public.app_user)::BIGINT;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_site_stats() TO anon, authenticated;

--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -7,9 +7,13 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 
 type SiteStatsRow = {
   total_manhole: number | string | null;
+  total_manholes_with_photos?: number | string | null;
   total_posts: number | string | null;
   total_users: number | string | null;
 };
+
+const toCount = (value: number | string | null | undefined) =>
+  typeof value === 'number' ? value : Number(value ?? 0);
 
 export async function GET() {
   try {
@@ -21,11 +25,26 @@ export async function GET() {
     const row = (Array.isArray(rpcData) ? rpcData[0] : rpcData) as Partial<SiteStatsRow> | null;
 
     if (!rpcError && row) {
+      const admin = supabaseAdmin as unknown as SupabaseClient<Database> | null;
+      let manholesWithPhotos = toCount(row.total_manholes_with_photos);
+
+      if (row.total_manholes_with_photos == null && admin) {
+        const { data: photoManholes } = await admin
+          .from('photo')
+          .select('manhole_id')
+          .not('manhole_id', 'is', null);
+
+        manholesWithPhotos = new Set(
+          (photoManholes as Array<{ manhole_id: number | null }> | null)?.map(photo => photo.manhole_id) || []
+        ).size;
+      }
+
       return NextResponse.json({
         success: true,
-        users: typeof row.total_users === 'number' ? row.total_users : Number(row.total_users ?? 0),
-        posts: typeof row.total_posts === 'number' ? row.total_posts : Number(row.total_posts ?? 0),
-        manholes: typeof row.total_manhole === 'number' ? row.total_manhole : Number(row.total_manhole ?? 0),
+        users: toCount(row.total_users),
+        posts: toCount(row.total_posts),
+        manholes: toCount(row.total_manhole),
+        manholes_with_photos: manholesWithPhotos,
         source: 'rpc',
       });
     }
@@ -33,15 +52,26 @@ export async function GET() {
     // Fallback (requires service role)
     const admin = supabaseAdmin as unknown as SupabaseClient<Database> | null;
     if (admin) {
-      const [{ count: userCount }, { count: postCount }] = await Promise.all([
+      const [
+        { count: userCount },
+        { count: postCount },
+        { count: manholeCount },
+        { data: photoManholes },
+      ] = await Promise.all([
         admin.from('app_user').select('id', { head: true, count: 'exact' }),
         admin.from('photo').select('id', { head: true, count: 'exact' }),
+        admin.from('manhole').select('id', { head: true, count: 'exact' }),
+        admin.from('photo').select('manhole_id').not('manhole_id', 'is', null),
       ]);
 
       return NextResponse.json({
         success: true,
         users: userCount ?? 0,
         posts: postCount ?? 0,
+        manholes: manholeCount ?? 0,
+        manholes_with_photos: new Set(
+          (photoManholes as Array<{ manhole_id: number | null }> | null)?.map(photo => photo.manhole_id) || []
+        ).size,
         source: 'admin',
       });
     }
@@ -50,6 +80,8 @@ export async function GET() {
       success: true,
       users: null,
       posts: null,
+      manholes: null,
+      manholes_with_photos: null,
       source: 'unavailable',
     });
   } catch (error: unknown) {
@@ -58,6 +90,8 @@ export async function GET() {
         success: false,
         users: null,
         posts: null,
+        manholes: null,
+        manholes_with_photos: null,
         error: 'Failed to get site statistics',
         details: error instanceof Error ? error.message : 'Unknown error',
       },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,6 +32,7 @@ export default function HomePage() {
   const [feed, setFeed] = useState<FeedVisit[]>([]);
   const [totalUsers, setTotalUsers] = useState<number | null>(null);
   const [totalPosts, setTotalPosts] = useState<number | null>(null);
+  const [manholesWithPhotos, setManholesWithPhotos] = useState<number | null>(null);
   const feedPerPage = 24;
   const { trackView } = useAnalytics();
 
@@ -55,9 +56,7 @@ export default function HomePage() {
       }
     })();
 
-    loadFeed();
     loadSiteStats();
-    loadManholeStats();
   }, []);
 
   useEffect(() => {
@@ -85,19 +84,6 @@ export default function HomePage() {
     }
   };
 
-  const loadManholeStats = async () => {
-    try {
-      const response = await fetch('/api/manholes?limit=1');
-      if (!response.ok) return;
-      const data = await response.json();
-      if (data?.success) {
-        if (typeof data.total === 'number') setTotalManholes(data.total);
-      }
-    } catch {
-      // ignore
-    }
-  };
-
   const loadSiteStats = async () => {
     try {
       const response = await fetch('/api/site-stats');
@@ -107,6 +93,10 @@ export default function HomePage() {
       // トップからユーザ数は基本的に外す（必要なら後で小さく出す）
       setTotalUsers(typeof data.users === 'number' ? data.users : null);
       setTotalPosts(typeof data.posts === 'number' ? data.posts : null);
+      if (typeof data.manholes === 'number') setTotalManholes(data.manholes);
+      setManholesWithPhotos(
+        typeof data.manholes_with_photos === 'number' ? data.manholes_with_photos : null
+      );
     } catch {
       // ignore
     }
@@ -285,10 +275,14 @@ export default function HomePage() {
             {/* Sub info */}
             <div className="rpg-window">
               <h2 className="text-sm font-bold font-pixelJp text-rpg-textDark mb-3">サブ情報</h2>
-              <div className="grid grid-cols-2 gap-3">
+              <div className="grid grid-cols-3 gap-3">
                 <div className="text-center">
                   <div className="font-pixel text-xl text-rpg-yellow">{totalManholes || '—'}</div>
                   <div className="font-pixelJp text-xs text-rpg-textDark">全ポケふた</div>
+                </div>
+                <div className="text-center">
+                  <div className="font-pixel text-xl text-rpg-green">{manholesWithPhotos ?? '—'}</div>
+                  <div className="font-pixelJp text-xs text-rpg-textDark">写真あり</div>
                 </div>
                 <div className="text-center">
                   <div className="font-pixel text-xl text-rpg-blue">{totalPosts ?? '—'}</div>


### PR DESCRIPTION
## Summary
- avoid duplicate initial home feed fetch
- fold home manhole stats into /api/site-stats
- add manholes_with_photos to site stats and display it on the home page

## Test
- npm run type-check