### PR TITLE
ナビゲーション整理（優先度S）- Bottom Navとメニューの重複削除

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
-import { Camera, CircleDot, Home, Image, Menu, Search } from 'lucide-react';
+import { CircleDot, Home, Menu, Search } from 'lucide-react';
 import MobileMenuDrawer from '@/components/MobileMenuDrawer';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
@@ -48,14 +48,12 @@ export default function BottomNav() {
       ? [
           { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
           { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
-          { href: '/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
           { href: '/', label: 'マイ旅', icon: <Home className="w-6 h-6 mb-1" /> },
         ]
       : [
           { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
           { href: '/login?redirect=/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
-          { href: '/', label: '写真館', icon: <Image className="w-6 h-6 mb-1" /> },
-          { href: '/login?redirect=/upload', label: '投稿', icon: <Camera className="w-6 h-6 mb-1" /> },
+          { href: '/', label: 'マイ旅', icon: <Home className="w-6 h-6 mb-1" /> },
         ],
     [isLoggedIn]
   );

--- a/src/components/MobileMenuDrawer.tsx
+++ b/src/components/MobileMenuDrawer.tsx
@@ -4,10 +4,6 @@ import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
   Home,
-  List,
-  Navigation,
-  Camera,
-  History,
   Info,
   LogOut,
   User as UserIcon,
@@ -78,25 +74,6 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
     icon: React.ReactNode;
   }> = [
     { href: '/', label: 'ホーム', description: '最近の投稿や入口', icon: <Home className="w-5 h-5" /> },
-    {
-      href: '/manholes',
-      label: 'マンホール一覧',
-      description: 'ポケふたを検索/一覧で見る',
-      icon: <List className="w-5 h-5" />,
-    },
-    {
-      href: '/nearby',
-      label: '近くの未訪問',
-      description: '今いる場所の近くを探す',
-      icon: <Navigation className="w-5 h-5" />,
-    },
-    {
-      href: user ? '/upload' : '/login?redirect=/upload',
-      label: '写真を登録',
-      description: user ? '訪問写真を追加する' : 'ログインして訪問写真を追加する',
-      icon: <Camera className="w-5 h-5" />,
-    },
-    { href: '/visits', label: '訪問履歴', description: '自分の訪問記録を見る', icon: <History className="w-5 h-5" /> },
     { href: '/about', label: 'このアプリについて', description: '使い方/注意事項', icon: <Info className="w-5 h-5" /> },
   ];
 


### PR DESCRIPTION
## 概要
pokefuta.comのナビゲーション構造を整理し、ユーザー行動単位での導線に再編成しました。
優先度Sの変更として、Bottom Navとメニューの重複導線を削除しました。

## 変更内容

### 1. Bottom Navigation の簡素化
**変更前（5項目）:**
- ログイン時: 探す / スタンプ帳 / 投稿 / マイ旅 / メニュー
- 未ログイン時: 探す / スタンプ帳 / 写真館 / 投稿 / メニュー

**変更後（4項目）:**
- 共通: 探す / スタンプ帳 / マイ旅 / メニュー

### 2. メニューの整理
**削除した項目（主要導線）:**
- ❌ マンホール一覧 → 今後「探す」タブへ統合予定
- ❌ 近くの未訪問 → 今後「探す」タブへ統合予定
- ❌ 写真を登録 → 今後FAB「訪問を記録」へ移行予定
- ❌ 訪問履歴 → 今後「マイ旅」タブへ統合予定

**保持した項目（補助導線）:**
- ✅ ホーム
- ✅ このアプリについて
- ✅ ログアウト（ログイン時のみ）

## 設計思想
1. **機能単位ではなく、ユーザー行動単位で整理**
2. **Bottom Navは迷わず使える最小構成に**
3. **メニューには補助導線のみを配置**
4. **重複導線を削除してUX向上**

## 技術的変更
- [BottomNav.tsx](src/components/BottomNav.tsx): 投稿タブを削除、未使用importを削除
- [MobileMenuDrawer.tsx](src/components/MobileMenuDrawer.tsx): 重複メニュー項目を削除、未使用importを削除

## 受け入れ条件
- ✅ Bottom Nav上に「投稿」が表示されない
- ✅ メニュー内に「マンホール一覧」「近くの未訪問」「写真を登録」「訪問履歴」が重複して存在しない
- ✅ ビルドが成功する（確認済み）

## 今後の予定（優先度A・B）
- [ ] FAB「訪問を記録」を主要画面に追加
- [ ] 探すタブ内に「近く / 地図 / 一覧 / 未訪問」の切り替えを実装
- [ ] マイ旅内に訪問履歴を統合
- [ ] スタンプ帳とマイ旅の役割を明確に分離

🤖 Generated with [Claude Code](https://claude.com/claude-code)