### PR TITLE
Add Google sitemap and robots.txt for SEO

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,9 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 # 本番環境
 # NEXT_PUBLIC_APP_URL=https://pokefuta.com
 
+# Sitemap用のベースURL（本番環境では必ず設定）
+NEXT_PUBLIC_SITE_URL=https://pokefuta.com
+
 NODE_ENV=development
 
 # ==========================================

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,20 @@
+import { MetadataRoute } from 'next';
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pokefuta.example.com';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',           // APIエンドポイント
+          '/upload',         // アップロードページ（認証が必要）
+          '/visits',         // 個人の訪問記録（認証が必要）
+        ],
+      },
+    ],
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,103 @@
+import { MetadataRoute } from 'next';
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database';
+
+const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pokefuta.example.com';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  // 静的ページ
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/map`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/manholes`,
+      lastModified: new Date(),
+      changeFrequency: 'daily',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/nearby`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/signup`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.5,
+    },
+    {
+      url: `${baseUrl}/upload`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/visits`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly',
+      priority: 0.7,
+    },
+    {
+      url: `${baseUrl}/api-docs`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly',
+      priority: 0.4,
+    },
+  ];
+
+  // 動的ページ（マンホール詳細ページ）
+  let dynamicPages: MetadataRoute.Sitemap = [];
+
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (supabaseUrl && supabaseKey && !supabaseUrl.includes('dummy')) {
+      const supabase = createClient<Database>(supabaseUrl, supabaseKey);
+
+      // 全マンホールのIDと更新日時を取得
+      const { data: manholes } = await supabase
+        .from('manhole')
+        .select('id, updated_at, created_at')
+        .order('id', { ascending: true });
+
+      if (manholes && manholes.length > 0) {
+        dynamicPages = manholes.map((manhole) => ({
+          url: `${baseUrl}/manhole/${manhole.id}`,
+          lastModified: new Date(manhole.updated_at || manhole.created_at),
+          changeFrequency: 'weekly' as const,
+          priority: 0.8,
+        }));
+      }
+    }
+  } catch (error) {
+    console.error('Error fetching manholes for sitemap:', error);
+    // エラーが発生しても静的ページのサイトマップは返す
+  }
+
+  return [...staticPages, ...dynamicPages];
+}


### PR DESCRIPTION
## Summary
- Add dynamic sitemap generation for all pages including manhole details
- Configure robots.txt to guide search engine crawlers
- Improve SEO by making all public pages discoverable by Google

## Changes
- **src/app/sitemap.ts**: Dynamic XML sitemap generator
  - Includes all static pages (home, map, manholes list, etc.)
  - Fetches all manhole IDs from Supabase and includes detail pages
  - Sets appropriate priority and change frequency for each page type
- **src/app/robots.ts**: robots.txt configuration
  - Allows crawling of public pages
  - Blocks private/authenticated pages (/upload, /visits, /api/)
  - References sitemap location
- **.env.example**: Added `NEXT_PUBLIC_SITE_URL` configuration

## Test plan
- [ ] Build and run locally to verify no TypeScript errors
- [ ] Access `/sitemap.xml` and verify all pages are listed
- [ ] Access `/robots.txt` and verify configuration
- [ ] Set `NEXT_PUBLIC_SITE_URL` in production environment variables
- [ ] Submit sitemap to Google Search Console after deployment

## Notes
- Sitemap is dynamically generated on each request/build
- Automatically updates when new manholes are added to the database
- Requires `NEXT_PUBLIC_SITE_URL` environment variable in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)