### PR TITLE
未ログイン時UI改善 - Discovery Mode強化

### DIFF
--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -730,7 +730,7 @@ export default function ManholeDetailPage() {
                   </button>
                 </div>
               ) : (
-                // Unvisited: Directions + Record visit + Share
+                // Unvisited: Directions + Record visit/Login CTA + Share
                 <div className="grid grid-cols-3 gap-2">
                   <button
                     onClick={openInMaps}
@@ -739,13 +739,23 @@ export default function ManholeDetailPage() {
                     <Navigation className="w-4 h-4" />
                     <span className="font-pixelJp text-xs">経路案内</span>
                   </button>
-                  <button
-                    onClick={() => router.push(currentUserId ? '/upload' : '/login?redirect=/upload')}
-                    className="rpg-button rpg-button-primary flex items-center justify-center gap-1 px-2"
-                  >
-                    <Camera className="w-4 h-4" />
-                    <span className="font-pixelJp text-xs">訪問記録</span>
-                  </button>
+                  {currentUserId ? (
+                    <button
+                      onClick={() => router.push('/upload')}
+                      className="rpg-button rpg-button-primary flex items-center justify-center gap-1 px-2"
+                    >
+                      <Camera className="w-4 h-4" />
+                      <span className="font-pixelJp text-xs">訪問記録</span>
+                    </button>
+                  ) : (
+                    <button
+                      onClick={() => router.push('/login?redirect=/upload')}
+                      className="rpg-button flex items-center justify-center gap-1 px-2 bg-white/70 border border-[#7B63A8] hover:bg-[#7B63A8]/5"
+                    >
+                      <Camera className="w-4 h-4 text-[#7B63A8]" />
+                      <span className="font-pixelJp text-xs text-[#7B63A8]">ログインして記録</span>
+                    </button>
+                  )}
                   <button
                     onClick={handleShare}
                     className="rpg-button flex items-center justify-center gap-1 px-2 bg-white/70 border border-[#8C6A4A]/25 hover:bg-[#8C6A4A]/10"

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -53,7 +53,7 @@ export default function BottomNav() {
       : [
           { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
           { href: '/popular', label: '人気', icon: <TrendingUp className="w-6 h-6 mb-1" /> },
-          { href: '/login?redirect=/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
+          { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
         ],
     [isLoggedIn]
   );

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -19,8 +19,9 @@ export async function middleware(req: NextRequest) {
     } = await supabase.auth.getSession();
 
     // 認証が必要なページへのアクセス
-    // upload, visits ページは認証必須
-    const protectedPaths = ['/upload', '/visits'];
+    // upload ページは認証必須
+    // visits ページはプレビューモードがあるため未認証でもアクセス可能
+    const protectedPaths = ['/upload'];
     const isProtectedPath = protectedPaths.some(path => req.nextUrl.pathname.startsWith(path));
 
     if (!session && isProtectedPath) {
@@ -37,5 +38,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/upload/:path*', '/visits/:path*', '/api/:path*'],
+  matcher: ['/upload/:path*', '/api/:path*'],
 };


### PR DESCRIPTION
## 概要

未ログイン時のユーザー体験を改善し、いきなりログインフォームを見せるのではなく、アプリの価値を先に見せる「Discovery Mode」を強化しました。

## 背景・課題

未ログインユーザーが以下の問題に直面していました：

1. **スタンプ帳タブ**: タップすると即座にログインフォームが表示され、機能の価値が伝わらない
2. **マンホール詳細ページ**: 未訪問時の「訪問記録」ボタンがログイン誘導として機能していない

## 主な変更内容

### 1️⃣ スタンプ帳タブのプレビューモード表示

**修正前:**
- Bottom Navigation の未ログインリンク: `/login?redirect=/visits`
- ミドルウェアで `/visits` が保護パスに指定
- 結果: いきなりログインフォームが表示

**修正後:**
- Bottom Navigation の未ログインリンク: `/visits`
- ミドルウェアから `/visits` を保護パスから除外
- 結果: プレビューモード表示
  - ✨ 「スタンプ機能のプレビュー」バッジ
  - 📊 進捗バー（0/470、0.0%）
  - 📝 4つの機能紹介（訪問記録保存、写真投稿、都道府県別進捗、全国制覇）
  - 🗺️ 全国470箇所のコレクション紹介
  - 🎯 複数のCTA（「無料でスタンプ帳をはじめる」「ログイン」）

**変更ファイル:**
- `src/components/BottomNav.tsx` (L56)
- `src/middleware.ts` (L24, L41)

### 2️⃣ 詳細ページの「訪問記録」ボタン改善

**修正前:**
- 未ログイン時も「訪問記録」（紫背景）が表示
- ログイン誘導として不明確

**修正後:**
- **未ログイン時**: 「ログインして記録」（白背景・紫枠・紫アイコン）
- **ログイン済み時**: 「訪問記録」（紫背景）
- スタイルとラベルで明確に差別化

**変更ファイル:**
- `src/app/manhole/[id]/page.tsx` (L742-758)

## 設計思想

### 🔍 Discovery Mode
未ログイン時は「管理」より「発見・探索」を優先。他ユーザーの写真や人気スポットを見せることで、自然に「自分も記録したい」と思わせる。

### 👀 Show, Don't Tell
登録を促す前に、実際の機能プレビューや写真を見せる。価値を理解してからの登録を促進。

### 🎯 Natural CTAs
ログイン誘導は強制せず、ユーザーが価値を理解したタイミングで表示。複数のCTA配置で選択肢を提供。

## スクリーンショット

### スタンプ帳タブ

<table>
<tr>
<th>修正前</th>
<th>修正後</th>
</tr>
<tr>
<td>

**いきなりログインフォーム**
- 価値提案なし
- なぜログインすべきか不明

</td>
<td>

**プレビューモード**
- 470箇所のコレクション紹介
- 4つの機能説明
- サンプル表示
- 明確なCTA配置

</td>
</tr>
</table>

### マンホール詳細ページ（未訪問時）

<table>
<tr>
<th>修正前</th>
<th>修正後</th>
</tr>
<tr>
<td>

**「訪問記録」ボタン**
- 紫背景
- 通常アクションに見える

</td>
<td>

**「ログインして記録」ボタン**
- 白背景・紫枠
- ログイン誘導として明確

</td>
</tr>
</table>

## テスト内容

スクリーンキャプチャツールで修正前後を比較検証:

```bash
npm run capture
```

**検証項目:**
- ✅ 未ログイン詳細ページに「ログインして記録」CTAが表示
- ✅ スタンプ帳タブでプレビュー画面が表示（ログインフォーム非表示）
- ✅ プレビュー画面に470箇所の情報、4つの機能、CTAが表示
- ✅ ログイン後は従来通りの動作を維持
- ✅ ビルドエラーなし

**スクリーンショット比較:**
- 修正前: `tools/capture/output/2026-05-16_22-47-47/`
- 修正後: `tools/capture/output/2026-05-16_23-41-34/`

## 影響範囲

### 破壊的変更
なし

### 既存機能への影響
- **未ログインユーザー**: スタンプ帳タブで価値提案を先に見られるように改善
- **ログイン済みユーザー**: 影響なし（従来通りの動作）

### パフォーマンス
- `/visits` ページの初回読み込み時にマンホールデータ取得（1000件制限）
- 既存のプレビューモード実装を活用（新規コード追加なし）

## チェックリスト

- [x] コードレビュー依頼前にセルフレビュー完了
- [x] TypeScriptのビルドエラーなし
- [x] 既存機能への影響を確認（ログイン済みユーザーは影響なし）
- [x] 未ログイン・ログイン両方の動作確認（スクリーンキャプチャで検証）
- [x] モバイル表示を考慮
- [x] アクセシビリティを考慮

## 関連Issue

指示書「未ログイン時UIレビュー追加修正」に基づく実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>