### PR TITLE
Make visits a stamp rally passport

### DIFF
--- a/src/app/api/photo/[id]/route.ts
+++ b/src/app/api/photo/[id]/route.ts
@@ -159,39 +159,84 @@ export async function DELETE(
       }, { status: 403 });
     }
 
-    // ✅ 4. R2から画像ファイルを削除
-    try {
-      if (storage.delete) {
-        await storage.delete(photo.storage_key);
-        console.log(`Deleted photo from storage: ${photo.storage_key}`);
-      } else {
-        console.warn('Storage adapter does not support delete operation');
-      }
-    } catch (storageError: any) {
-      console.error('Error deleting photo from storage:', storageError);
-      // ストレージ削除に失敗してもDB削除は続行
-      // （ファイルが既に存在しない可能性もあるため）
-    }
+    const visitId = (photo.visit as any).id as string;
 
-    // ✅ 5. データベースから写真レコードを削除
-    const { error: deleteError } = await supabase
+    // ✅ 4. 同じ訪問記録に紐づく写真を取得
+    // 写真削除は「訪問記録の削除」として扱うため、同じvisitの写真もまとめて削除する。
+    const { data: visitPhotos, error: visitPhotosError } = await supabase
       .from('photo')
-      .delete()
-      .eq('id', photoId);
+      .select('id, storage_key')
+      .eq('visit_id', visitId);
 
-    if (deleteError) {
-      console.error('Error deleting photo from database:', deleteError);
+    if (visitPhotosError) {
+      console.error('Error fetching visit photos before delete:', visitPhotosError);
       return NextResponse.json({
         success: false,
-        error: 'Failed to delete photo from database',
-        details: deleteError.message
+        error: 'Failed to fetch related photos',
+        details: visitPhotosError.message
+      }, { status: 500 });
+    }
+
+    const photosToDelete = (visitPhotos && visitPhotos.length > 0)
+      ? visitPhotos
+      : [{ id: photo.id, storage_key: photo.storage_key }];
+    const deletedPhotoIds = photosToDelete.map((targetPhoto) => targetPhoto.id);
+
+    // ✅ 5. R2から画像ファイルを削除
+    for (const targetPhoto of photosToDelete) {
+      try {
+        if (storage.delete) {
+          await storage.delete(targetPhoto.storage_key);
+          console.log(`Deleted photo from storage: ${targetPhoto.storage_key}`);
+        } else {
+          console.warn('Storage adapter does not support delete operation');
+        }
+      } catch (storageError: any) {
+        console.error('Error deleting photo from storage:', storageError);
+        // ストレージ削除に失敗してもDB削除は続行
+        // （ファイルが既に存在しない可能性もあるため）
+      }
+    }
+
+    // ✅ 6. データベースから写真レコードを削除
+    const { error: deletePhotosError } = await supabase
+      .from('photo')
+      .delete()
+      .eq('visit_id', visitId);
+
+    if (deletePhotosError) {
+      console.error('Error deleting photos from database:', deletePhotosError);
+      return NextResponse.json({
+        success: false,
+        error: 'Failed to delete photos from database',
+        details: deletePhotosError.message
+      }, { status: 500 });
+    }
+
+    // ✅ 7. 訪問記録も削除
+    // visit_like / visit_comment / visit_bookmark はDB側の ON DELETE CASCADE で削除される。
+    const { error: deleteVisitError } = await supabase
+      .from('visit')
+      .delete()
+      .eq('id', visitId)
+      .eq('user_id', session.user.id);
+
+    if (deleteVisitError) {
+      console.error('Error deleting visit from database:', deleteVisitError);
+      return NextResponse.json({
+        success: false,
+        error: 'Failed to delete visit from database',
+        details: deleteVisitError.message
       }, { status: 500 });
     }
 
     return NextResponse.json({
       success: true,
-      message: 'Photo deleted successfully',
-      photo_id: photoId
+      message: 'Photo and visit deleted successfully',
+      photo_id: photoId,
+      photo_ids: deletedPhotoIds,
+      visit_id: visitId,
+      visit_deleted: true
     });
 
   } catch (error: any) {

--- a/src/app/api/photo/[id]/route.ts
+++ b/src/app/api/photo/[id]/route.ts
@@ -159,84 +159,39 @@ export async function DELETE(
       }, { status: 403 });
     }
 
-    const visitId = (photo.visit as any).id as string;
-
-    // ✅ 4. 同じ訪問記録に紐づく写真を取得
-    // 写真削除は「訪問記録の削除」として扱うため、同じvisitの写真もまとめて削除する。
-    const { data: visitPhotos, error: visitPhotosError } = await supabase
-      .from('photo')
-      .select('id, storage_key')
-      .eq('visit_id', visitId);
-
-    if (visitPhotosError) {
-      console.error('Error fetching visit photos before delete:', visitPhotosError);
-      return NextResponse.json({
-        success: false,
-        error: 'Failed to fetch related photos',
-        details: visitPhotosError.message
-      }, { status: 500 });
-    }
-
-    const photosToDelete = (visitPhotos && visitPhotos.length > 0)
-      ? visitPhotos
-      : [{ id: photo.id, storage_key: photo.storage_key }];
-    const deletedPhotoIds = photosToDelete.map((targetPhoto) => targetPhoto.id);
-
-    // ✅ 5. R2から画像ファイルを削除
-    for (const targetPhoto of photosToDelete) {
-      try {
-        if (storage.delete) {
-          await storage.delete(targetPhoto.storage_key);
-          console.log(`Deleted photo from storage: ${targetPhoto.storage_key}`);
-        } else {
-          console.warn('Storage adapter does not support delete operation');
-        }
-      } catch (storageError: any) {
-        console.error('Error deleting photo from storage:', storageError);
-        // ストレージ削除に失敗してもDB削除は続行
-        // （ファイルが既に存在しない可能性もあるため）
+    // ✅ 4. R2から画像ファイルを削除
+    try {
+      if (storage.delete) {
+        await storage.delete(photo.storage_key);
+        console.log(`Deleted photo from storage: ${photo.storage_key}`);
+      } else {
+        console.warn('Storage adapter does not support delete operation');
       }
+    } catch (storageError: any) {
+      console.error('Error deleting photo from storage:', storageError);
+      // ストレージ削除に失敗してもDB削除は続行
+      // （ファイルが既に存在しない可能性もあるため）
     }
 
-    // ✅ 6. データベースから写真レコードを削除
-    const { error: deletePhotosError } = await supabase
+    // ✅ 5. データベースから写真レコードを削除
+    const { error: deleteError } = await supabase
       .from('photo')
       .delete()
-      .eq('visit_id', visitId);
+      .eq('id', photoId);
 
-    if (deletePhotosError) {
-      console.error('Error deleting photos from database:', deletePhotosError);
+    if (deleteError) {
+      console.error('Error deleting photo from database:', deleteError);
       return NextResponse.json({
         success: false,
-        error: 'Failed to delete photos from database',
-        details: deletePhotosError.message
-      }, { status: 500 });
-    }
-
-    // ✅ 7. 訪問記録も削除
-    // visit_like / visit_comment / visit_bookmark はDB側の ON DELETE CASCADE で削除される。
-    const { error: deleteVisitError } = await supabase
-      .from('visit')
-      .delete()
-      .eq('id', visitId)
-      .eq('user_id', session.user.id);
-
-    if (deleteVisitError) {
-      console.error('Error deleting visit from database:', deleteVisitError);
-      return NextResponse.json({
-        success: false,
-        error: 'Failed to delete visit from database',
-        details: deleteVisitError.message
+        error: 'Failed to delete photo from database',
+        details: deleteError.message
       }, { status: 500 });
     }
 
     return NextResponse.json({
       success: true,
-      message: 'Photo and visit deleted successfully',
-      photo_id: photoId,
-      photo_ids: deletedPhotoIds,
-      visit_id: visitId,
-      visit_deleted: true
+      message: 'Photo deleted successfully',
+      photo_id: photoId
     });
 
   } catch (error: any) {

--- a/src/app/api/visits/[id]/route.ts
+++ b/src/app/api/visits/[id]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { Database } from '@/types/database';
+import { storage } from '@/lib/storage';
+
+// Delete a visit and all photos attached to it.
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const supabase = createRouteHandlerClient<Database>({ cookies });
+    const visitId = params.id;
+
+    const { data: { session } } = await supabase.auth.getSession();
+
+    if (!session?.user) {
+      return NextResponse.json({
+        success: false,
+        error: 'Authentication required'
+      }, { status: 401 });
+    }
+
+    const { data: visit, error: visitError } = await supabase
+      .from('visit')
+      .select('id, user_id')
+      .eq('id', visitId)
+      .single();
+
+    if (visitError || !visit) {
+      return NextResponse.json({
+        success: false,
+        error: 'Visit not found'
+      }, { status: 404 });
+    }
+
+    if (visit.user_id !== session.user.id) {
+      return NextResponse.json({
+        success: false,
+        error: 'Permission denied: You can only delete your own visits'
+      }, { status: 403 });
+    }
+
+    const { data: visitPhotos, error: photosError } = await supabase
+      .from('photo')
+      .select('id, storage_key')
+      .eq('visit_id', visitId);
+
+    if (photosError) {
+      console.error('Error fetching visit photos before delete:', photosError);
+      return NextResponse.json({
+        success: false,
+        error: 'Failed to fetch related photos',
+        details: photosError.message
+      }, { status: 500 });
+    }
+
+    const photosToDelete = visitPhotos || [];
+    const deletedPhotoIds = photosToDelete.map((photo) => photo.id);
+
+    for (const photo of photosToDelete) {
+      try {
+        if (storage.delete) {
+          await storage.delete(photo.storage_key);
+          console.log(`Deleted photo from storage: ${photo.storage_key}`);
+        } else {
+          console.warn('Storage adapter does not support delete operation');
+        }
+      } catch (storageError: any) {
+        console.error('Error deleting photo from storage:', storageError);
+        // Continue DB deletion even if the object has already gone missing.
+      }
+    }
+
+    if (deletedPhotoIds.length > 0) {
+      const { error: deletePhotosError } = await supabase
+        .from('photo')
+        .delete()
+        .eq('visit_id', visitId);
+
+      if (deletePhotosError) {
+        console.error('Error deleting photos from database:', deletePhotosError);
+        return NextResponse.json({
+          success: false,
+          error: 'Failed to delete photos from database',
+          details: deletePhotosError.message
+        }, { status: 500 });
+      }
+    }
+
+    // visit_like / visit_comment / visit_bookmark are deleted by ON DELETE CASCADE.
+    const { error: deleteVisitError } = await supabase
+      .from('visit')
+      .delete()
+      .eq('id', visitId)
+      .eq('user_id', session.user.id);
+
+    if (deleteVisitError) {
+      console.error('Error deleting visit from database:', deleteVisitError);
+      return NextResponse.json({
+        success: false,
+        error: 'Failed to delete visit from database',
+        details: deleteVisitError.message
+      }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'Visit deleted successfully',
+      visit_id: visitId,
+      photo_ids: deletedPhotoIds,
+      visit_deleted: true
+    });
+  } catch (error: any) {
+    console.error('Unexpected error deleting visit:', error);
+    return NextResponse.json({
+      success: false,
+      error: 'Unexpected error',
+      details: error?.message || 'Unknown error'
+    }, { status: 500 });
+  }
+}

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -297,16 +297,17 @@ export default function ManholeDetailPage() {
 
       if (response.ok && data.success) {
         // 成功: 写真リストから削除
-        const updatedPhotos = photos.filter(p => p.id !== selectedPhotoId);
+        const deletedPhotoIds = new Set<string>(data.photo_ids || [selectedPhotoId]);
+        const updatedPhotos = photos.filter(p => !deletedPhotoIds.has(p.id));
         setPhotos(updatedPhotos);
         setDeleteModalOpen(false);
         setSelectedPhotoId(null);
 
         // 成功メッセージ
         if (updatedPhotos.length === 0) {
-          alert('写真を削除しました。このマンホールの写真はすべて削除されました。');
+          alert(data.visit_deleted ? '写真と訪問記録を削除しました。このマンホールの写真はすべて削除されました。' : '写真を削除しました。このマンホールの写真はすべて削除されました。');
         } else {
-          alert('写真を削除しました');
+          alert(data.visit_deleted ? '写真と訪問記録を削除しました' : '写真を削除しました');
         }
       } else {
         // エラー

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -80,6 +80,7 @@ export default function ManholeDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
+  const [selectedVisitId, setSelectedVisitId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [photoReactions, setPhotoReactions] = useState<Map<string, PhotoSocial>>(new Map());
@@ -279,17 +280,18 @@ export default function ManholeDetailPage() {
     }
   };
 
-  const handleDeleteClick = (photoId: string) => {
+  const handleDeleteClick = (photoId: string, visitId?: string) => {
     setSelectedPhotoId(photoId);
+    setSelectedVisitId(visitId || null);
     setDeleteModalOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
-    if (!selectedPhotoId) return;
+    if (!selectedPhotoId || !selectedVisitId) return;
 
     setIsDeleting(true);
     try {
-      const response = await fetch(`/api/photo/${selectedPhotoId}`, {
+      const response = await fetch(`/api/visits/${selectedVisitId}`, {
         method: 'DELETE',
       });
 
@@ -302,6 +304,7 @@ export default function ManholeDetailPage() {
         setPhotos(updatedPhotos);
         setDeleteModalOpen(false);
         setSelectedPhotoId(null);
+        setSelectedVisitId(null);
 
         // 成功メッセージ
         if (updatedPhotos.length === 0) {
@@ -325,6 +328,7 @@ export default function ManholeDetailPage() {
   const handleDeleteCancel = () => {
     setDeleteModalOpen(false);
     setSelectedPhotoId(null);
+    setSelectedVisitId(null);
   };
 
   const handleReaction = async (photo: Photo, reactionType: 'like' | 'bookmark') => {
@@ -611,7 +615,7 @@ export default function ManholeDetailPage() {
                             {/* Right: Delete Button (only for owner) */}
                             {isOwner && (
                               <button
-                                onClick={() => handleDeleteClick(photo.id)}
+                                onClick={() => handleDeleteClick(photo.id, photo.visit?.id)}
                                 className="bg-rpg-red/80 backdrop-blur-sm border border-white/30 p-1.5 hover:bg-rpg-red transition-colors"
                                 title="写真を削除"
                               >

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,9 +3,12 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import {
+  Award,
   Camera,
   ChevronLeft,
   ChevronRight,
+  CheckCircle2,
+  CircleDot,
   Compass,
   Heart,
   MapPin,
@@ -14,6 +17,7 @@ import {
   Search,
   SlidersHorizontal,
   Sparkles,
+  Stamp,
 } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
@@ -38,22 +42,72 @@ type FeedVisit = {
 };
 
 type GalleryTab = 'latest';
+type JourneyTab = 'unvisited' | 'nearby' | 'continue';
+
+type JourneyVisit = {
+  id: string;
+  manhole_id: number | null;
+  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'title' | 'pokemons'> | null;
+  shot_at: string;
+  photos: Array<{ id: string; thumbnail_url?: string }>;
+};
+
+type JourneyManhole = Manhole & {
+  name?: string;
+  city?: string;
+  distance?: number;
+  is_visited?: boolean;
+  last_visit?: string | null;
+};
+
+type PrefectureProgress = {
+  name: string;
+  total: number;
+  visited: number;
+  remaining: number;
+  rate: number;
+};
 
 const galleryTabs: Array<{ key: GalleryTab | 'prefectures'; label: string; mobileLabel: string }> = [
   { key: 'latest', label: '最新', mobileLabel: '最新' },
   { key: 'prefectures', label: '都道府県から探す', mobileLabel: '探す' },
 ];
 
+const journeyTabs: Array<{ key: JourneyTab; label: string }> = [
+  { key: 'unvisited', label: '未訪問' },
+  { key: 'nearby', label: '近く' },
+  { key: 'continue', label: '続き' },
+];
+
+const FALLBACK_TOTAL_MANHOLES = 470;
+
+const getDisplayName = (session: any) => {
+  const metadataName = session?.user?.user_metadata?.display_name;
+  const emailName = session?.user?.email?.split('@')[0];
+  return metadataName || emailName || 'タコさん';
+};
+
+const getMunicipality = (manhole?: Pick<Manhole, 'municipality'> & { city?: string }) =>
+  manhole?.city || manhole?.municipality || '場所未設定';
+
+const getManholeTitle = (manhole?: Pick<Manhole, 'title' | 'municipality'> & { name?: string; city?: string }) =>
+  manhole?.name || manhole?.title || getMunicipality(manhole);
+
 export default function HomePage() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [userName, setUserName] = useState('タコさん');
   const [loading, setLoading] = useState(true);
   const [totalManholes, setTotalManholes] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
   const [feed, setFeed] = useState<FeedVisit[]>([]);
+  const [journeyVisits, setJourneyVisits] = useState<JourneyVisit[]>([]);
+  const [journeyManholes, setJourneyManholes] = useState<JourneyManhole[]>([]);
+  const [nearbyUnvisited, setNearbyUnvisited] = useState<JourneyManhole[]>([]);
   const [totalUsers, setTotalUsers] = useState<number | null>(null);
   const [totalPosts, setTotalPosts] = useState<number | null>(null);
   const [manholesWithPhotos, setManholesWithPhotos] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<GalleryTab>('latest');
+  const [journeyTab, setJourneyTab] = useState<JourneyTab>('unvisited');
   const [menuOpen, setMenuOpen] = useState(false);
   const feedPerPage = 24;
   const { trackView } = useAnalytics();
@@ -72,7 +126,13 @@ export default function HomePage() {
         const {
           data: { session },
         } = await supabase.auth.getSession();
-        setIsLoggedIn(Boolean(session?.user));
+        const loggedIn = Boolean(session?.user);
+        setIsLoggedIn(loggedIn);
+        if (loggedIn) {
+          setUserName(getDisplayName(session));
+          loadJourney();
+          loadNearbyUnvisited();
+        }
       } catch {
         setIsLoggedIn(false);
       }
@@ -124,6 +184,57 @@ export default function HomePage() {
     }
   };
 
+  const loadJourney = async () => {
+    try {
+      const [visitsResponse, manholesResponse] = await Promise.all([
+        fetch('/api/visits?limit=1000'),
+        fetch('/api/manholes?limit=1000'),
+      ]);
+
+      if (visitsResponse.ok) {
+        const data = await visitsResponse.json();
+        setJourneyVisits(Array.isArray(data.visits) ? data.visits : []);
+      }
+
+      if (manholesResponse.ok) {
+        const data = await manholesResponse.json();
+        const manholes: JourneyManhole[] = Array.isArray(data.manholes)
+          ? data.manholes.map((manhole: any) => ({
+              ...manhole,
+              name: manhole.name || manhole.title,
+              city: manhole.city || manhole.municipality,
+            }))
+          : [];
+        setJourneyManholes(manholes);
+        if (typeof data.total === 'number') setTotalManholes(data.total);
+      }
+    } catch (error) {
+      console.error('Failed to load journey:', error);
+    }
+  };
+
+  const loadNearbyUnvisited = async () => {
+    if (!navigator.geolocation) return;
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        try {
+          const { latitude, longitude } = position.coords;
+          const response = await fetch(
+            `/api/manholes?lat=${latitude}&lng=${longitude}&radius=30&visited=false&limit=3`
+          );
+          if (!response.ok) return;
+          const data = await response.json();
+          setNearbyUnvisited(Array.isArray(data.manholes) ? data.manholes : []);
+        } catch (error) {
+          console.error('Failed to load nearby unvisited:', error);
+        }
+      },
+      () => undefined,
+      { maximumAge: 1000 * 60 * 10, timeout: 6000 }
+    );
+  };
+
   const sortedFeed = [...feed].sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
@@ -136,6 +247,98 @@ export default function HomePage() {
   const canGoNext = totalPages ? currentPage < totalPages : feed.length === feedPerPage;
   const showPagination = totalPages ? totalPages > 1 : currentPage > 1 || feed.length === feedPerPage;
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
+  const knownTotalManholes = totalManholes || FALLBACK_TOTAL_MANHOLES;
+
+  const visitsByManholeId = new Map<number, JourneyVisit[]>();
+  journeyVisits.forEach((visit) => {
+    const manholeId = visit.manhole?.id ?? visit.manhole_id;
+    if (!manholeId) return;
+    const current = visitsByManholeId.get(manholeId) || [];
+    current.push(visit);
+    visitsByManholeId.set(manholeId, current);
+  });
+
+  const visitedCount = visitsByManholeId.size;
+  const completionRate = knownTotalManholes > 0 ? (visitedCount / knownTotalManholes) * 100 : 0;
+  const journeyManholesById = new Map(journeyManholes.map((manhole) => [manhole.id, manhole]));
+
+  journeyVisits.forEach((visit) => {
+    const manhole = visit.manhole;
+    const manholeId = manhole?.id ?? visit.manhole_id;
+    if (!manholeId || journeyManholesById.has(manholeId) || !manhole) return;
+    journeyManholesById.set(manholeId, {
+      id: manholeId,
+      title: manhole.title || 'ポケふた',
+      prefecture: manhole.prefecture || '',
+      municipality: manhole.municipality || null,
+      location: '',
+      pokemons: manhole.pokemons || [],
+      name: manhole.title || 'ポケふた',
+      city: manhole.municipality || '',
+      prefecture_id: null,
+      prefecture_code: null,
+      address: '',
+      detail_url: null,
+      prefecture_site_url: null,
+      region: null,
+      is_active: true,
+      last_verified_at: '',
+      data_source: null,
+      created_at: '',
+      updated_at: '',
+    });
+  });
+
+  const allJourneyManholes = Array.from(journeyManholesById.values());
+  const unvisitedManholes = allJourneyManholes
+    .filter((manhole) => !visitsByManholeId.has(manhole.id))
+    .sort((a, b) => `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(`${b.prefecture}${getMunicipality(b)}${b.id}`, 'ja'));
+
+  const prefectureProgress: PrefectureProgress[] = Array.from(
+    allJourneyManholes.reduce((map, manhole) => {
+      const name = manhole.prefecture || '都道府県未設定';
+      const current = map.get(name) || { totalIds: new Set<number>(), visitedIds: new Set<number>() };
+      current.totalIds.add(manhole.id);
+      if (visitsByManholeId.has(manhole.id)) current.visitedIds.add(manhole.id);
+      map.set(name, current);
+      return map;
+    }, new Map<string, { totalIds: Set<number>; visitedIds: Set<number> }>())
+  )
+    .map(([name, value]) => {
+      const total = value.totalIds.size;
+      const visited = value.visitedIds.size;
+      return {
+        name,
+        total,
+        visited,
+        remaining: Math.max(total - visited, 0),
+        rate: total > 0 ? (visited / total) * 100 : 0,
+      };
+    })
+    .sort((a, b) => {
+      const aNearComplete = a.remaining > 0 ? a.remaining : 999;
+      const bNearComplete = b.remaining > 0 ? b.remaining : 999;
+      if (aNearComplete !== bNearComplete) return aNearComplete - bNearComplete;
+      if (b.visited !== a.visited) return b.visited - a.visited;
+      return a.name.localeCompare(b.name, 'ja');
+    });
+
+  const leadingPrefectures = prefectureProgress.filter((prefecture) => prefecture.visited > 0).slice(0, 3);
+  const nextPrefecture = prefectureProgress.find((prefecture) => prefecture.visited > 0 && prefecture.remaining > 0);
+  const completedPrefecture = prefectureProgress.find((prefecture) => prefecture.total > 0 && prefecture.remaining === 0);
+  const continuedManholes = allJourneyManholes
+    .filter((manhole) => visitsByManholeId.has(manhole.id))
+    .sort((a, b) => {
+      const aVisit = visitsByManholeId.get(a.id)?.[0];
+      const bVisit = visitsByManholeId.get(b.id)?.[0];
+      return new Date(bVisit?.shot_at || 0).getTime() - new Date(aVisit?.shot_at || 0).getTime();
+    });
+  const collectionManholes =
+    journeyTab === 'nearby'
+      ? (nearbyUnvisited.length > 0 ? nearbyUnvisited : unvisitedManholes.slice(0, 6))
+      : journeyTab === 'continue'
+        ? [...continuedManholes.slice(0, 6), ...unvisitedManholes.slice(0, Math.max(0, 6 - continuedManholes.length))]
+        : unvisitedManholes.slice(0, 6);
 
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
@@ -201,186 +404,316 @@ export default function HomePage() {
 
         {!loading && (
           <>
-            <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-8 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-12">
-              <div className="absolute right-6 top-7 hidden w-[300px] rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block xl:w-[360px]">
-                <img
-                  src="/pokefuta_photo_gallery_mockup.svg"
-                  alt=""
-                  className="h-[220px] w-full rounded-[6px] object-cover object-left-top xl:h-[250px]"
-                />
-              </div>
-              <div className="relative max-w-3xl lg:max-w-[680px]">
-                <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
-                  <Sparkles className="h-3.5 w-3.5" />
-                  旅行スタンプ帳
-                </div>
-                <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
-                  旅先で見つけたポケふたを記録しよう
-                </h1>
-                <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
-                  旅行やお出かけで出会ったポケふた写真をみんなでシェアしよう！
-                </p>
-
-                <div className="mt-7 grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">
-                  <div className="flex items-center gap-3 rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-4 shadow-sm">
-                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[#7B63A8] shadow-sm">
-                      <MapPin className="h-6 w-6" />
-                    </div>
+            {isLoggedIn ? (
+              <>
+                <section className="relative overflow-hidden rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] px-5 py-6 shadow-[0_10px_26px_rgba(95,68,42,0.12)] sm:px-8">
+                  <div className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+                  <div className="relative grid gap-5 lg:grid-cols-[1.25fr_0.75fr]">
                     <div>
-                      <div className="text-xl font-extrabold leading-none">全国387自治体</div>
-                      <div className="mt-1 text-xs font-bold text-[#6B6B6B]">に設置</div>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-3 rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-4 shadow-sm">
-                    <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[#FF8F1F] shadow-sm">
-                      <Compass className="h-6 w-6" />
-                    </div>
-                    <div>
-                      <div className="text-xl font-extrabold leading-none">{listedCountLabel}</div>
-                      <div className="mt-1 text-xs font-bold text-[#6B6B6B]">のポケふたを掲載</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
+                      <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#B5483C]/25 bg-[#F8D9C4] px-3 py-1 text-xs font-bold text-[#B5483C]">
+                        <Stamp className="h-3.5 w-3.5" />
+                        次のスタンプを探そう
+                      </div>
+                      <h1 className="text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
+                        {userName}のポケふた旅
+                      </h1>
 
-            <section className="mt-6">
-              <div className="-mx-4 overflow-x-auto px-4 pb-1">
-                <div className="flex min-w-max gap-2 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB]/80 p-1 shadow-sm sm:min-w-0">
-                  {galleryTabs.map((tab) => {
-                    if (tab.key === 'prefectures') {
-                      return (
-                        <Link
-                          key={tab.key}
-                          href="/manholes"
-                          className="flex min-h-[44px] items-center justify-center gap-2 rounded-[7px] px-5 text-sm font-bold text-[#2A2A2A] transition hover:bg-white"
-                        >
-                          <span className="hidden sm:inline">{tab.label}</span>
-                          <span className="sm:hidden">{tab.mobileLabel}</span>
-                          <MapPin className="h-4 w-4" />
-                        </Link>
-                      );
-                    }
-
-                    const isActive = activeTab === tab.key;
-                    return (
-                      <button
-                        key={tab.key}
-                        type="button"
-                        onClick={() => setActiveTab(tab.key as GalleryTab)}
-                        className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
-                          isActive
-                            ? 'bg-[#7B63A8] text-white shadow-sm'
-                            : 'text-[#2A2A2A] hover:bg-white'
-                        }`}
-                      >
-                        {tab.label}
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            </section>
-
-            <section className="mt-6">
-              {visibleFeed.length === 0 ? (
-                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-10 text-center shadow-sm">
-                  <p className="text-sm font-bold text-[#6B6B6B]">
-                    まだ投稿がありません
-                  </p>
-                  <Link
-                    href={uploadHref}
-                    className="mt-5 inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-                  >
-                    <Camera className="w-4 h-4" />
-                    <span>{isLoggedIn ? '写真を投稿' : 'ログインして投稿'}</span>
-                  </Link>
-                </div>
-              ) : (
-                <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
-                  {visibleFeed.map((visit, index) => {
-                    const photo = visit.photos?.[0];
-                    const title = [visit.manhole?.prefecture, visit.manhole?.municipality]
-                      .filter(Boolean)
-                      .join(' ');
-                    const locationLabel = title || visit.shot_location || '';
-                    const manholeId = visit.manhole?.id ?? visit.manhole_id;
-                    const canNavigate = Boolean(manholeId);
-                    const to = canNavigate ? `/manhole/${manholeId}` : '';
-
-                    const commonAriaLabel = `${locationLabel}、撮影 ${formatDateJa(visit.shot_at)}、いいね ${visit.likes_count}、コメント ${visit.comments_count}`;
-                    const cardContent = (
-                      <>
-                        {photo?.thumbnail_url ? (
-                          <img
-                            src={photo.thumbnail_url}
-                            alt=""
-                            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-                            loading="lazy"
+                      <div className="mt-5 max-w-2xl rounded-[8px] border border-[#8C6A4A]/15 bg-white/60 p-4">
+                        <div className="mb-2 flex items-end justify-between gap-3">
+                          <div>
+                            <p className="font-pixel text-2xl text-[#4F3828]">
+                              {visitedCount} / {knownTotalManholes} STAMPS
+                            </p>
+                            <p className="mt-1 text-xs font-bold text-[#6A4D36]">旅の進捗</p>
+                          </div>
+                          <p className="font-pixel text-xl text-[#B5483C]">{completionRate.toFixed(1)}%</p>
+                        </div>
+                        <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/20 bg-[#E4D4B8]">
+                          <div
+                            className="h-full bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D]"
+                            style={{ width: `${Math.min(completionRate, 100)}%` }}
                           />
-                        ) : (
-                          <div className="flex h-full w-full items-center justify-center bg-[#FFF8EB] text-[#7B63A8]">
-                            <MapPin className="h-8 w-8 opacity-80" />
-                          </div>
-                        )}
-
-                        {currentPage === 1 && index < 3 && (
-                          <span className="absolute left-2 top-2 rounded-[6px] bg-[#7B63A8] px-2 py-1 text-xs font-extrabold text-white shadow-sm">
-                            NEW
-                          </span>
-                        )}
-                        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/55 to-transparent p-3 pt-14 text-white sm:p-4 sm:pt-20">
-                          <div className="line-clamp-1 text-sm font-extrabold sm:text-base">
-                            {locationLabel || 'ポケふた'}
-                          </div>
-                          <div className="mt-1 text-sm font-semibold">{formatDateJa(visit.shot_at)}</div>
-                          <div className="mt-3 flex items-center gap-4 text-sm font-semibold">
-                            <span className="inline-flex items-center gap-1">
-                              <Heart className="h-4 w-4" />
-                              {visit.likes_count}
-                            </span>
-                            <span className="inline-flex items-center gap-1">
-                              <MessageCircle className="h-4 w-4" />
-                              {visit.comments_count}
-                            </span>
-                          </div>
                         </div>
-                      </>
-                    );
-
-                    if (!canNavigate) {
-                      if (process.env.NODE_ENV !== 'production') {
-                        console.warn('Home feed item missing manholeId; navigation disabled', {
-                          visitId: visit.id,
-                          manhole_id: visit.manhole_id,
-                        });
-                      }
-
-                      return (
-                        <div
-                          key={visit.id}
-                          className="group relative aspect-square overflow-hidden rounded-[8px] bg-[#FFF8EB] shadow-sm ring-1 ring-[#7B63A8]/15"
-                          aria-label={commonAriaLabel}
-                        >
-                          {cardContent}
+                        <div className="mt-4 grid gap-2 sm:grid-cols-3">
+                          {(leadingPrefectures.length > 0 ? leadingPrefectures : prefectureProgress.slice(0, 3)).map((prefecture) => (
+                            <JourneyPrefectureStat key={prefecture.name} prefecture={prefecture} />
+                          ))}
                         </div>
-                      );
-                    }
+                      </div>
+                    </div>
 
-                    return (
+                    <div className="rounded-[8px] border border-[#8C6A4A]/15 bg-white/70 p-4">
+                      <p className="flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                        <Compass className="h-4 w-4 text-[#B5483C]" />
+                        次のスタンプ候補
+                      </p>
+                      <div className="mt-3 space-y-2">
+                        {(nearbyUnvisited.length > 0 ? nearbyUnvisited : unvisitedManholes.slice(0, 3)).map((manhole) => (
+                          <Link
+                            key={manhole.id}
+                            href={`/manhole/${manhole.id}`}
+                            className="flex items-center justify-between gap-3 rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-3 py-2 transition hover:bg-[#F8D9C4]"
+                          >
+                            <span className="min-w-0">
+                              <span className="block truncate text-sm font-bold text-[#4F3828]">{getMunicipality(manhole)}</span>
+                              <span className="block truncate text-xs font-bold text-[#6A4D36]">{manhole.prefecture}</span>
+                            </span>
+                            <span className="shrink-0 font-pixel text-xs text-[#B5483C]">
+                              {typeof manhole.distance === 'number' ? `${manhole.distance.toFixed(1)}km` : '未訪問'}
+                            </span>
+                          </Link>
+                        ))}
+                      </div>
+                      {completedPrefecture ? (
+                        <div className="mt-4 rounded-[7px] border border-[#3F9D7D]/25 bg-[#DFF1E9] px-3 py-2">
+                          <p className="flex items-center gap-2 text-xs font-extrabold text-[#2C765E]">
+                            <CheckCircle2 className="h-4 w-4" />
+                            {completedPrefecture.name}コンプリート！
+                          </p>
+                        </div>
+                      ) : nextPrefecture ? (
+                        <div className="mt-4 rounded-[7px] border border-[#DDA63A]/30 bg-[#FFF0C7] px-3 py-2">
+                          <p className="flex items-center gap-2 text-xs font-extrabold text-[#8C6315]">
+                            <Award className="h-4 w-4" />
+                            あと{nextPrefecture.remaining}枚で{nextPrefecture.name}制覇
+                          </p>
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="mt-6">
+                  <div className="-mx-4 overflow-x-auto px-4 pb-1">
+                    <div className="flex min-w-max gap-2 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5]/90 p-1 shadow-sm sm:min-w-0">
+                      {journeyTabs.map((tab) => {
+                        const isActive = journeyTab === tab.key;
+                        return (
+                          <button
+                            key={tab.key}
+                            type="button"
+                            onClick={() => setJourneyTab(tab.key)}
+                            className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
+                              isActive
+                                ? 'bg-[#4F3828] text-[#FFF7E5] shadow-sm'
+                                : 'text-[#4F3828] hover:bg-white'
+                            }`}
+                          >
+                            {tab.label}
+                          </button>
+                        );
+                      })}
                       <Link
-                        key={visit.id}
-                        href={to}
-                        className="group relative aspect-square overflow-hidden rounded-[8px] bg-[#FFF8EB] shadow-sm ring-1 ring-[#7B63A8]/15 transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#FFB347]"
-                        aria-label={commonAriaLabel}
+                        href="/visits"
+                        className="flex min-h-[44px] items-center justify-center gap-2 rounded-[7px] px-5 text-sm font-bold text-[#4F3828] transition hover:bg-white"
                       >
-                        {cardContent}
+                        スタンプ帳
+                        <Stamp className="h-4 w-4" />
                       </Link>
-                    );
-                  })}
-                </div>
-              )}
-            </section>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="mt-6 grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
+                  {collectionManholes.length > 0 ? (
+                    collectionManholes.map((manhole) => (
+                      <JourneyStampCard
+                        key={manhole.id}
+                        manhole={manhole}
+                        visits={visitsByManholeId.get(manhole.id)}
+                      />
+                    ))
+                  ) : (
+                    <div className="col-span-full rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-5 py-10 text-center shadow-sm">
+                      <p className="text-sm font-bold text-[#6A4D36]">次の候補を準備中です</p>
+                      <Link
+                        href="/nearby"
+                        className="mt-5 inline-flex items-center gap-2 rounded-lg bg-[#B5483C] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#9F3D33]"
+                      >
+                        <MapPin className="h-4 w-4" />
+                        近くの未訪問を見る
+                      </Link>
+                    </div>
+                  )}
+                </section>
+              </>
+            ) : (
+              <>
+                <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-8 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-12">
+                  <div className="absolute right-6 top-7 hidden w-[300px] rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block xl:w-[360px]">
+                    <img
+                      src="/pokefuta_photo_gallery_mockup.svg"
+                      alt=""
+                      className="h-[220px] w-full rounded-[6px] object-cover object-left-top xl:h-[250px]"
+                    />
+                  </div>
+                  <div className="relative max-w-3xl lg:max-w-[680px]">
+                    <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+                      <Sparkles className="h-3.5 w-3.5" />
+                      旅行スタンプ帳
+                    </div>
+                    <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
+                      旅先で見つけたポケふたを記録しよう
+                    </h1>
+                    <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
+                      旅行やお出かけで出会ったポケふた写真をみんなでシェアしよう！
+                    </p>
+
+                    <div className="mt-7 grid max-w-2xl grid-cols-1 gap-3 sm:grid-cols-2">
+                      <div className="flex items-center gap-3 rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-4 shadow-sm">
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[#7B63A8] shadow-sm">
+                          <MapPin className="h-6 w-6" />
+                        </div>
+                        <div>
+                          <div className="text-xl font-extrabold leading-none">全国387自治体</div>
+                          <div className="mt-1 text-xs font-bold text-[#6B6B6B]">に設置</div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-3 rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-4 shadow-sm">
+                        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-white text-[#FF8F1F] shadow-sm">
+                          <Compass className="h-6 w-6" />
+                        </div>
+                        <div>
+                          <div className="text-xl font-extrabold leading-none">{listedCountLabel}</div>
+                          <div className="mt-1 text-xs font-bold text-[#6B6B6B]">のポケふたを掲載</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                <section className="mt-6">
+                  <div className="-mx-4 overflow-x-auto px-4 pb-1">
+                    <div className="flex min-w-max gap-2 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB]/80 p-1 shadow-sm sm:min-w-0">
+                      {galleryTabs.map((tab) => {
+                        if (tab.key === 'prefectures') {
+                          return (
+                            <Link
+                              key={tab.key}
+                              href="/manholes"
+                              className="flex min-h-[44px] items-center justify-center gap-2 rounded-[7px] px-5 text-sm font-bold text-[#2A2A2A] transition hover:bg-white"
+                            >
+                              <span className="hidden sm:inline">{tab.label}</span>
+                              <span className="sm:hidden">{tab.mobileLabel}</span>
+                              <MapPin className="h-4 w-4" />
+                            </Link>
+                          );
+                        }
+
+                        const isActive = activeTab === tab.key;
+                        return (
+                          <button
+                            key={tab.key}
+                            type="button"
+                            onClick={() => setActiveTab(tab.key as GalleryTab)}
+                            className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
+                              isActive
+                                ? 'bg-[#7B63A8] text-white shadow-sm'
+                                : 'text-[#2A2A2A] hover:bg-white'
+                            }`}
+                          >
+                            {tab.label}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </section>
+
+                <section className="mt-6">
+                  {visibleFeed.length === 0 ? (
+                    <div className="rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-10 text-center shadow-sm">
+                      <p className="text-sm font-bold text-[#6B6B6B]">
+                        まだ投稿がありません
+                      </p>
+                      <Link
+                        href={uploadHref}
+                        className="mt-5 inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
+                      >
+                        <Camera className="w-4 h-4" />
+                        <span>ログインして投稿</span>
+                      </Link>
+                    </div>
+                  ) : (
+                    <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
+                      {visibleFeed.map((visit, index) => {
+                        const photo = visit.photos?.[0];
+                        const title = [visit.manhole?.prefecture, visit.manhole?.municipality]
+                          .filter(Boolean)
+                          .join(' ');
+                        const locationLabel = title || visit.shot_location || '';
+                        const manholeId = visit.manhole?.id ?? visit.manhole_id;
+                        const canNavigate = Boolean(manholeId);
+                        const to = canNavigate ? `/manhole/${manholeId}` : '';
+
+                        const commonAriaLabel = `${locationLabel}、撮影 ${formatDateJa(visit.shot_at)}、いいね ${visit.likes_count}、コメント ${visit.comments_count}`;
+                        const cardContent = (
+                          <>
+                            {photo?.thumbnail_url ? (
+                              <img
+                                src={photo.thumbnail_url}
+                                alt=""
+                                className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                                loading="lazy"
+                              />
+                            ) : (
+                              <div className="flex h-full w-full items-center justify-center bg-[#FFF8EB] text-[#7B63A8]">
+                                <MapPin className="h-8 w-8 opacity-80" />
+                              </div>
+                            )}
+
+                            {currentPage === 1 && index < 3 && (
+                              <span className="absolute left-2 top-2 rounded-[6px] bg-[#7B63A8] px-2 py-1 text-xs font-extrabold text-white shadow-sm">
+                                NEW
+                              </span>
+                            )}
+                            <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/55 to-transparent p-3 pt-14 text-white sm:p-4 sm:pt-20">
+                              <div className="line-clamp-1 text-sm font-extrabold sm:text-base">
+                                {locationLabel || 'ポケふた'}
+                              </div>
+                              <div className="mt-1 text-sm font-semibold">{formatDateJa(visit.shot_at)}</div>
+                              <div className="mt-3 flex items-center gap-4 text-sm font-semibold">
+                                <span className="inline-flex items-center gap-1">
+                                  <Heart className="h-4 w-4" />
+                                  {visit.likes_count}
+                                </span>
+                                <span className="inline-flex items-center gap-1">
+                                  <MessageCircle className="h-4 w-4" />
+                                  {visit.comments_count}
+                                </span>
+                              </div>
+                            </div>
+                          </>
+                        );
+
+                        if (!canNavigate) {
+                          return (
+                            <div
+                              key={visit.id}
+                              className="group relative aspect-square overflow-hidden rounded-[8px] bg-[#FFF8EB] shadow-sm ring-1 ring-[#7B63A8]/15"
+                              aria-label={commonAriaLabel}
+                            >
+                              {cardContent}
+                            </div>
+                          );
+                        }
+
+                        return (
+                          <Link
+                            key={visit.id}
+                            href={to}
+                            className="group relative aspect-square overflow-hidden rounded-[8px] bg-[#FFF8EB] shadow-sm ring-1 ring-[#7B63A8]/15 transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#FFB347]"
+                            aria-label={commonAriaLabel}
+                          >
+                            {cardContent}
+                          </Link>
+                        );
+                      })}
+                    </div>
+                  )}
+                </section>
+              </>
+            )}
 
             <div className="sr-only" aria-live="polite">
               全ポケふた {totalManholes || 0}、写真あり {manholesWithPhotos ?? 0}、全投稿{' '}
@@ -392,7 +725,7 @@ export default function HomePage() {
             </div>
 
             {/* Feed Pagination */}
-            {showPagination && (
+            {!isLoggedIn && showPagination && (
               <div className="mt-7 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-3 shadow-sm">
                 <div className="flex items-center justify-center gap-3">
                   <button
@@ -428,14 +761,101 @@ export default function HomePage() {
 
       <Link
         href={uploadHref}
-        className="fixed bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] right-4 z-40 inline-flex items-center gap-2 rounded-full bg-[#7B63A8] px-5 py-4 text-sm font-extrabold text-white shadow-[0_8px_18px_rgba(123,99,168,0.30)] transition hover:bg-[#6A5299] sm:bottom-6 sm:right-6"
+        className={`fixed bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] right-4 z-40 inline-flex items-center gap-2 rounded-full px-5 py-4 text-sm font-extrabold text-white shadow-[0_8px_18px_rgba(123,99,168,0.30)] transition sm:bottom-6 sm:right-6 ${
+          isLoggedIn ? 'bg-[#B5483C] hover:bg-[#9F3D33]' : 'bg-[#7B63A8] hover:bg-[#6A5299]'
+        }`}
       >
         <Camera className="h-5 w-5" />
-        写真を投稿
+        {isLoggedIn ? '訪問を記録' : '写真を投稿'}
       </Link>
 
       <BottomNav />
       <MobileMenuDrawer open={menuOpen} onClose={() => setMenuOpen(false)} />
     </div>
+  );
+}
+
+function JourneyPrefectureStat({ prefecture }: { prefecture: PrefectureProgress }) {
+  return (
+    <div className="rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="truncate text-sm font-extrabold text-[#4F3828]">{prefecture.name}</p>
+        <p className="shrink-0 font-pixel text-sm text-[#B5483C]">
+          {prefecture.visited}/{prefecture.total}
+        </p>
+      </div>
+      <div className="h-2 overflow-hidden rounded-sm bg-[#E4D4B8]">
+        <div className="h-full bg-[#3F9D7D]" style={{ width: `${Math.min(prefecture.rate, 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function JourneyStampCard({ manhole, visits }: { manhole: JourneyManhole; visits?: JourneyVisit[] }) {
+  const isVisited = Boolean(visits?.length);
+  const latestVisit = visits?.slice().sort((a, b) => new Date(b.shot_at).getTime() - new Date(a.shot_at).getTime())[0];
+  const hasPhoto = Boolean(latestVisit?.photos?.length);
+
+  return (
+    <Link
+      href={`/manhole/${manhole.id}`}
+      className={`group relative flex aspect-[4/5] flex-col justify-between overflow-hidden rounded-[8px] border-2 p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg ${
+        isVisited
+          ? 'border-[#B5483C]/40 bg-[#FFF7E5]'
+          : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]'
+      }`}
+    >
+      <div className="absolute inset-0 opacity-[0.06] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:16px_16px]" />
+      <div className="relative flex items-center justify-between gap-2">
+        <span
+          className={`rounded-full px-2 py-1 text-[11px] font-extrabold ${
+            isVisited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
+          }`}
+        >
+          {isVisited ? '訪問済み' : '未訪問'}
+        </span>
+        <span className="flex items-center gap-1">
+          {hasPhoto && <Camera className="h-4 w-4 text-[#B5483C]" />}
+          {visits && visits.length > 1 && (
+            <span className="rounded-full bg-[#4F3828] px-1.5 py-0.5 font-pixel text-[10px] text-white">
+              x{visits.length}
+            </span>
+          )}
+          {!isVisited && typeof manhole.distance === 'number' && (
+            <span className="font-pixel text-xs text-[#B5483C]">{manhole.distance.toFixed(1)}km</span>
+          )}
+        </span>
+      </div>
+
+      <div className="relative flex flex-1 items-center justify-center">
+        <div
+          className={`flex h-24 w-24 rotate-[-8deg] items-center justify-center rounded-full border-4 text-center ${
+            isVisited
+              ? 'border-[#D94D3F] bg-white/50 text-[#D94D3F] shadow-[inset_0_2px_8px_rgba(181,72,60,0.12)]'
+              : 'border-[#B8AB96] text-[#A39580]'
+          }`}
+        >
+          {isVisited ? (
+            <div>
+              <CircleDot className="mx-auto h-7 w-7" />
+              <p className="mt-1 font-pixel text-[10px] leading-none">POKEFUTA</p>
+            </div>
+          ) : (
+            <div>
+              <Stamp className="mx-auto h-7 w-7" />
+              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="relative">
+        <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">{getMunicipality(manhole)}</p>
+        <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.prefecture}</p>
+        <p className="mt-2 line-clamp-1 text-xs font-bold text-[#8C6A4A]">
+          {isVisited && latestVisit ? formatDateJa(latestVisit.shot_at) : getManholeTitle(manhole)}
+        </p>
+      </div>
+    </Link>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import {
   Award,
@@ -80,8 +80,6 @@ const journeyTabs: Array<{ key: JourneyTab; label: string }> = [
   { key: 'continue', label: '続き' },
 ];
 
-const FALLBACK_TOTAL_MANHOLES = 470;
-
 const getDisplayName = (session: any) => {
   const metadataName = session?.user?.user_metadata?.display_name;
   const emailName = session?.user?.email?.split('@')[0];
@@ -104,6 +102,7 @@ export default function HomePage() {
   const [journeyVisits, setJourneyVisits] = useState<JourneyVisit[]>([]);
   const [journeyManholes, setJourneyManholes] = useState<JourneyManhole[]>([]);
   const [nearbyUnvisited, setNearbyUnvisited] = useState<JourneyManhole[]>([]);
+  const [nearbyStatus, setNearbyStatus] = useState<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
   const [totalUsers, setTotalUsers] = useState<number | null>(null);
   const [totalPosts, setTotalPosts] = useState<number | null>(null);
   const [manholesWithPhotos, setManholesWithPhotos] = useState<number | null>(null);
@@ -132,7 +131,6 @@ export default function HomePage() {
         if (loggedIn) {
           setUserName(getDisplayName(session));
           loadJourney();
-          loadNearbyUnvisited();
         }
       } catch {
         setIsLoggedIn(false);
@@ -215,8 +213,12 @@ export default function HomePage() {
   };
 
   const loadNearbyUnvisited = async () => {
-    if (!navigator.geolocation) return;
+    if (!navigator.geolocation) {
+      setNearbyStatus('unavailable');
+      return;
+    }
 
+    setNearbyStatus('loading');
     navigator.geolocation.getCurrentPosition(
       async (position) => {
         try {
@@ -227,11 +229,13 @@ export default function HomePage() {
           if (!response.ok) return;
           const data = await response.json();
           setNearbyUnvisited(Array.isArray(data.manholes) ? data.manholes : []);
+          setNearbyStatus('ready');
         } catch (error) {
           console.error('Failed to load nearby unvisited:', error);
+          setNearbyStatus('unavailable');
         }
       },
-      () => undefined,
+      () => setNearbyStatus('unavailable'),
       { maximumAge: 1000 * 60 * 10, timeout: 6000 }
     );
   };
@@ -248,98 +252,119 @@ export default function HomePage() {
   const canGoNext = totalPages ? currentPage < totalPages : feed.length === feedPerPage;
   const showPagination = totalPages ? totalPages > 1 : currentPage > 1 || feed.length === feedPerPage;
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
-  const knownTotalManholes = totalManholes || FALLBACK_TOTAL_MANHOLES;
+  const knownTotalManholes = totalManholes > 0 ? totalManholes : null;
 
-  const visitsByManholeId = new Map<number, JourneyVisit[]>();
-  journeyVisits.forEach((visit) => {
-    const manholeId = visit.manhole?.id ?? visit.manhole_id;
-    if (!manholeId) return;
-    const current = visitsByManholeId.get(manholeId) || [];
-    current.push(visit);
-    visitsByManholeId.set(manholeId, current);
-  });
-
-  const visitedCount = visitsByManholeId.size;
-  const completionRate = knownTotalManholes > 0 ? (visitedCount / knownTotalManholes) * 100 : 0;
-  const journeyManholesById = new Map(journeyManholes.map((manhole) => [manhole.id, manhole]));
-
-  journeyVisits.forEach((visit) => {
-    const manhole = visit.manhole;
-    const manholeId = manhole?.id ?? visit.manhole_id;
-    if (!manholeId || journeyManholesById.has(manholeId) || !manhole) return;
-    journeyManholesById.set(manholeId, {
-      id: manholeId,
-      title: manhole.title || 'ポケふた',
-      prefecture: manhole.prefecture || '',
-      municipality: manhole.municipality || null,
-      location: '',
-      pokemons: manhole.pokemons || [],
-      name: manhole.title || 'ポケふた',
-      city: manhole.municipality || '',
-      prefecture_id: null,
-      prefecture_code: null,
-      address: '',
-      detail_url: null,
-      prefecture_site_url: null,
-      region: null,
-      is_active: true,
-      last_verified_at: '',
-      data_source: null,
-      created_at: '',
-      updated_at: '',
-    });
-  });
-
-  const allJourneyManholes = Array.from(journeyManholesById.values());
-  const unvisitedManholes = allJourneyManholes
-    .filter((manhole) => !visitsByManholeId.has(manhole.id))
-    .sort((a, b) => `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(`${b.prefecture}${getMunicipality(b)}${b.id}`, 'ja'));
-
-  const prefectureProgress: PrefectureProgress[] = Array.from(
-    allJourneyManholes.reduce((map, manhole) => {
-      const name = manhole.prefecture || '都道府県未設定';
-      const current = map.get(name) || { totalIds: new Set<number>(), visitedIds: new Set<number>() };
-      current.totalIds.add(manhole.id);
-      if (visitsByManholeId.has(manhole.id)) current.visitedIds.add(manhole.id);
-      map.set(name, current);
-      return map;
-    }, new Map<string, { totalIds: Set<number>; visitedIds: Set<number> }>())
-  )
-    .map(([name, value]) => {
-      const total = value.totalIds.size;
-      const visited = value.visitedIds.size;
-      return {
-        name,
-        total,
-        visited,
-        remaining: Math.max(total - visited, 0),
-        rate: total > 0 ? (visited / total) * 100 : 0,
-      };
-    })
-    .sort((a, b) => {
-      const aNearComplete = a.remaining > 0 ? a.remaining : 999;
-      const bNearComplete = b.remaining > 0 ? b.remaining : 999;
-      if (aNearComplete !== bNearComplete) return aNearComplete - bNearComplete;
-      if (b.visited !== a.visited) return b.visited - a.visited;
-      return a.name.localeCompare(b.name, 'ja');
+  const journeyData = useMemo(() => {
+    const visitsByManholeId = new Map<number, JourneyVisit[]>();
+    journeyVisits.forEach((visit) => {
+      const manholeId = visit.manhole?.id ?? visit.manhole_id;
+      if (!manholeId) return;
+      const current = visitsByManholeId.get(manholeId) || [];
+      current.push(visit);
+      visitsByManholeId.set(manholeId, current);
     });
 
-  const leadingPrefectures = prefectureProgress.filter((prefecture) => prefecture.visited > 0).slice(0, 3);
-  const nextPrefecture = prefectureProgress.find((prefecture) => prefecture.visited > 0 && prefecture.remaining > 0);
-  const completedPrefecture = prefectureProgress.find((prefecture) => prefecture.total > 0 && prefecture.remaining === 0);
-  const continuedManholes = allJourneyManholes
-    .filter((manhole) => visitsByManholeId.has(manhole.id))
-    .sort((a, b) => {
-      const aVisit = visitsByManholeId.get(a.id)?.[0];
-      const bVisit = visitsByManholeId.get(b.id)?.[0];
-      return new Date(bVisit?.shot_at || 0).getTime() - new Date(aVisit?.shot_at || 0).getTime();
+    const journeyManholesById = new Map(journeyManholes.map((manhole) => [manhole.id, manhole]));
+
+    journeyVisits.forEach((visit) => {
+      const manhole = visit.manhole;
+      const manholeId = manhole?.id ?? visit.manhole_id;
+      if (!manholeId || journeyManholesById.has(manholeId) || !manhole) return;
+      journeyManholesById.set(manholeId, {
+        id: manholeId,
+        title: manhole.title || 'ポケふた',
+        prefecture: manhole.prefecture || '',
+        municipality: manhole.municipality || null,
+        location: '',
+        pokemons: manhole.pokemons || [],
+        name: manhole.title || 'ポケふた',
+        city: manhole.municipality || '',
+        prefecture_id: null,
+        prefecture_code: null,
+        address: '',
+        detail_url: null,
+        prefecture_site_url: null,
+        region: null,
+        is_active: true,
+        last_verified_at: '',
+        data_source: null,
+        created_at: '',
+        updated_at: '',
+      });
     });
-  const collectionManholes =
-    journeyTab === 'nearby'
-      ? (nearbyUnvisited.length > 0 ? nearbyUnvisited : unvisitedManholes.slice(0, 6))
-      : journeyTab === 'continue'
-        ? [...continuedManholes.slice(0, 6), ...unvisitedManholes.slice(0, Math.max(0, 6 - continuedManholes.length))]
-        : unvisitedManholes.slice(0, 6);
+
+    const allJourneyManholes = Array.from(journeyManholesById.values());
+    const unvisitedManholes = allJourneyManholes
+      .filter((manhole) => !visitsByManholeId.has(manhole.id))
+      .sort((a, b) => `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(`${b.prefecture}${getMunicipality(b)}${b.id}`, 'ja'));
+
+    const prefectureProgress: PrefectureProgress[] = Array.from(
+      allJourneyManholes.reduce((map, manhole) => {
+        const name = manhole.prefecture || '都道府県未設定';
+        const current = map.get(name) || { totalIds: new Set<number>(), visitedIds: new Set<number>() };
+        current.totalIds.add(manhole.id);
+        if (visitsByManholeId.has(manhole.id)) current.visitedIds.add(manhole.id);
+        map.set(name, current);
+        return map;
+      }, new Map<string, { totalIds: Set<number>; visitedIds: Set<number> }>())
+    )
+      .map(([name, value]) => {
+        const total = value.totalIds.size;
+        const visited = value.visitedIds.size;
+        return {
+          name,
+          total,
+          visited,
+          remaining: Math.max(total - visited, 0),
+          rate: total > 0 ? (visited / total) * 100 : 0,
+        };
+      })
+      .sort((a, b) => {
+        const aNearComplete = a.remaining > 0 ? a.remaining : 999;
+        const bNearComplete = b.remaining > 0 ? b.remaining : 999;
+        if (aNearComplete !== bNearComplete) return aNearComplete - bNearComplete;
+        if (b.visited !== a.visited) return b.visited - a.visited;
+        return a.name.localeCompare(b.name, 'ja');
+      });
+
+    const continuedManholes = allJourneyManholes
+      .filter((manhole) => visitsByManholeId.has(manhole.id))
+      .sort((a, b) => {
+        const aVisit = visitsByManholeId.get(a.id)?.[0];
+        const bVisit = visitsByManholeId.get(b.id)?.[0];
+        return new Date(bVisit?.shot_at || 0).getTime() - new Date(aVisit?.shot_at || 0).getTime();
+      });
+
+    const collectionManholes =
+      journeyTab === 'nearby'
+        ? (nearbyUnvisited.length > 0 ? nearbyUnvisited : unvisitedManholes.slice(0, 6))
+        : journeyTab === 'continue'
+          ? [...continuedManholes.slice(0, 6), ...unvisitedManholes.slice(0, Math.max(0, 6 - continuedManholes.length))]
+          : unvisitedManholes.slice(0, 6);
+
+    return {
+      visitsByManholeId,
+      visitedCount: visitsByManholeId.size,
+      unvisitedManholes,
+      prefectureProgress,
+      leadingPrefectures: prefectureProgress.filter((prefecture) => prefecture.visited > 0).slice(0, 3),
+      nextPrefecture: prefectureProgress.find((prefecture) => prefecture.visited > 0 && prefecture.remaining > 0),
+      completedPrefecture: prefectureProgress.find((prefecture) => prefecture.total > 0 && prefecture.remaining === 0),
+      collectionManholes,
+    };
+  }, [journeyVisits, journeyManholes, nearbyUnvisited, journeyTab]);
+
+  const {
+    visitsByManholeId,
+    visitedCount,
+    unvisitedManholes,
+    prefectureProgress,
+    leadingPrefectures,
+    nextPrefecture,
+    completedPrefecture,
+    collectionManholes,
+  } = journeyData;
+  const completionRate = knownTotalManholes ? (visitedCount / knownTotalManholes) * 100 : null;
 
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
@@ -423,16 +448,18 @@ export default function HomePage() {
                         <div className="mb-2 flex items-end justify-between gap-3">
                           <div>
                             <p className="font-pixel text-2xl text-[#4F3828]">
-                              {visitedCount} / {knownTotalManholes} STAMPS
+                              {visitedCount} / {knownTotalManholes ?? '集計中'} STAMPS
                             </p>
                             <p className="mt-1 text-xs font-bold text-[#6A4D36]">旅の進捗</p>
                           </div>
-                          <p className="font-pixel text-xl text-[#B5483C]">{completionRate.toFixed(1)}%</p>
+                          <p className="font-pixel text-xl text-[#B5483C]">
+                            {completionRate === null ? '--%' : `${completionRate.toFixed(1)}%`}
+                          </p>
                         </div>
                         <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/20 bg-[#E4D4B8]">
                           <div
                             className="h-full bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D]"
-                            style={{ width: `${Math.min(completionRate, 100)}%` }}
+                            style={{ width: `${Math.min(completionRate ?? 0, 100)}%` }}
                           />
                         </div>
                         <div className="mt-4 grid gap-2 sm:grid-cols-3">
@@ -465,6 +492,16 @@ export default function HomePage() {
                           </Link>
                         ))}
                       </div>
+                      {nearbyStatus !== 'ready' && (
+                        <button
+                          type="button"
+                          onClick={loadNearbyUnvisited}
+                          disabled={nearbyStatus === 'loading'}
+                          className="mt-3 min-h-[40px] w-full rounded-[7px] border border-[#8C6A4A]/20 bg-white px-3 text-sm font-extrabold text-[#4F3828] transition hover:bg-[#F8D9C4] disabled:opacity-60"
+                        >
+                          {nearbyStatus === 'loading' ? '現在地を確認中...' : '近くの未訪問を表示'}
+                        </button>
+                      )}
                       {completedPrefecture ? (
                         <div className="mt-4 rounded-[7px] border border-[#3F9D7D]/25 bg-[#DFF1E9] px-3 py-2">
                           <p className="flex items-center gap-2 text-xs font-extrabold text-[#2C765E]">
@@ -794,7 +831,7 @@ function JourneyPrefectureStat({ prefecture }: { prefecture: PrefectureProgress 
   );
 }
 
-function UnauthedStampOnboarding({ totalManholes }: { totalManholes: number }) {
+function UnauthedStampOnboarding({ totalManholes }: { totalManholes: number | null }) {
   const previewPrefectures = [
     { name: '愛知県', visited: 0, total: 7 },
     { name: '岐阜県', visited: 0, total: 5 },
@@ -818,7 +855,7 @@ function UnauthedStampOnboarding({ totalManholes }: { totalManholes: number }) {
         <div className="mt-5 rounded-[8px] border border-[#8C6A4A]/15 bg-white/60 p-4">
           <div className="mb-2 flex items-end justify-between gap-3">
             <div>
-              <p className="font-pixel text-2xl text-[#4F3828]">0 / {totalManholes} STAMPS</p>
+              <p className="font-pixel text-2xl text-[#4F3828]">0 / {totalManholes ?? '集計中'} STAMPS</p>
               <p className="mt-1 text-xs font-bold text-[#6A4D36]">あなたの旅はここから</p>
             </div>
             <p className="font-pixel text-xl text-[#B5483C]">0%</p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import {
   CircleDot,
   Compass,
   Heart,
+  Lock,
   MapPin,
   Menu,
   MessageCircle,
@@ -483,6 +484,8 @@ export default function HomePage() {
                   </div>
                 </section>
 
+                <UnauthedStampOnboarding totalManholes={knownTotalManholes} />
+
                 <section className="mt-6">
                   <div className="-mx-4 overflow-x-auto px-4 pb-1">
                     <div className="flex min-w-max gap-2 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5]/90 p-1 shadow-sm sm:min-w-0">
@@ -786,6 +789,133 @@ function JourneyPrefectureStat({ prefecture }: { prefecture: PrefectureProgress 
       </div>
       <div className="h-2 overflow-hidden rounded-sm bg-[#E4D4B8]">
         <div className="h-full bg-[#3F9D7D]" style={{ width: `${Math.min(prefecture.rate, 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function UnauthedStampOnboarding({ totalManholes }: { totalManholes: number }) {
+  const previewPrefectures = [
+    { name: '愛知県', visited: 0, total: 7 },
+    { name: '岐阜県', visited: 0, total: 5 },
+    { name: '三重県', visited: 0, total: 4 },
+  ];
+
+  return (
+    <section className="mt-6 grid gap-4 rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] p-4 shadow-[0_8px_22px_rgba(95,68,42,0.10)] lg:grid-cols-[0.9fr_1.1fr]">
+      <div>
+        <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#B5483C]/25 bg-[#F8D9C4] px-3 py-1 text-xs font-extrabold text-[#B5483C]">
+          <Lock className="h-3.5 w-3.5" />
+          登録すると使える
+        </div>
+        <h2 className="text-2xl font-extrabold leading-tight text-[#4F3828] sm:text-3xl">
+          自分だけのスタンプ帳を作ろう
+        </h2>
+        <p className="mt-3 text-sm font-semibold leading-6 text-[#6A4D36]">
+          訪問したポケふたがマンホール写真として埋まり、未訪問は次のスタンプ候補として残ります。
+        </p>
+
+        <div className="mt-5 rounded-[8px] border border-[#8C6A4A]/15 bg-white/60 p-4">
+          <div className="mb-2 flex items-end justify-between gap-3">
+            <div>
+              <p className="font-pixel text-2xl text-[#4F3828]">0 / {totalManholes} STAMPS</p>
+              <p className="mt-1 text-xs font-bold text-[#6A4D36]">あなたの旅はここから</p>
+            </div>
+            <p className="font-pixel text-xl text-[#B5483C]">0%</p>
+          </div>
+          <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/20 bg-[#E4D4B8]">
+            <div className="h-full w-[6%] bg-[#D5C8B3]" />
+          </div>
+          <div className="mt-4 grid gap-2 sm:grid-cols-3 lg:grid-cols-1 xl:grid-cols-3">
+            {previewPrefectures.map((prefecture) => (
+              <div key={prefecture.name} className="rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3">
+                <div className="mb-2 flex items-center justify-between">
+                  <p className="text-sm font-extrabold text-[#4F3828]">{prefecture.name}</p>
+                  <p className="font-pixel text-sm text-[#B5483C]">{prefecture.visited}/{prefecture.total}</p>
+                </div>
+                <div className="h-2 overflow-hidden rounded-sm bg-[#E4D4B8]">
+                  <div className="h-full w-[8%] bg-[#D5C8B3]" />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+          <Link
+            href="/signup"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-[7px] bg-[#B5483C] px-5 text-sm font-extrabold text-white shadow-sm transition hover:bg-[#9F3D33]"
+          >
+            無料でスタンプ帳を始める
+          </Link>
+          <Link
+            href="/login?redirect=/visits"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-[7px] border border-[#8C6A4A]/20 bg-white px-5 text-sm font-extrabold text-[#4F3828] transition hover:bg-[#F8D9C4]"
+          >
+            ログインして続きへ
+          </Link>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 lg:grid-cols-2">
+        <UnauthedStampPreviewCard visited municipality="刈谷市" prefecture="愛知県" date="2026/春" />
+        <UnauthedStampPreviewCard visited municipality="名古屋市" prefecture="愛知県" date="2026/夏" />
+        <UnauthedStampPreviewCard municipality="岡崎市" prefecture="愛知県" />
+        <UnauthedStampPreviewCard municipality="豊田市" prefecture="愛知県" />
+      </div>
+    </section>
+  );
+}
+
+function UnauthedStampPreviewCard({
+  visited = false,
+  municipality,
+  prefecture,
+  date,
+}: {
+  visited?: boolean;
+  municipality: string;
+  prefecture: string;
+  date?: string;
+}) {
+  return (
+    <div
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-[8px] border-2 p-3 ${
+        visited
+          ? 'border-[#B5483C]/40 bg-[#FFF7E5] shadow-sm'
+          : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]'
+      }`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span
+          className={`rounded-full px-2 py-1 text-[10px] font-extrabold ${
+            visited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
+          }`}
+        >
+          {visited ? '見本' : '未訪問'}
+        </span>
+        {!visited && <Lock className="h-4 w-4 text-[#8C6A4A]" />}
+      </div>
+
+      <div className="flex flex-1 items-center justify-center">
+        {visited ? (
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border-4 border-[#D94D3F] bg-[radial-gradient(circle,#5EA7C7_0_18%,#F4D36F_19%_33%,#2D2D2D_34%_38%,#8ED1C6_39%_58%,#2D2D2D_59%_64%,#E9DEC9_65%)]">
+            <CircleDot className="h-8 w-8 text-white/90" />
+          </div>
+        ) : (
+          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-[#A39580]">
+            <div className="text-center">
+              <Stamp className="mx-auto h-6 w-6" />
+              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">{municipality}</p>
+        <p className="mt-1 text-xs font-bold text-[#6A4D36]">{prefecture}</p>
+        <p className="mt-2 font-pixel text-xs text-[#B5483C]">{visited ? date : '登録で解放'}</p>
       </div>
     </div>
   );

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -1,8 +1,20 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { MapPin, Calendar, Camera, Navigation, History, Heart, Bookmark, Home, Trash2 } from 'lucide-react';
+import {
+  Bookmark,
+  Calendar,
+  Camera,
+  CheckCircle2,
+  CircleDot,
+  Heart,
+  MapPin,
+  Navigation,
+  PlusCircle,
+  Stamp,
+  Trash2,
+} from 'lucide-react';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
 import { Manhole } from '@/types/database';
@@ -27,8 +39,45 @@ interface Visit {
   is_bookmarked: boolean;
 }
 
+type PassportTab = 'stamps' | 'prefectures' | 'recent' | 'unvisited';
+
+type VisitSummary = {
+  count: number;
+  latestVisit: Visit;
+  hasPhotos: boolean;
+};
+
+type PrefectureProgress = {
+  name: string;
+  total: number;
+  visited: number;
+  remaining: number;
+  rate: number;
+};
+
+const FALLBACK_TOTAL_MANHOLES = 470;
+
+const tabs: { id: PassportTab; label: string }[] = [
+  { id: 'stamps', label: 'スタンプ帳' },
+  { id: 'prefectures', label: '都道府県' },
+  { id: 'recent', label: '最近' },
+  { id: 'unvisited', label: '未訪問' },
+];
+
+const formatVisitDate = (date: string, pattern = 'yyyy/MM/dd') => {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return '日付なし';
+  return format(parsed, pattern, { locale: ja });
+};
+
+const getManholeName = (manhole: Manhole) => manhole.name || manhole.title || 'ポケふた';
+const getMunicipality = (manhole: Manhole) => manhole.city || manhole.municipality || '場所未設定';
+
 export default function VisitsPage() {
   const [visits, setVisits] = useState<Visit[]>([]);
+  const [manholes, setManholes] = useState<Manhole[]>([]);
+  const [totalManholes, setTotalManholes] = useState(FALLBACK_TOTAL_MANHOLES);
+  const [activeTab, setActiveTab] = useState<PassportTab>('stamps');
   const [loading, setLoading] = useState(true);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
@@ -36,25 +85,22 @@ export default function VisitsPage() {
   const { trackView } = useAnalytics();
 
   useEffect(() => {
-    // ページタイトル設定
-    document.title = '訪問履歴 - ポケふた訪問記録';
-
-    // ✅ GA: ページビュー追跡
-    trackView('/visits', '訪問履歴', 'visits');
-
-    loadVisits();
+    document.title = 'ポケふた訪問パスポート - ポケふた訪問記録';
+    trackView('/visits', 'ポケふた訪問パスポート', 'visits');
+    loadPassport();
   }, []);
 
-  const loadVisits = async () => {
+  const loadPassport = async () => {
     try {
-      // Fetch visits from the API
-      const response = await fetch('/api/visits');
-      if (response.ok) {
-        const data = await response.json();
+      const [visitsResponse, manholesResponse] = await Promise.all([
+        fetch('/api/visits?limit=1000'),
+        fetch('/api/manholes?limit=1000'),
+      ]);
+
+      if (visitsResponse.ok) {
+        const data = await visitsResponse.json();
 
         if (data.success && data.visits) {
-          // Transform API response to match our Visit interface
-          // Filter out visits without manhole data
           const apiVisits: Visit[] = data.visits
             .filter((visit: any) => visit.manhole && visit.manhole.id)
             .map((visit: any) => ({
@@ -78,7 +124,7 @@ export default function VisitsPage() {
               photos: visit.photos?.map((photo: any) => ({
                 id: photo.id,
                 url: photo.url,
-                thumbnail_url: photo.thumbnail_url
+                thumbnail_url: photo.thumbnail_url,
               })) || [],
               notes: visit.note,
               comment: visit.comment,
@@ -91,28 +137,130 @@ export default function VisitsPage() {
           setVisits(apiVisits);
         }
       }
+
+      if (manholesResponse.ok) {
+        const data = await manholesResponse.json();
+        const apiManholes: Manhole[] = Array.isArray(data.manholes)
+          ? data.manholes.map((manhole: any) => ({
+              ...manhole,
+              name: manhole.name || manhole.title,
+              city: manhole.city || manhole.municipality,
+            }))
+          : [];
+
+        setManholes(apiManholes);
+        setTotalManholes(data.total || apiManholes.length || FALLBACK_TOTAL_MANHOLES);
+      }
     } catch (error) {
-      console.error('Failed to load visits:', error);
+      console.error('Failed to load passport:', error);
     } finally {
       setLoading(false);
     }
   };
 
-  const sortedVisits = [...visits].sort((a, b) =>
-    new Date(b.visited_at).getTime() - new Date(a.visited_at).getTime()
+  const sortedVisits = useMemo(
+    () => [...visits].sort((a, b) => new Date(b.visited_at).getTime() - new Date(a.visited_at).getTime()),
+    [visits]
   );
 
-  const visitedManholesCount = new Set(
-    visits
-      .map((visit) => visit.manhole?.id)
-      .filter((id): id is number => typeof id === 'number')
-  ).size;
+  const visitSummaryByManholeId = useMemo(() => {
+    const summary = new Map<number, VisitSummary>();
 
-  const visitedPrefecturesCount = new Set(
-    visits
-      .map((visit) => visit.manhole?.prefecture?.trim())
-      .filter((prefecture): prefecture is string => Boolean(prefecture))
-  ).size;
+    sortedVisits.forEach((visit) => {
+      const manholeId = visit.manhole?.id;
+      if (typeof manholeId !== 'number') return;
+
+      const current = summary.get(manholeId);
+      summary.set(manholeId, {
+        count: (current?.count || 0) + 1,
+        latestVisit: current?.latestVisit || visit,
+        hasPhotos: Boolean(current?.hasPhotos || visit.photos.length > 0),
+      });
+    });
+
+    return summary;
+  }, [sortedVisits]);
+
+  const visitedManholesCount = visitSummaryByManholeId.size;
+  const completionRate = totalManholes > 0 ? (visitedManholesCount / totalManholes) * 100 : 0;
+
+  const visitedMunicipalityCount = useMemo(() => {
+    return new Set(
+      visits
+        .map((visit) => {
+          const prefecture = visit.manhole?.prefecture?.trim();
+          const municipality = getMunicipality(visit.manhole).trim();
+          return prefecture && municipality ? `${prefecture}-${municipality}` : null;
+        })
+        .filter((value): value is string => Boolean(value))
+    ).size;
+  }, [visits]);
+
+  const passportManholes = useMemo(() => {
+    const byId = new Map<number, Manhole>();
+
+    manholes.forEach((manhole) => {
+      byId.set(manhole.id, manhole);
+    });
+
+    visits.forEach((visit) => {
+      if (!byId.has(visit.manhole.id)) {
+        byId.set(visit.manhole.id, visit.manhole);
+      }
+    });
+
+    return Array.from(byId.values()).sort((a, b) => {
+      const aSummary = visitSummaryByManholeId.get(a.id);
+      const bSummary = visitSummaryByManholeId.get(b.id);
+
+      if (aSummary && bSummary) {
+        return new Date(bSummary.latestVisit.visited_at).getTime() - new Date(aSummary.latestVisit.visited_at).getTime();
+      }
+
+      if (aSummary) return -1;
+      if (bSummary) return 1;
+
+      return `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(`${b.prefecture}${getMunicipality(b)}${b.id}`, 'ja');
+    });
+  }, [manholes, visits, visitSummaryByManholeId]);
+
+  const prefectureProgress = useMemo<PrefectureProgress[]>(() => {
+    const progress = new Map<string, { totalIds: Set<number>; visitedIds: Set<number> }>();
+
+    passportManholes.forEach((manhole) => {
+      const prefecture = manhole.prefecture || '都道府県未設定';
+      const current = progress.get(prefecture) || { totalIds: new Set<number>(), visitedIds: new Set<number>() };
+      current.totalIds.add(manhole.id);
+
+      if (visitSummaryByManholeId.has(manhole.id)) {
+        current.visitedIds.add(manhole.id);
+      }
+
+      progress.set(prefecture, current);
+    });
+
+    return Array.from(progress.entries())
+      .map(([name, value]) => {
+        const total = value.totalIds.size;
+        const visited = value.visitedIds.size;
+        return {
+          name,
+          total,
+          visited,
+          remaining: Math.max(total - visited, 0),
+          rate: total > 0 ? (visited / total) * 100 : 0,
+        };
+      })
+      .sort((a, b) => {
+        if (b.visited !== a.visited) return b.visited - a.visited;
+        if (b.rate !== a.rate) return b.rate - a.rate;
+        return a.name.localeCompare(b.name, 'ja');
+      });
+  }, [passportManholes, visitSummaryByManholeId]);
+
+  const leadingPrefecture = prefectureProgress.find((prefecture) => prefecture.visited > 0) || prefectureProgress[0];
+  const unvisitedManholes = passportManholes.filter((manhole) => !visitSummaryByManholeId.has(manhole.id));
+  const recentMilestone = Math.floor(visitedManholesCount / 10) * 10;
 
   const handleDeleteClick = (photoId: string) => {
     setSelectedPhotoId(photoId);
@@ -131,22 +279,20 @@ export default function VisitsPage() {
       const data = await response.json();
 
       if (response.ok && data.success) {
-        // 成功: 写真リストから削除し、写真がなくなったvisitは非表示
+        const deletedPhotoIds = new Set<string>(data.photo_ids || [selectedPhotoId]);
+        const deletedVisitId = data.visit_id;
         const updatedVisits = visits
-          .map(visit => ({
+          .filter((visit) => visit.id !== deletedVisitId)
+          .map((visit) => ({
             ...visit,
-            photos: visit.photos.filter(p => p.id !== selectedPhotoId)
-          }))
-          .filter(visit => visit.photos.length > 0); // 写真が0枚になったvisitを除外
+            photos: visit.photos.filter((photo) => !deletedPhotoIds.has(photo.id)),
+          }));
 
         setVisits(updatedVisits);
         setDeleteModalOpen(false);
         setSelectedPhotoId(null);
-
-        // 成功メッセージ（オプション）
-        alert('写真を削除しました');
+        alert(data.visit_deleted ? '写真と訪問記録を削除しました' : '写真を削除しました');
       } else {
-        // エラー
         console.error('Failed to delete photo:', data);
         alert(`削除に失敗しました: ${data.error || '不明なエラー'}`);
       }
@@ -164,90 +310,74 @@ export default function VisitsPage() {
   };
 
   const handleLikeToggle = async (visitId: string) => {
-    const visit = visits.find(v => v.id === visitId);
+    const visit = visits.find((target) => target.id === visitId);
     if (!visit) return;
 
     const isLiked = visit.is_liked;
     const method = isLiked ? 'DELETE' : 'POST';
 
-    // Optimistic update
-    setVisits(prevVisits => prevVisits.map(v =>
-      v.id === visitId
+    setVisits((prevVisits) => prevVisits.map((target) =>
+      target.id === visitId
         ? {
-            ...v,
+            ...target,
             is_liked: !isLiked,
-            likes_count: isLiked ? v.likes_count - 1 : v.likes_count + 1
+            likes_count: isLiked ? target.likes_count - 1 : target.likes_count + 1,
           }
-        : v
+        : target
     ));
 
     try {
-      const response = await fetch(`/api/visits/${visitId}/like`, {
-        method,
-      });
+      const response = await fetch(`/api/visits/${visitId}/like`, { method });
 
       if (!response.ok) {
-        // Revert on error
-        setVisits(prevVisits => prevVisits.map(v =>
-          v.id === visitId
+        setVisits((prevVisits) => prevVisits.map((target) =>
+          target.id === visitId
             ? {
-                ...v,
+                ...target,
                 is_liked: isLiked,
-                likes_count: isLiked ? v.likes_count + 1 : v.likes_count - 1
+                likes_count: isLiked ? target.likes_count + 1 : target.likes_count - 1,
               }
-            : v
+            : target
         ));
         console.error('Failed to toggle like');
       }
     } catch (error) {
-      // Revert on error
-      setVisits(prevVisits => prevVisits.map(v =>
-        v.id === visitId
+      setVisits((prevVisits) => prevVisits.map((target) =>
+        target.id === visitId
           ? {
-              ...v,
+              ...target,
               is_liked: isLiked,
-              likes_count: isLiked ? v.likes_count + 1 : v.likes_count - 1
+              likes_count: isLiked ? target.likes_count + 1 : target.likes_count - 1,
             }
-          : v
+          : target
       ));
       console.error('Error toggling like:', error);
     }
   };
 
   const handleBookmarkToggle = async (visitId: string) => {
-    const visit = visits.find(v => v.id === visitId);
+    const visit = visits.find((target) => target.id === visitId);
     if (!visit) return;
 
     const isBookmarked = visit.is_bookmarked;
     const method = isBookmarked ? 'DELETE' : 'POST';
 
-    // Optimistic update
-    setVisits(prevVisits => prevVisits.map(v =>
-      v.id === visitId
-        ? { ...v, is_bookmarked: !isBookmarked }
-        : v
+    setVisits((prevVisits) => prevVisits.map((target) =>
+      target.id === visitId ? { ...target, is_bookmarked: !isBookmarked } : target
     ));
 
     try {
-      const response = await fetch(`/api/visits/${visitId}/bookmark`, {
-        method,
-      });
+      const response = await fetch(`/api/visits/${visitId}/bookmark`, { method });
 
       if (!response.ok) {
-        // Revert on error
-        setVisits(prevVisits => prevVisits.map(v =>
-          v.id === visitId
-            ? { ...v, is_bookmarked: isBookmarked }
-            : v
+        setVisits((prevVisits) => prevVisits.map((target) =>
+          target.id === visitId ? { ...target, is_bookmarked: isBookmarked } : target
         ));
         console.error('Failed to toggle bookmark');
       }
     } catch (error) {
-      // Revert on error
-      setVisits(prevVisits => prevVisits.map(v =>
-        v.id === visitId
-          ? { ...v, is_bookmarked: isBookmarked }
-          : v
+      setVisits((prevVisits) => prevVisits.map((target) =>
+        target.id === visitId ? { ...target, is_bookmarked: isBookmarked } : target
       ));
       console.error('Error toggling bookmark:', error);
     }
@@ -255,10 +385,10 @@ export default function VisitsPage() {
 
   if (loading) {
     return (
-      <div className="min-h-screen safe-area-inset bg-[#F6EEDC] flex items-center justify-center">
+      <div className="min-h-screen safe-area-inset bg-[#F3E7CC] flex items-center justify-center">
         <div className="text-center">
-          <div className="font-pixelJp text-[#7B63A8]">
-            読み込み中<span className="rpg-loading"></span>
+          <div className="font-pixelJp text-[#6A4D36]">
+            パスポート準備中<span className="rpg-loading"></span>
           </div>
         </div>
       </div>
@@ -266,248 +396,160 @@ export default function VisitsPage() {
   }
 
   return (
-    <div className="min-h-screen safe-area-inset bg-[#F6EEDC]">
-      {/* Feed Container */}
-      <div className="max-w-2xl mx-auto pb-nav-safe">
-        <div className="p-4 pb-0">
-          <div className="rpg-window">
-            <h2 className="font-pixelJp text-sm text-rpg-textDark font-bold mb-1">訪問履歴</h2>
-            <p className="font-pixelJp text-xs text-rpg-textDark opacity-70">
-              登録した訪問記録を一覧で見られます。写真・コメントを確認したり、いいね/ブックマークの状態もチェックできます。
-            </p>
-          </div>
+    <div className="min-h-screen safe-area-inset bg-[#F3E7CC]">
+      <div className="max-w-3xl mx-auto pb-[10rem]">
+        <div className="p-4 space-y-4">
+          <section className="relative overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5] p-4 shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
+            <div className="absolute inset-0 opacity-[0.08] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+            <div className="relative">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <p className="font-pixelJp text-[11px] font-bold text-[#9B5C2E]">POKEFUTA PASSPORT</p>
+                  <h1 className="mt-1 font-pixelJp text-xl font-bold text-[#4F3828]">
+                    ポケふた訪問パスポート
+                  </h1>
+                </div>
+                <div className="shrink-0 rounded-lg border border-[#B65A4B]/30 bg-[#F8D9C4] px-3 py-2 text-center">
+                  <p className="font-pixel text-2xl leading-none text-[#B5483C]">{visitedManholesCount}</p>
+                  <p className="font-pixelJp text-[10px] font-bold text-[#6A4D36]">STAMPS</p>
+                </div>
+              </div>
+
+              <div className="mt-5">
+                <div className="mb-2 flex items-end justify-between">
+                  <div>
+                    <p className="font-pixel text-2xl text-[#4F3828]">
+                      {visitedManholesCount} / {totalManholes}
+                    </p>
+                    <p className="font-pixelJp text-xs text-[#6A4D36]">訪問済みスタンプ</p>
+                  </div>
+                  <p className="font-pixel text-xl text-[#B5483C]">{completionRate.toFixed(1)}%</p>
+                </div>
+                <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/25 bg-[#E4D4B8]">
+                  <div
+                    className="h-full rounded-sm bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D] transition-all"
+                    style={{ width: `${Math.min(completionRate, 100)}%` }}
+                  />
+                </div>
+              </div>
+
+              <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                <SummaryStat label="達成率" value={`${completionRate.toFixed(1)}%`} />
+                <SummaryStat label="訪問自治体" value={`${visitedMunicipalityCount}`} />
+                <SummaryStat label="写真つき" value={`${visits.filter((visit) => visit.photos.length > 0).length}`} />
+                <SummaryStat
+                  label="先頭の県"
+                  value={leadingPrefecture ? `${leadingPrefecture.name} ${leadingPrefecture.visited}/${leadingPrefecture.total}` : '-'}
+                  compact
+                />
+              </div>
+
+              {visitedManholesCount > 0 && (
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <AchievementBadge label="NEW STAMP" active={visitedManholesCount === 1} />
+                  {recentMilestone >= 10 && <AchievementBadge label={`${recentMilestone} STAMPS達成`} active />}
+                  {prefectureProgress.some((prefecture) => prefecture.total > 0 && prefecture.remaining === 0) && (
+                    <AchievementBadge label="都道府県コンプリート" active />
+                  )}
+                </div>
+              )}
+            </div>
+          </section>
+
+          {prefectureProgress.some((prefecture) => prefecture.visited > 0) && (
+            <section className="grid gap-3 sm:grid-cols-3">
+              {prefectureProgress
+                .filter((prefecture) => prefecture.visited > 0)
+                .slice(0, 3)
+                .map((prefecture) => (
+                  <PrefectureMiniCard key={prefecture.name} prefecture={prefecture} />
+                ))}
+            </section>
+          )}
+
+          <nav className="sticky top-2 z-20 -mx-1 rounded-lg border border-[#8C6A4A]/15 bg-[#FFF7E5]/95 p-1 shadow-sm backdrop-blur">
+            <div className="grid grid-cols-4 gap-1">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`min-h-[38px] rounded-md px-2 text-center font-pixelJp text-[11px] font-bold transition-colors sm:text-xs ${
+                    activeTab === tab.id
+                      ? 'bg-[#4F3828] text-[#FFF7E5]'
+                      : 'text-[#6A4D36] hover:bg-[#EAD9B8]'
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+          </nav>
+
+          {sortedVisits.length === 0 ? (
+            <EmptyPassport />
+          ) : (
+            <>
+              {activeTab === 'stamps' && (
+                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                  {passportManholes.slice(0, 60).map((manhole) => (
+                    <StampCard
+                      key={manhole.id}
+                      manhole={manhole}
+                      summary={visitSummaryByManholeId.get(manhole.id)}
+                    />
+                  ))}
+                </section>
+              )}
+
+              {activeTab === 'prefectures' && (
+                <section className="grid gap-3 sm:grid-cols-2">
+                  {prefectureProgress.map((prefecture) => (
+                    <PrefectureProgressCard key={prefecture.name} prefecture={prefecture} />
+                  ))}
+                </section>
+              )}
+
+              {activeTab === 'recent' && (
+                <section className="space-y-4">
+                  {sortedVisits.map((visit) => (
+                    <RecentVisitCard
+                      key={visit.id}
+                      visit={visit}
+                      onDeleteClick={handleDeleteClick}
+                      onLikeToggle={handleLikeToggle}
+                      onBookmarkToggle={handleBookmarkToggle}
+                    />
+                  ))}
+                </section>
+              )}
+
+              {activeTab === 'unvisited' && (
+                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                  {unvisitedManholes.slice(0, 60).map((manhole) => (
+                    <StampCard key={manhole.id} manhole={manhole} />
+                  ))}
+                </section>
+              )}
+            </>
+          )}
         </div>
+      </div>
 
-        {visits.length > 0 && (
-          <div className="p-4 pb-0">
-            <div className="grid grid-cols-2 gap-3">
-              <div className="rpg-window text-center">
-                <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mb-2">
-                  訪れたマンホール
-                </p>
-                <p className="font-pixel text-2xl text-rpg-textDark">
-                  {visitedManholesCount}
-                </p>
-              </div>
-              <div className="rpg-window text-center">
-                <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mb-2">
-                  訪れた都道府県
-                </p>
-                <p className="font-pixel text-2xl text-rpg-textDark">
-                  {visitedPrefecturesCount}
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {sortedVisits.length === 0 ? (
-          <div className="text-center py-12 px-4">
-            <div className="rpg-window">
-              <Camera className="w-16 h-16 mx-auto mb-4 text-rpg-textDark opacity-50" />
-              <h3 className="font-pixelJp text-lg text-rpg-textDark mb-2">
-                まだ冒険の記録がありません
-              </h3>
-              <p className="font-pixelJp text-sm text-rpg-textDark mb-6">
-                ポケふたを見つけて、冒険を始めよう！
-              </p>
-              <button
-                onClick={() => window.location.href = '/nearby'}
-                className="rpg-button rpg-button-primary"
-              >
-                近くを探す
-              </button>
-            </div>
-          </div>
-        ) : (
-          <div className="space-y-4 p-4">
-            {sortedVisits.map((visit) => (
-              <div key={visit.id} className="rpg-window">
-                {/* Header */}
-                <div className="flex items-center gap-3 mb-3 pb-3 border-b border-[#7B63A8]/15">
-                  <div className="w-10 h-10 bg-rpg-yellow border border-[#7B63A8]/15 flex items-center justify-center">
-                    <MapPin className="w-6 h-6 text-rpg-textDark" />
-                  </div>
-                  <div className="flex-1">
-                    <h3 className="font-pixelJp text-sm text-rpg-textDark font-bold">
-                      {visit.manhole.name || 'ポケふた'}
-                    </h3>
-                    <p className="font-pixelJp text-xs text-rpg-textDark opacity-70">
-                      {visit.manhole.prefecture} {visit.manhole.city}
-                    </p>
-                  </div>
-                </div>
-
-                {/* Photos */}
-                {visit.photos.length > 0 ? (
-                  <div className="mb-3 -mx-rpg-2">
-                    <div className={`grid gap-1 ${visit.photos.length === 1 ? 'grid-cols-1' : visit.photos.length === 2 ? 'grid-cols-2' : 'grid-cols-2'}`}>
-                      {visit.photos.slice(0, 4).map((photo, index) => (
-                        <div
-                          key={photo.id}
-                          className={`relative ${visit.photos.length === 1 ? 'aspect-square' : 'aspect-square'} bg-[#F6EEDC] overflow-hidden group border border-[#7B63A8]/15`}
-                        >
-                          <img
-                            src={photo.thumbnail_url}
-                            alt={`Photo ${index + 1}`}
-                            className="w-full h-full object-cover"
-                            style={{ imageRendering: 'pixelated' }}
-                            onError={(e) => {
-                              // 画像読み込みエラー時の表示
-                              const target = e.currentTarget;
-                              target.style.display = 'none';
-                              const parent = target.parentElement;
-                              if (parent && !parent.querySelector('.error-placeholder')) {
-                                const errorDiv = document.createElement('div');
-                                errorDiv.className = 'error-placeholder absolute inset-0 bg-[#F6EEDC] flex flex-col items-center justify-center';
-                                errorDiv.innerHTML = `
-                                  <svg class="w-8 h-8 text-rpg-textDark opacity-50 mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
-                                  </svg>
-                                  <span class="font-pixelJp text-[10px] text-rpg-textDark opacity-70 text-center px-2">画像なし</span>
-                                `;
-                                parent.appendChild(errorDiv);
-                              }
-                            }}
-                          />
-                          {visit.photos.length > 4 && index === 3 && (
-                            <div className="absolute inset-0 bg-black/70 flex items-center justify-center z-10">
-                              <span className="font-pixel text-white text-xl">
-                                +{visit.photos.length - 3}
-                              </span>
-                            </div>
-                          )}
-                          {/* Delete button - shows on hover (always display regardless of image load status) */}
-                          {visit.photos.length <= 4 && (
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteClick(photo.id);
-                              }}
-                              className="absolute top-2 right-2 bg-rpg-red border border-[#7B63A8]/15 p-1.5 opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-600 z-20"
-                              title="写真を削除"
-                            >
-                              <Trash2 className="w-3 h-3 text-white" />
-                            </button>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : (
-                  <div className="mb-3 -mx-rpg-2">
-                    <div className="aspect-video bg-[#F6EEDC] border border-[#7B63A8]/15 flex items-center justify-center">
-                      <Camera className="w-12 h-12 text-rpg-textDark opacity-30" />
-                    </div>
-                  </div>
-                )}
-
-                {/* Actions (Instagram-like) */}
-                <div className="flex items-center gap-4 mb-3 pb-3 border-b border-[#7B63A8]/15">
-                  <button
-                    onClick={() => handleLikeToggle(visit.id)}
-                    className="flex items-center gap-1 hover:opacity-70 transition-opacity"
-                  >
-                    <Heart
-                      className={`w-5 h-5 ${visit.is_liked ? 'fill-rpg-red text-rpg-red' : 'text-rpg-red'}`}
-                    />
-                    {visit.likes_count > 0 && (
-                      <span className="font-pixel text-xs text-rpg-textDark">
-                        {visit.likes_count}
-                      </span>
-                    )}
-                  </button>
-                  <div className="flex-1"></div>
-                  <button
-                    onClick={() => handleBookmarkToggle(visit.id)}
-                    className="hover:opacity-70 transition-opacity"
-                  >
-                    <Bookmark
-                      className={`w-5 h-5 ${visit.is_bookmarked ? 'fill-rpg-yellow text-rpg-yellow' : 'text-rpg-yellow'}`}
-                    />
-                  </button>
-                </div>
-
-                {/* Info */}
-                <div className="space-y-2">
-                  {visit.likes_count > 0 && (
-                    <div className="font-pixelJp text-sm text-rpg-textDark">
-                      <span className="font-bold">{visit.likes_count}人</span>がいいねしました
-                    </div>
-                  )}
-
-                  {visit.comment && (
-                    <p className="font-pixelJp text-sm text-rpg-textDark">
-                      {visit.comment}
-                    </p>
-                  )}
-
-                  <div className="flex items-center gap-2">
-                    <span className="font-pixel text-xs text-rpg-yellow">
-                      {visit.photos.length}
-                    </span>
-                    <span className="font-pixelJp text-xs text-rpg-textDark">
-                      枚の写真
-                    </span>
-                  </div>
-
-                  {visit.notes && (
-                    <p className="font-pixelJp text-sm text-rpg-textDark">
-                      <span className="font-bold">メモ:</span> {visit.notes}
-                    </p>
-                  )}
-
-                  {visit.manhole.pokemons && visit.manhole.pokemons.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {visit.manhole.pokemons.slice(0, 5).map((pokemon, index) => (
-                        <span
-                          key={index}
-                          className="bg-rpg-yellow px-2 py-1 border border-[#7B63A8]/15 font-pixelJp text-xs text-rpg-textDark"
-                        >
-                          {pokemon}
-                        </span>
-                      ))}
-                      {visit.manhole.pokemons.length > 5 && (
-                        <span className="font-pixelJp text-xs text-rpg-textDark opacity-70">
-                          +{visit.manhole.pokemons.length - 5}
-                        </span>
-                      )}
-                    </div>
-                  )}
-
-                  <div className="flex items-center gap-2 pt-2">
-                    <Calendar className="w-4 h-4 text-rpg-textDark opacity-70" />
-                    <span className="font-pixelJp text-xs text-rpg-textDark opacity-70">
-                      {format(new Date(visit.visited_at), 'yyyy/MM/dd HH:mm', { locale: ja })}
-                    </span>
-                  </div>
-
-                  <div className="flex gap-2 pt-2">
-                    <button
-                      onClick={() => window.location.href = `/manhole/${visit.manhole.id}`}
-                      className="rpg-button text-xs flex-1"
-                    >
-                      詳細
-                    </button>
-                    {visit.photos.length > 0 && (
-                      <button
-                        onClick={() => window.location.href = `/manhole/${visit.manhole.id}`}
-                        className="rpg-button rpg-button-success text-xs flex-1"
-                      >
-                        写真
-                      </button>
-                    )}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+      <div className="fixed inset-x-0 bottom-[4.6rem] z-30 px-4">
+        <div className="mx-auto flex max-w-3xl gap-2 rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5]/95 p-2 shadow-lg backdrop-blur">
+          <Link href="/upload" className="flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-md bg-[#B5483C] px-3 font-pixelJp text-xs font-bold text-white">
+            <PlusCircle className="h-4 w-4" />
+            訪問を記録
+          </Link>
+          <Link href="/nearby" className="flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-md border border-[#8C6A4A]/25 bg-white px-3 font-pixelJp text-xs font-bold text-[#4F3828]">
+            <Navigation className="h-4 w-4" />
+            近くの未訪問
+          </Link>
+        </div>
       </div>
 
       <BottomNav />
 
-      {/* Delete Photo Modal */}
       {selectedPhotoId && (
         <DeletePhotoModal
           isOpen={deleteModalOpen}
@@ -518,5 +560,254 @@ export default function VisitsPage() {
         />
       )}
     </div>
+  );
+}
+
+function SummaryStat({ label, value, compact = false }: { label: string; value: string; compact?: boolean }) {
+  return (
+    <div className="rounded-md border border-[#8C6A4A]/15 bg-white/55 px-3 py-2">
+      <p className="font-pixelJp text-[10px] font-bold text-[#8C6A4A]">{label}</p>
+      <p className={`mt-1 font-pixelJp font-bold text-[#4F3828] ${compact ? 'text-xs' : 'text-lg'}`}>{value}</p>
+    </div>
+  );
+}
+
+function AchievementBadge({ label, active }: { label: string; active: boolean }) {
+  return (
+    <span className={`rounded-full border px-3 py-1 font-pixelJp text-[10px] font-bold ${
+      active
+        ? 'border-[#B5483C]/30 bg-[#F8D9C4] text-[#B5483C]'
+        : 'border-[#8C6A4A]/20 bg-white/50 text-[#8C6A4A]'
+    }`}>
+      {label}
+    </span>
+  );
+}
+
+function PrefectureMiniCard({ prefecture }: { prefecture: PrefectureProgress }) {
+  return (
+    <div className="rounded-lg border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm">
+      <div className="mb-2 flex items-center justify-between">
+        <p className="font-pixelJp text-sm font-bold text-[#4F3828]">{prefecture.name}</p>
+        <p className="font-pixel text-sm text-[#B5483C]">{prefecture.visited}/{prefecture.total}</p>
+      </div>
+      <div className="h-2 overflow-hidden rounded-sm bg-[#E4D4B8]">
+        <div className="h-full bg-[#3F9D7D]" style={{ width: `${Math.min(prefecture.rate, 100)}%` }} />
+      </div>
+    </div>
+  );
+}
+
+function PrefectureProgressCard({ prefecture }: { prefecture: PrefectureProgress }) {
+  const complete = prefecture.total > 0 && prefecture.remaining === 0;
+
+  return (
+    <article className="rounded-lg border border-[#8C6A4A]/15 bg-[#FFF7E5] p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h2 className="font-pixelJp text-base font-bold text-[#4F3828]">{prefecture.name}</h2>
+          <p className="mt-1 font-pixelJp text-xs text-[#6A4D36]">
+            {complete ? '制覇済み' : `あと${prefecture.remaining}件`}
+          </p>
+        </div>
+        <div className={`rounded-md px-3 py-2 text-center ${complete ? 'bg-[#DFF1E9]' : 'bg-[#F8D9C4]'}`}>
+          <p className="font-pixel text-xl leading-none text-[#4F3828]">{prefecture.visited}/{prefecture.total}</p>
+          <p className="font-pixelJp text-[10px] font-bold text-[#6A4D36]">{prefecture.rate.toFixed(0)}%</p>
+        </div>
+      </div>
+      <div className="mt-4 h-3 overflow-hidden rounded-sm border border-[#8C6A4A]/15 bg-[#E4D4B8]">
+        <div
+          className={`h-full ${complete ? 'bg-[#3F9D7D]' : 'bg-[#D94D3F]'}`}
+          style={{ width: `${Math.min(prefecture.rate, 100)}%` }}
+        />
+      </div>
+      {complete && (
+        <div className="mt-3 flex items-center gap-2 rounded-md border border-[#3F9D7D]/25 bg-[#DFF1E9] px-3 py-2">
+          <CheckCircle2 className="h-4 w-4 text-[#2C765E]" />
+          <p className="font-pixelJp text-xs font-bold text-[#2C765E]">都道府県コンプリート</p>
+        </div>
+      )}
+    </article>
+  );
+}
+
+function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSummary }) {
+  const isVisited = Boolean(summary);
+
+  return (
+    <Link
+      href={`/manhole/${manhole.id}`}
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-lg border-2 p-3 shadow-sm transition-transform hover:-translate-y-0.5 ${
+        isVisited
+          ? 'border-[#B5483C]/45 bg-[#FFF7E5]'
+          : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]/75'
+      }`}
+    >
+      <div className="flex items-center justify-between">
+        <span className={`rounded-full px-2 py-1 font-pixelJp text-[10px] font-bold ${
+          isVisited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
+        }`}>
+          {isVisited ? '済' : '未訪問'}
+        </span>
+        <div className="flex items-center gap-1">
+          {summary?.hasPhotos && <Camera className="h-4 w-4 text-[#B5483C]" />}
+          {summary && summary.count > 1 && (
+            <span className="rounded-full bg-[#4F3828] px-1.5 py-0.5 font-pixel text-[10px] text-white">
+              x{summary.count}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center">
+        {isVisited ? (
+          <div className="relative h-24 w-24 overflow-hidden rounded-full border-4 border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
+            {summary?.latestVisit.photos[0]?.thumbnail_url ? (
+              <img
+                src={summary.latestVisit.photos[0].thumbnail_url}
+                alt=""
+                className="h-full w-full object-cover"
+                loading="lazy"
+                onError={(event) => {
+                  event.currentTarget.style.display = 'none';
+                }}
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle,#6F6658_0_18%,#B9AA91_19%_29%,#6F6658_30%_33%,#D7C9AF_34%_48%,#8B7D67_49%_52%,#CFC0A5_53%)]">
+                <CircleDot className="h-8 w-8 text-[#4F3828]/70" />
+              </div>
+            )}
+          </div>
+        ) : (
+          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
+            <div>
+              <Stamp className="mx-auto h-6 w-6" />
+              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div>
+        <p className="line-clamp-2 font-pixelJp text-sm font-bold leading-tight text-[#4F3828]">
+          {getMunicipality(manhole)}
+        </p>
+        <p className="mt-1 truncate font-pixelJp text-[11px] text-[#6A4D36]">{manhole.prefecture}</p>
+        {summary && (
+          <p className="mt-2 font-pixel text-xs text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function RecentVisitCard({
+  visit,
+  onDeleteClick,
+  onLikeToggle,
+  onBookmarkToggle,
+}: {
+  visit: Visit;
+  onDeleteClick: (photoId: string) => void;
+  onLikeToggle: (visitId: string) => void;
+  onBookmarkToggle: (visitId: string) => void;
+}) {
+  return (
+    <article className="rounded-lg border border-[#8C6A4A]/15 bg-[#FFF7E5] p-4 shadow-sm">
+      <div className="mb-3 flex items-center gap-3 border-b border-[#8C6A4A]/15 pb-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-md bg-[#F8D9C4]">
+          <MapPin className="h-5 w-5 text-[#B5483C]" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate font-pixelJp text-sm font-bold text-[#4F3828]">
+            {getManholeName(visit.manhole)}
+          </h3>
+          <p className="font-pixelJp text-xs text-[#6A4D36]">
+            {visit.manhole.prefecture} {getMunicipality(visit.manhole)}
+          </p>
+        </div>
+      </div>
+
+      {visit.photos.length > 0 ? (
+        <div className="mb-3 grid grid-cols-2 gap-1">
+          {visit.photos.slice(0, 4).map((photo, index) => (
+            <div key={photo.id} className="group relative aspect-square overflow-hidden rounded-md border border-[#8C6A4A]/15 bg-[#E9DEC9]">
+              <img
+                src={photo.thumbnail_url}
+                alt={`Photo ${index + 1}`}
+                className="h-full w-full object-cover"
+                onError={(event) => {
+                  event.currentTarget.style.display = 'none';
+                }}
+              />
+              {visit.photos.length > 4 && index === 3 && (
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/65">
+                  <span className="font-pixel text-xl text-white">+{visit.photos.length - 3}</span>
+                </div>
+              )}
+              <button
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onDeleteClick(photo.id);
+                }}
+                className="absolute right-2 top-2 z-20 rounded-md bg-[#B5483C] p-1.5 opacity-0 transition-opacity group-hover:opacity-100"
+                title="写真を削除"
+              >
+                <Trash2 className="h-3 w-3 text-white" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="mb-3 flex aspect-video items-center justify-center rounded-md border border-[#8C6A4A]/15 bg-[#E9DEC9]">
+          <Camera className="h-10 w-10 text-[#8C6A4A]/40" />
+        </div>
+      )}
+
+      <div className="mb-3 flex items-center gap-4 border-b border-[#8C6A4A]/15 pb-3">
+        <button onClick={() => onLikeToggle(visit.id)} className="flex items-center gap-1 hover:opacity-75">
+          <Heart className={`h-5 w-5 ${visit.is_liked ? 'fill-[#B5483C] text-[#B5483C]' : 'text-[#B5483C]'}`} />
+          {visit.likes_count > 0 && <span className="font-pixel text-xs text-[#4F3828]">{visit.likes_count}</span>}
+        </button>
+        <button onClick={() => onBookmarkToggle(visit.id)} className="hover:opacity-75">
+          <Bookmark className={`h-5 w-5 ${visit.is_bookmarked ? 'fill-[#DDA63A] text-[#DDA63A]' : 'text-[#DDA63A]'}`} />
+        </button>
+      </div>
+
+      <div className="space-y-2">
+        {visit.comment && <p className="font-pixelJp text-sm text-[#4F3828]">{visit.comment}</p>}
+        {visit.notes && (
+          <p className="font-pixelJp text-sm text-[#4F3828]">
+            <span className="font-bold">メモ:</span> {visit.notes}
+          </p>
+        )}
+        <div className="flex items-center gap-2 pt-1">
+          <Calendar className="h-4 w-4 text-[#8C6A4A]" />
+          <span className="font-pixelJp text-xs text-[#6A4D36]">
+            {formatVisitDate(visit.visited_at, 'yyyy/MM/dd HH:mm')}
+          </span>
+        </div>
+        <Link href={`/manhole/${visit.manhole.id}`} className="mt-2 inline-flex min-h-[38px] items-center rounded-md border border-[#8C6A4A]/25 bg-white px-4 font-pixelJp text-xs font-bold text-[#4F3828]">
+          詳細を見る
+        </Link>
+      </div>
+    </article>
+  );
+}
+
+function EmptyPassport() {
+  return (
+    <section className="rounded-lg border border-[#8C6A4A]/15 bg-[#FFF7E5] p-8 text-center shadow-sm">
+      <Stamp className="mx-auto mb-4 h-14 w-14 text-[#8C6A4A]/45" />
+      <h2 className="font-pixelJp text-lg font-bold text-[#4F3828]">まだスタンプがありません</h2>
+      <p className="mx-auto mt-3 max-w-sm font-pixelJp text-sm leading-6 text-[#6A4D36]">
+        最初のポケふたを記録すると、ここに旅の達成記録がたまっていきます。
+      </p>
+      <div className="mt-6 flex justify-center gap-2">
+        <Link href="/nearby" className="rounded-md bg-[#B5483C] px-4 py-3 font-pixelJp text-xs font-bold text-white">
+          近くを探す
+        </Link>
+      </div>
+    </section>
   );
 }

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -55,8 +55,6 @@ type PrefectureProgress = {
   rate: number;
 };
 
-const FALLBACK_TOTAL_MANHOLES = 470;
-
 const tabs: { id: PassportTab; label: string }[] = [
   { id: 'stamps', label: 'スタンプ帳' },
   { id: 'prefectures', label: '都道府県' },
@@ -76,11 +74,12 @@ const getMunicipality = (manhole: Manhole) => manhole.city || manhole.municipali
 export default function VisitsPage() {
   const [visits, setVisits] = useState<Visit[]>([]);
   const [manholes, setManholes] = useState<Manhole[]>([]);
-  const [totalManholes, setTotalManholes] = useState(FALLBACK_TOTAL_MANHOLES);
+  const [totalManholes, setTotalManholes] = useState<number | null>(null);
   const [activeTab, setActiveTab] = useState<PassportTab>('stamps');
   const [loading, setLoading] = useState(true);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [selectedPhotoId, setSelectedPhotoId] = useState<string | null>(null);
+  const [selectedVisitId, setSelectedVisitId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const { trackView } = useAnalytics();
 
@@ -149,7 +148,7 @@ export default function VisitsPage() {
           : [];
 
         setManholes(apiManholes);
-        setTotalManholes(data.total || apiManholes.length || FALLBACK_TOTAL_MANHOLES);
+        setTotalManholes(typeof data.total === 'number' ? data.total : apiManholes.length || null);
       }
     } catch (error) {
       console.error('Failed to load passport:', error);
@@ -182,7 +181,7 @@ export default function VisitsPage() {
   }, [sortedVisits]);
 
   const visitedManholesCount = visitSummaryByManholeId.size;
-  const completionRate = totalManholes > 0 ? (visitedManholesCount / totalManholes) * 100 : 0;
+  const completionRate = totalManholes ? (visitedManholesCount / totalManholes) * 100 : null;
 
   const visitedMunicipalityCount = useMemo(() => {
     return new Set(
@@ -262,17 +261,18 @@ export default function VisitsPage() {
   const unvisitedManholes = passportManholes.filter((manhole) => !visitSummaryByManholeId.has(manhole.id));
   const recentMilestone = Math.floor(visitedManholesCount / 10) * 10;
 
-  const handleDeleteClick = (photoId: string) => {
+  const handleDeleteClick = (photoId: string, visitId: string) => {
     setSelectedPhotoId(photoId);
+    setSelectedVisitId(visitId);
     setDeleteModalOpen(true);
   };
 
   const handleDeleteConfirm = async () => {
-    if (!selectedPhotoId) return;
+    if (!selectedPhotoId || !selectedVisitId) return;
 
     setIsDeleting(true);
     try {
-      const response = await fetch(`/api/photo/${selectedPhotoId}`, {
+      const response = await fetch(`/api/visits/${selectedVisitId}`, {
         method: 'DELETE',
       });
 
@@ -291,6 +291,7 @@ export default function VisitsPage() {
         setVisits(updatedVisits);
         setDeleteModalOpen(false);
         setSelectedPhotoId(null);
+        setSelectedVisitId(null);
         alert(data.visit_deleted ? '写真と訪問記録を削除しました' : '写真を削除しました');
       } else {
         console.error('Failed to delete photo:', data);
@@ -307,6 +308,7 @@ export default function VisitsPage() {
   const handleDeleteCancel = () => {
     setDeleteModalOpen(false);
     setSelectedPhotoId(null);
+    setSelectedVisitId(null);
   };
 
   const handleLikeToggle = async (visitId: string) => {
@@ -419,22 +421,24 @@ export default function VisitsPage() {
                 <div className="mb-2 flex items-end justify-between">
                   <div>
                     <p className="font-pixel text-2xl text-[#4F3828]">
-                      {visitedManholesCount} / {totalManholes}
+                      {visitedManholesCount} / {totalManholes ?? '集計中'}
                     </p>
                     <p className="font-pixelJp text-xs text-[#6A4D36]">訪問済みスタンプ</p>
                   </div>
-                  <p className="font-pixel text-xl text-[#B5483C]">{completionRate.toFixed(1)}%</p>
+                  <p className="font-pixel text-xl text-[#B5483C]">
+                    {completionRate === null ? '--%' : `${completionRate.toFixed(1)}%`}
+                  </p>
                 </div>
                 <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/25 bg-[#E4D4B8]">
                   <div
                     className="h-full rounded-sm bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D] transition-all"
-                    style={{ width: `${Math.min(completionRate, 100)}%` }}
+                    style={{ width: `${Math.min(completionRate ?? 0, 100)}%` }}
                   />
                 </div>
               </div>
 
               <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-                <SummaryStat label="達成率" value={`${completionRate.toFixed(1)}%`} />
+                <SummaryStat label="達成率" value={completionRate === null ? '--%' : `${completionRate.toFixed(1)}%`} />
                 <SummaryStat label="訪問自治体" value={`${visitedMunicipalityCount}`} />
                 <SummaryStat label="写真つき" value={`${visits.filter((visit) => visit.photos.length > 0).length}`} />
                 <SummaryStat
@@ -708,7 +712,7 @@ function RecentVisitCard({
   onBookmarkToggle,
 }: {
   visit: Visit;
-  onDeleteClick: (photoId: string) => void;
+  onDeleteClick: (photoId: string, visitId: string) => void;
   onLikeToggle: (visitId: string) => void;
   onBookmarkToggle: (visitId: string) => void;
 }) {
@@ -748,7 +752,7 @@ function RecentVisitCard({
               <button
                 onClick={(event) => {
                   event.stopPropagation();
-                  onDeleteClick(photo.id);
+                  onDeleteClick(photo.id, visit.id);
                 }}
                 className="absolute right-2 top-2 z-20 rounded-md bg-[#B5483C] p-1.5 opacity-0 transition-opacity group-hover:opacity-100"
                 title="写真を削除"

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { Camera, Image, Menu, Search } from 'lucide-react';
+import { Camera, CircleDot, Home, Image, Menu, Search } from 'lucide-react';
 import MobileMenuDrawer from '@/components/MobileMenuDrawer';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
@@ -44,13 +44,18 @@ export default function BottomNav() {
   }, []);
 
   const items = useMemo(
-    () => [
-      { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
-      { href: '/', label: '写真館', icon: <Image className="w-6 h-6 mb-1" /> },
-      isLoggedIn
-        ? { href: '/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> }
-        : { href: '/login?redirect=/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
-    ],
+    () => isLoggedIn
+      ? [
+          { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
+          { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
+          { href: '/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
+          { href: '/', label: 'マイ旅', icon: <Home className="w-6 h-6 mb-1" /> },
+        ]
+      : [
+          { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
+          { href: '/', label: '写真館', icon: <Image className="w-6 h-6 mb-1" /> },
+          { href: '/login?redirect=/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
+        ],
     [isLoggedIn]
   );
 

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -53,6 +53,7 @@ export default function BottomNav() {
         ]
       : [
           { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
+          { href: '/login?redirect=/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
           { href: '/', label: '写真館', icon: <Image className="w-6 h-6 mb-1" /> },
           { href: '/login?redirect=/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
         ],

--- a/src/components/DeletePhotoModal.tsx
+++ b/src/components/DeletePhotoModal.tsx
@@ -46,12 +46,12 @@ export default function DeletePhotoModal({
         {/* Content */}
         <div className="space-y-4">
           <p className="font-pixelJp text-sm text-rpg-textDark">
-            この写真を削除してもよろしいですか？
+            この写真と訪問記録を削除してもよろしいですか？
           </p>
 
           <div className="bg-rpg-red bg-opacity-10 border-2 border-rpg-red p-3">
             <p className="font-pixelJp text-xs text-rpg-textDark">
-              <span className="font-bold text-rpg-red">注意:</span> この操作は取り消せません。写真ファイルとデータベースから完全に削除されます。
+              <span className="font-bold text-rpg-red">注意:</span> この操作は取り消せません。同じ訪問記録に紐づく写真、コメント、いいね、ブックマークも削除されます。
             </p>
           </div>
 


### PR DESCRIPTION
## Summary
- Rework logged-in home around personal journey progress, next unvisited candidates, and collection-style stamp cards.
- Rebuild `/visits` as a passport-style stamp rally with progress gauges, prefecture progress, visited/unvisited tabs, and fixed CTAs.
- Update bottom navigation for logged-in users and make photo deletion remove the linked visit record as well.

## Verification
- `npm run type-check`
- `npm run build`

## Notes
- Existing Next.js dynamic API warnings appear during build for cookie/request-url routes, but the build completes successfully.
- `.DS_Store` was left untracked.