### PR TITLE
GA4イベント設計実装 - p_ prefix統一で22イベントを導入

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -22,7 +22,7 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
 
   const supabase = createBrowserClient();
-  const { trackSignIn, setUser, trackAuthError } = useAnalytics();
+  const { trackLoginStart, trackLoginSuccess, setUser, trackAuthError, updateUserProperties } = useAnalytics();
 
   // ページタイトル設定
   useEffect(() => {
@@ -35,6 +35,7 @@ function LoginForm() {
     setError(null);
 
     console.log('🔐 ログイン試行開始:', { email, redirectTo });
+    trackLoginStart();
 
     try {
       const { data, error } = await supabase.auth.signInWithPassword({
@@ -66,12 +67,11 @@ function LoginForm() {
           redirectTo,
         });
 
-        // ✅ GA: ユーザーID設定（ユーザーIDが取得できた時のみ）
         if (data.user?.id) {
           setUser(data.user.id);
         }
-        // ✅ GA: ログインイベント追跡
-        trackSignIn();
+        trackLoginSuccess();
+        updateUserProperties({ registered_user: true });
 
         // app_userレコードの存在確認
         const { data: appUser, error: appUserError } = await supabase

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -12,6 +12,7 @@ import { Manhole } from '@/types/database';
 import DeletePhotoModal from '@/components/DeletePhotoModal';
 import BottomNav from '@/components/BottomNav';
 import { formatDateJa } from '@/lib/date';
+import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 const MapComponent = dynamic(
   () => import('@/components/Map/MapComponent'),
@@ -92,6 +93,16 @@ export default function ManholeDetailPage() {
   const [newManholeComment, setNewManholeComment] = useState('');
   const [showDetails, setShowDetails] = useState(false);
 
+  const {
+    trackManholeDetailOpen,
+    trackRouteOpen,
+    trackVisitDelete,
+    trackShareClick,
+    trackShareX,
+    trackShareLine,
+    trackCopyLink,
+  } = useAnalytics();
+
   useEffect(() => {
     const manholeId = params.id;
     if (manholeId) {
@@ -101,6 +112,17 @@ export default function ManholeDetailPage() {
       loadCurrentUser();
     }
   }, [params.id]);
+
+  // マンホール詳細閲覧トラッキング
+  useEffect(() => {
+    if (manhole) {
+      trackManholeDetailOpen({
+        manhole_id: manhole.id,
+        prefecture: manhole.prefecture,
+        pokemon_ids: manhole.pokemons?.join(','),
+      });
+    }
+  }, [manhole?.id]);
 
   // Update document title and meta tags
   useEffect(() => {
@@ -362,6 +384,7 @@ export default function ManholeDetailPage() {
 
   const openInMaps = () => {
     if (manhole && manhole.latitude && manhole.longitude) {
+      trackRouteOpen({ manhole_id: manhole.id, prefecture: manhole.prefecture });
       const url = `https://www.google.com/maps/dir/?api=1&destination=${manhole.latitude},${manhole.longitude}`;
       window.open(url, '_blank');
     }
@@ -385,6 +408,7 @@ export default function ManholeDetailPage() {
       const data = await response.json();
 
       if (response.ok && data.success) {
+        trackVisitDelete({ manhole_id: manhole?.id });
         // 成功: 写真リストから削除
         const deletedPhotoIds = new Set<string>(data.photo_ids || [selectedPhotoId]);
         const updatedPhotos = photos.filter(p => !deletedPhotoIds.has(p.id));
@@ -431,35 +455,83 @@ export default function ManholeDetailPage() {
       ? `${manhole.prefecture}${municipality}のポケふたを見つけました！\n${pokemonList}が描かれたポケモンマンホールです。`
       : `${manhole.prefecture}${municipality}のポケふたを見つけました！`;
     const shareUrl = `https://pokefuta.com/manhole/${manhole.id}`;
+    const trackParams = { manhole_id: manhole.id, prefecture: manhole.prefecture };
+
+    trackShareClick(trackParams);
 
     try {
       if (navigator.share) {
-        // Web Share API available
-        await navigator.share({
-          title: shareTitle,
-          text: shareText,
-          url: shareUrl
-        });
+        await navigator.share({ title: shareTitle, text: shareText, url: shareUrl });
       } else {
-        // Fallback to clipboard
-        await navigator.clipboard.writeText(shareUrl);
-        // Show toast notification
-        const toast = document.createElement('div');
-        toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white px-4 py-3 rounded-lg shadow-lg font-pixelJp text-sm z-50 animate-fade-in';
-        toast.textContent = 'リンクをコピーしました';
-        document.body.appendChild(toast);
-        setTimeout(() => {
-          toast.classList.add('animate-fade-out');
-          setTimeout(() => document.body.removeChild(toast), 300);
-        }, 2000);
+        // デスクトップ: X / LINE / コピーの選択パネルを表示
+        showSharePanel(shareText, shareUrl, trackParams);
       }
     } catch (error) {
-      // User cancelled share or error occurred
-      // Don't show error for user cancellation
       if (error instanceof Error && error.name !== 'AbortError') {
         console.error('Share failed:', error);
       }
     }
+  };
+
+  const showSharePanel = (
+    shareText: string,
+    shareUrl: string,
+    trackParams: { manhole_id: number | string; prefecture?: string }
+  ) => {
+    // 既存パネルがあれば削除
+    const existing = document.getElementById('pokefuta-share-panel');
+    if (existing) existing.remove();
+
+    const panel = document.createElement('div');
+    panel.id = 'pokefuta-share-panel';
+    panel.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white rounded-lg shadow-xl font-pixelJp text-sm z-50 p-4 flex flex-col gap-2 min-w-[200px]';
+
+    const title = document.createElement('p');
+    title.className = 'text-xs text-center opacity-70 mb-1';
+    title.textContent = '共有する';
+    panel.appendChild(title);
+
+    const makeBtn = (label: string, onClick: () => void) => {
+      const btn = document.createElement('button');
+      btn.className = 'w-full text-left px-3 py-2 rounded bg-white/10 hover:bg-white/20 transition-colors text-sm';
+      btn.textContent = label;
+      btn.addEventListener('click', () => { onClick(); panel.remove(); });
+      return btn;
+    };
+
+    const xText = `${shareText}\n${shareUrl}`;
+    panel.appendChild(makeBtn('X でシェア', () => {
+      trackShareX(trackParams);
+      window.open(`https://twitter.com/intent/tweet?text=${encodeURIComponent(xText)}`, '_blank');
+    }));
+
+    panel.appendChild(makeBtn('LINE でシェア', () => {
+      trackShareLine(trackParams);
+      window.open(`https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(shareUrl)}`, '_blank');
+    }));
+
+    panel.appendChild(makeBtn('リンクをコピー', async () => {
+      await navigator.clipboard.writeText(shareUrl);
+      trackCopyLink(trackParams);
+      const toast = document.createElement('div');
+      toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white px-4 py-3 rounded-lg shadow-lg font-pixelJp text-sm z-50';
+      toast.textContent = 'リンクをコピーしました';
+      document.body.appendChild(toast);
+      setTimeout(() => document.body.removeChild(toast), 2000);
+    }));
+
+    document.body.appendChild(panel);
+
+    // パネル外クリックで閉じる
+    setTimeout(() => {
+      const closePanel = (e: MouseEvent) => {
+        if (!panel.contains(e.target as Node)) {
+          panel.remove();
+          document.removeEventListener('click', closePanel);
+        }
+      };
+      document.addEventListener('click', closePanel);
+    }, 0);
   };
 
   const handleReaction = async (photo: Photo, reactionType: 'like' | 'bookmark') => {

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -1,7 +1,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { MapPin, ArrowLeft, Camera, Navigation, Clock, Trash2, Heart, Bookmark, User as UserIcon, Stamp, CircleDot, CheckCircle2, ChevronDown, Share2 } from 'lucide-react';
@@ -102,6 +102,14 @@ export default function ManholeDetailPage() {
     trackShareLine,
     trackCopyLink,
   } = useAnalytics();
+
+  // 共有パネルのクリーンアップ（コンポーネントアンマウント時）
+  const sharePanelCleanupRef = useRef<(() => void) | null>(null);
+  useEffect(() => {
+    return () => {
+      sharePanelCleanupRef.current?.();
+    };
+  }, []);
 
   useEffect(() => {
     const manholeId = params.id;
@@ -478,24 +486,26 @@ export default function ManholeDetailPage() {
     shareUrl: string,
     trackParams: { manhole_id: number | string; prefecture?: string }
   ) => {
-    // 既存パネルがあれば削除
-    const existing = document.getElementById('pokefuta-share-panel');
-    if (existing) existing.remove();
+    // 既存パネルがあればクリーンアップ
+    sharePanelCleanupRef.current?.();
 
     const panel = document.createElement('div');
     panel.id = 'pokefuta-share-panel';
     panel.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white rounded-lg shadow-xl font-pixelJp text-sm z-50 p-4 flex flex-col gap-2 min-w-[200px]';
 
-    const title = document.createElement('p');
-    title.className = 'text-xs text-center opacity-70 mb-1';
-    title.textContent = '共有する';
-    panel.appendChild(title);
+    const titleEl = document.createElement('p');
+    titleEl.className = 'text-xs text-center opacity-70 mb-1';
+    titleEl.textContent = '共有する';
+    panel.appendChild(titleEl);
+
+    // cleanup を先に宣言し、各ボタンから参照させる
+    let cleanup: () => void;
 
     const makeBtn = (label: string, onClick: () => void) => {
       const btn = document.createElement('button');
       btn.className = 'w-full text-left px-3 py-2 rounded bg-white/10 hover:bg-white/20 transition-colors text-sm';
       btn.textContent = label;
-      btn.addEventListener('click', () => { onClick(); panel.remove(); });
+      btn.addEventListener('click', () => { onClick(); cleanup(); });
       return btn;
     };
 
@@ -522,16 +532,21 @@ export default function ManholeDetailPage() {
 
     document.body.appendChild(panel);
 
-    // パネル外クリックで閉じる
-    setTimeout(() => {
-      const closePanel = (e: MouseEvent) => {
-        if (!panel.contains(e.target as Node)) {
-          panel.remove();
-          document.removeEventListener('click', closePanel);
-        }
-      };
-      document.addEventListener('click', closePanel);
-    }, 0);
+    const closeOnOutside = (e: MouseEvent) => {
+      if (!panel.contains(e.target as Node)) cleanup();
+    };
+
+    cleanup = () => {
+      panel.remove();
+      document.removeEventListener('click', closeOnOutside);
+      sharePanelCleanupRef.current = null;
+    };
+
+    // アンマウント時用にrefへ登録
+    sharePanelCleanupRef.current = cleanup;
+
+    // トリガーとなったクリックイベントを捕捉しないよう次のticksで登録
+    setTimeout(() => document.addEventListener('click', closeOnOutside), 0);
   };
 
   const handleReaction = async (photo: Photo, reactionType: 'like' | 'bookmark') => {

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -521,13 +521,21 @@ export default function ManholeDetailPage() {
     }));
 
     panel.appendChild(makeBtn('リンクをコピー', async () => {
-      await navigator.clipboard.writeText(shareUrl);
-      trackCopyLink(trackParams);
-      const toast = document.createElement('div');
-      toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white px-4 py-3 rounded-lg shadow-lg font-pixelJp text-sm z-50';
-      toast.textContent = 'リンクをコピーしました';
-      document.body.appendChild(toast);
-      setTimeout(() => document.body.removeChild(toast), 2000);
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        trackCopyLink(trackParams);
+        const toast = document.createElement('div');
+        toast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-[#4F3828] text-white px-4 py-3 rounded-lg shadow-lg font-pixelJp text-sm z-50';
+        toast.textContent = 'リンクをコピーしました';
+        document.body.appendChild(toast);
+        setTimeout(() => document.body.removeChild(toast), 2000);
+      } catch {
+        const errToast = document.createElement('div');
+        errToast.className = 'fixed bottom-24 left-1/2 -translate-x-1/2 bg-rpg-red text-white px-4 py-3 rounded-lg shadow-lg font-pixelJp text-sm z-50';
+        errToast.textContent = 'コピーに失敗しました';
+        document.body.appendChild(errToast);
+        setTimeout(() => document.body.removeChild(errToast), 2000);
+      }
     }));
 
     document.body.appendChild(panel);

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Camera, MapPin, Search } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import { createBrowserClient } from '@/lib/supabase/client';
+import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 export default function ManholesPage() {
   const [manholes, setManholes] = useState<Manhole[]>([]);
   const [loading, setLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [query, setQuery] = useState('');
+  const { trackPrefectureOpen } = useAnalytics();
+  const lastTrackedPrefecture = useRef<string | null>(null);
 
   useEffect(() => {
     document.title = 'ポケふた一覧 - ポケふた訪問記録';
@@ -63,6 +66,19 @@ export default function ManholesPage() {
       return target.includes(normalized);
     });
   }, [manholes, query]);
+
+  // クエリが都道府県に絞り込まれた場合にトラッキング
+  useEffect(() => {
+    if (filteredManholes.length === 0 || !query.trim()) return;
+    const prefectures = new Set(filteredManholes.map((m) => m.prefecture).filter(Boolean));
+    if (prefectures.size === 1) {
+      const prefecture = [...prefectures][0] as string;
+      if (prefecture !== lastTrackedPrefecture.current) {
+        lastTrackedPrefecture.current = prefecture;
+        trackPrefectureOpen({ prefecture });
+      }
+    }
+  }, [filteredManholes, query]);
 
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
   const prefectureCount = new Set(manholes.map((manhole) => manhole.prefecture).filter(Boolean)).size;

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -53,9 +53,13 @@ export default function NearbyPage() {
   const { trackSearch, trackNearbyOpen, trackGeolocationEnable } = useAnalytics();
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
 
+  // ページ初回マウント時のみ発火
+  useEffect(() => {
+    trackNearbyOpen();
+  }, []);
+
   useEffect(() => {
     document.title = '近くのポケふた - ポケふた訪問記録';
-    trackNearbyOpen();
     (async () => {
       try {
         const supabase = createBrowserClient();

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -50,11 +50,12 @@ export default function NearbyPage() {
   const [radius, setRadius] = useState(30);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [activeTab, setActiveTab] = useState<SearchTab>('nearby');
-  const { trackSearch } = useAnalytics();
+  const { trackSearch, trackNearbyOpen, trackGeolocationEnable } = useAnalytics();
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
 
   useEffect(() => {
     document.title = '近くのポケふた - ポケふた訪問記録';
+    trackNearbyOpen();
     (async () => {
       try {
         const supabase = createBrowserClient();
@@ -120,6 +121,7 @@ export default function NearbyPage() {
       setLoading(true);
       navigator.geolocation.getCurrentPosition(
         (position) => {
+          trackGeolocationEnable();
           const location = {
             lat: position.coords.latitude,
             lng: position.coords.longitude

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -106,16 +106,12 @@ export default function HomePage() {
   const [activeTab, setActiveTab] = useState<GalleryTab>('latest');
   const [journeyTab, setJourneyTab] = useState<JourneyTab>('unvisited');
   const feedPerPage = 24;
-  const { trackView } = useAnalytics();
+  const { trackView, trackCollectionOpen, updateUserProperties } = useAnalytics();
 
   useEffect(() => {
-    // ページタイトル設定
     document.title = 'ポケふた写真館 - ポケふた訪問記録';
-
-    // ✅ GA: ページビュー追跡
     trackView('/', 'ホーム', 'home');
 
-    // ログイン状態はSupabase sessionで判定（APIは常に公開フィードを使う）
     (async () => {
       try {
         const supabase = createBrowserClient();
@@ -124,13 +120,13 @@ export default function HomePage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
+        trackCollectionOpen({ is_logged_in: loggedIn });
         if (loggedIn) {
           setUserName(getDisplayName(session));
-          // ログイン済みユーザーの場合、loadingをfalseに設定
+          updateUserProperties({ registered_user: true });
           setLoading(false);
           loadJourney();
         }
-        // 未ログインユーザーの場合はloadFeed()でloadingがfalseになる
       } catch (error) {
         console.error('Session check error:', error);
         setIsLoggedIn(false);

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -21,7 +21,7 @@ export default function SignUpPage() {
   const [success, setSuccess] = useState(false);
 
   const supabase = createBrowserClient();
-  const { trackSignUp, trackAuthError, setUser } = useAnalytics();
+  const { trackSignupStart, trackSignupComplete, trackAuthError, setUser } = useAnalytics();
 
   // ページタイトル設定
   useEffect(() => {
@@ -33,6 +33,7 @@ export default function SignUpPage() {
     setLoading(true);
     setError(null);
     setSuccess(false);
+    trackSignupStart();
 
     try {
       // パスワード検証
@@ -61,10 +62,8 @@ export default function SignUpPage() {
           email: data.user.email,
         });
 
-        // ✅ GA: ユーザーID設定（GA4では user_id は gtag('set') で設定）
         setUser(data.user.id);
-        // ✅ GA: サインアップイベント追跡
-        trackSignUp();
+        trackSignupComplete();
 
         // ✅ app_user は初回の関連API利用時に自動作成される（/api/image-upload、like/bookmark/comment 等で）
         // signup では auth.signUp() のみで完了

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -378,6 +378,8 @@ export default function UploadPage() {
     ));
 
     try {
+      const uploadStartTime = Date.now();
+
       // Compress image
       const compressedFile = await imageCompression(photo.file, {
         maxSizeMB: 2,
@@ -445,6 +447,10 @@ export default function UploadPage() {
         manhole_id: photo.matchedManhole?.id,
         prefecture: photo.matchedManhole?.prefecture,
         is_logged_in: true,
+        upload_duration_ms: Date.now() - uploadStartTime,
+        has_location: isValidCoordinates(photo.metadata.latitude, photo.metadata.longitude),
+        has_note: !!visitNote.trim(),
+        is_public: isPublic,
       };
       trackPhotoUploadComplete(manholeParams);
       trackVisitRegister(manholeParams);

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -47,7 +47,7 @@ export default function UploadPage() {
   const [isPublic, setIsPublic] = useState<boolean>(true); // 公開設定（デフォルト: 公開）
   const [alerts, setAlerts] = useState<AlertMessage[]>([]); // アラートメッセージ
   const timerRefsRef = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
-  const { trackView, trackUploadStart, trackUploadSuccess, trackUploadError } = useAnalytics();
+  const { trackView, trackPhotoUploadStart, trackPhotoUploadComplete, trackAppError, trackVisitRegister } = useAnalytics();
 
   // ✅ タイマークリーンアップ（コンポーネントアンマウント時）
   useEffect(() => {
@@ -385,8 +385,7 @@ export default function UploadPage() {
         useWebWorker: true
       });
 
-      // ✅ GA: アップロード開始イベント追跡
-      trackUploadStart(compressedFile.size, compressedFile.type);
+      trackPhotoUploadStart({ is_logged_in: true });
 
       // Prepare form data for upload
       const formData = new FormData();
@@ -442,20 +441,13 @@ export default function UploadPage() {
         throw new Error(uploadResult.error || 'Upload failed');
       }
 
-      // ✅ GA: アップロード成功イベント追跡
-      const uploadEndTime = Date.now();
-      const uploadDuration = uploadEndTime - uploadStartTime;
-      trackUploadSuccess(
-        compressedFile.size,
-        compressedFile.type,
-        uploadDuration,
-        {
-          manhole_id: photo.matchedManhole?.id,
-          has_location: isValidCoordinates(photo.metadata.latitude, photo.metadata.longitude),
-          has_note: !!visitNote.trim(),
-          is_public: isPublic
-        }
-      );
+      const manholeParams = {
+        manhole_id: photo.matchedManhole?.id,
+        prefecture: photo.matchedManhole?.prefecture,
+        is_logged_in: true,
+      };
+      trackPhotoUploadComplete(manholeParams);
+      trackVisitRegister(manholeParams);
 
       setPhotos(prev => prev.map(p =>
         p.id === photoId ? {
@@ -470,16 +462,7 @@ export default function UploadPage() {
     } catch (error: any) {
       console.error('Upload failed:', error);
 
-      // ✅ GA: アップロードエラーイベント追跡
-      trackUploadError(
-        'upload_error',
-        error?.message || 'Unknown error',
-        photo.file.size,
-        {
-          file_type: photo.file.type,
-          manhole_id: photo.matchedManhole?.id
-        }
-      );
+      trackAppError('upload_error', error?.message || 'Unknown error');
 
       const errorMsg = error?.message || 'アップロードに失敗しました';
       setPhotos(prev => prev.map(p =>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -468,7 +468,14 @@ export default function UploadPage() {
     } catch (error: any) {
       console.error('Upload failed:', error);
 
-      trackAppError('upload_error', error?.message || 'Unknown error');
+      const errorType = (() => {
+        if (error?.status === 401 || error?.message?.includes('Unauthorized')) return 'unauthorized';
+        if (error?.name === 'TypeError' || error?.message?.includes('network')) return 'network';
+        if (error?.message?.includes('size') || error?.message?.includes('large')) return 'file_size';
+        if (error?.message?.includes('GPS') || error?.message?.includes('location')) return 'gps_validation';
+        return 'unknown';
+      })();
+      trackAppError('upload_error', errorType);
 
       const errorMsg = error?.message || 'アップロードに失敗しました';
       setPhotos(prev => prev.map(p =>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -83,11 +83,12 @@ export default function VisitsPage() {
   const [selectedVisitId, setSelectedVisitId] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const { trackView } = useAnalytics();
+  const { trackView, trackPassportOpen } = useAnalytics();
 
   useEffect(() => {
     document.title = 'ポケふた訪問パスポート - ポケふた訪問記録';
     trackView('/visits', 'ポケふた訪問パスポート', 'visits');
+    trackPassportOpen();
     checkAuth();
   }, []);
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -71,10 +71,10 @@ export default function Header({ title = 'ポケふた', icon }: HeaderProps) {
     if (!supabase) return;
 
     try {
-      trackLogout();
-      clearUser();
       await fetch('/api/auth/logout', { method: 'POST' });
       await supabase.auth.signOut();
+      trackLogout();
+      clearUser();
       setIsMenuOpen(false);
       router.push('/');
       router.refresh();

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from 'next/navigation';
 import { Menu, X, Home, Map, Navigation, Camera, History, List, LogOut, User as UserIcon, Info } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 import type { User, SupabaseClient } from '@supabase/supabase-js';
+import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 interface HeaderProps {
   title?: string;
@@ -18,6 +19,8 @@ export default function Header({ title = 'ポケふた', icon }: HeaderProps) {
   const [supabaseError, setSupabaseError] = useState<string | null>(null);
   const pathname = usePathname();
   const router = useRouter();
+
+  const { trackLogout, clearUser } = useAnalytics();
 
   let supabase: SupabaseClient | undefined;
   try {
@@ -68,6 +71,8 @@ export default function Header({ title = 'ポケふた', icon }: HeaderProps) {
     if (!supabase) return;
 
     try {
+      trackLogout();
+      clearUser();
       await fetch('/api/auth/logout', { method: 'POST' });
       await supabase.auth.signOut();
       setIsMenuOpen(false);

--- a/src/components/MobileMenuDrawer.tsx
+++ b/src/components/MobileMenuDrawer.tsx
@@ -84,10 +84,10 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
     if (!supabase) return;
 
     try {
-      trackLogout();
-      clearUser();
       await fetch('/api/auth/logout', { method: 'POST' });
       await supabase.auth.signOut();
+      trackLogout();
+      clearUser();
       onClose();
       router.push('/');
       router.refresh();

--- a/src/components/MobileMenuDrawer.tsx
+++ b/src/components/MobileMenuDrawer.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import type { SupabaseClient, User } from '@supabase/supabase-js';
 import { createBrowserClient } from '@/lib/supabase/client';
+import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 type Props = {
   open: boolean;
@@ -24,6 +25,8 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
   const [user, setUser] = useState<User | null>(null);
   const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [supabaseError, setSupabaseError] = useState<string | null>(null);
+
+  const { trackLogout, clearUser } = useAnalytics();
 
   useEffect(() => {
     if (!open) return;
@@ -81,6 +84,8 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
     if (!supabase) return;
 
     try {
+      trackLogout();
+      clearUser();
       await fetch('/api/auth/logout', { method: 'POST' });
       await supabase.auth.signOut();
       onClose();

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -15,6 +15,15 @@ export interface GAUserProperties {
   [key: string]: string | number | boolean | undefined;
 }
 
+/** pokefuta.com 共通イベントパラメータ */
+export interface PokefutaEventParams extends GAEventParams {
+  manhole_id?: string | number;
+  prefecture?: string;
+  pokemon_ids?: string;    // カンマ区切り文字列 (GA4は配列非対応)
+  is_logged_in?: boolean;
+  source_app?: 'tracker' | 'map';
+}
+
 // ==========================================
 // グローバル型拡張
 // ==========================================
@@ -30,16 +39,10 @@ declare global {
 // ヘルパー関数: SSR チェック
 // ==========================================
 
-/**
- * クライアント側でのみ実行されるかをチェック
- */
 function isClientSide(): boolean {
   return typeof window !== 'undefined';
 }
 
-/**
- * gtag が利用可能かをチェック
- */
 function isGtagAvailable(): boolean {
   return isClientSide() && typeof window.gtag === 'function';
 }
@@ -48,20 +51,6 @@ function isGtagAvailable(): boolean {
 // コア関数: イベント送信
 // ==========================================
 
-/**
- * GA4 イベントを送信
- *
- * @param eventName - イベント名 (例: 'file_upload', 'sign_in')
- * @param eventParams - イベントパラメータ
- * @param context - 追加コンテキスト情報
- *
- * @example
- * trackEvent('file_upload', {
- *   file_size: 1024000,
- *   file_type: 'image/jpeg',
- *   manhole_id: 123
- * });
- */
 export function trackEvent(
   eventName: string,
   eventParams?: GAEventParams,
@@ -74,26 +63,15 @@ export function trackEvent(
     return;
   }
 
-  // ==========================================
-  // 共通属性の自動付与
-  // ==========================================
   const enrichedParams: GAEventParams = {
-    // ページ情報（デフォルト値）
     page_path: isClientSide() ? window.location.pathname : undefined,
     page_title: isClientSide() ? document.title : undefined,
-    // タイムスタンプ
     event_timestamp: new Date().toISOString(),
-    // ユーザーロケール
     user_locale: navigator.language || 'ja-JP',
-    // カスタムコンテキスト
     ...context,
-    // eventParams で明示指定された値を優先
     ...eventParams,
   };
 
-  // ==========================================
-  // 開発環境でのログ出力
-  // ==========================================
   if (process.env.NODE_ENV === 'development') {
     console.log('[GA Event]', {
       event: eventName,
@@ -101,10 +79,6 @@ export function trackEvent(
       timestamp: new Date().toISOString(),
     });
   }
-
-  // ==========================================
-  // GA に送信
-  // ==========================================
 
   try {
     window.gtag!('event', eventName, enrichedParams);
@@ -117,10 +91,6 @@ export function trackEvent(
 // ページビュー関数
 // ==========================================
 
-/**
- * ページビューイベントを送信
- * 必要な箇所で明示的に呼び出して使用する
- */
 export function trackPageView(
   pagePath: string,
   pageTitle: string,
@@ -137,15 +107,6 @@ export function trackPageView(
 // ユーザー設定関数
 // ==========================================
 
-/**
- * ユーザー ID を GA に設定
- * ログイン時に呼び出す
- *
- * @param userId - Supabase auth.user.id
- *
- * @example
- * setUserId(session.user.id);
- */
 export function setUserId(userId: string): void {
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
@@ -155,7 +116,6 @@ export function setUserId(userId: string): void {
   }
 
   try {
-    // gtag('set') を使用してユーザーIDを設定
     window.gtag!('set', { 'user_id': userId });
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA] User ID set');
@@ -165,10 +125,6 @@ export function setUserId(userId: string): void {
   }
 }
 
-/**
- * ユーザー ID をクリア
- * ログアウト時に呼び出す
- */
 export function clearUserId(): void {
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
@@ -178,7 +134,6 @@ export function clearUserId(): void {
   }
 
   try {
-    // gtag('set') を使用してユーザーIDをクリア
     window.gtag!('set', { 'user_id': null });
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA] User ID cleared');
@@ -188,22 +143,7 @@ export function clearUserId(): void {
   }
 }
 
-/**
- * ユーザープロパティを設定
- * ユーザーの属性情報（ロール、プラン等）を設定
- *
- * @param properties - ユーザープロパティ
- *
- * @example
- * setUserProperties({
- *   user_tier: 'free',
- *   is_beta_tester: false,
- *   registration_source: 'organic'
- * });
- */
-export function setUserProperties(
-  properties: GAUserProperties
-): void {
+export function setUserProperties(properties: GAUserProperties): void {
   if (!isGtagAvailable()) {
     if (process.env.NODE_ENV === 'development') {
       console.warn('[GA] gtag not available. User properties not set.');
@@ -212,9 +152,7 @@ export function setUserProperties(
   }
 
   try {
-    window.gtag!('set', {
-      user_properties: properties,
-    });
+    window.gtag!('set', { user_properties: properties });
     if (process.env.NODE_ENV === 'development') {
       console.log('[GA] User properties set:', properties);
     }
@@ -224,96 +162,53 @@ export function setUserProperties(
 }
 
 // ==========================================
-// カテゴリ別追跡関数
+// pokefuta.com イベント (p_ prefix)
 // ==========================================
 
-/**
- * 認証イベント
- */
-export const authEvents = {
-  signIn: (metadata?: GAEventParams) =>
-    trackEvent('sign_in', metadata),
+export const pokefutaEvents = {
+  // --- 認証系 ---
+  loginStart:          (p?: PokefutaEventParams) => trackEvent('p_login_start', p),
+  loginSuccess:        (p?: PokefutaEventParams) => trackEvent('p_login_success', p),
+  signupStart:         (p?: PokefutaEventParams) => trackEvent('p_signup_start', p),
+  signupComplete:      (p?: PokefutaEventParams) => trackEvent('p_signup_complete', p),
+  logout:              (p?: PokefutaEventParams) => trackEvent('p_logout', p),
 
-  signUp: (metadata?: GAEventParams) =>
-    trackEvent('sign_up', metadata),
+  // --- 訪問記録系 ---
+  visitRegister:       (p?: PokefutaEventParams) => trackEvent('p_visit_register', p),
+  visitDelete:         (p?: PokefutaEventParams) => trackEvent('p_visit_delete', p),
+  passportOpen:        (p?: PokefutaEventParams) => trackEvent('p_passport_open', p),
+  collectionOpen:      (p?: PokefutaEventParams) => trackEvent('p_collection_open', p),
 
-  signOut: (metadata?: GAEventParams) =>
-    trackEvent('sign_out', metadata),
+  // --- 写真投稿系 ---
+  photoUploadStart:    (p?: PokefutaEventParams) => trackEvent('p_photo_upload_start', p),
+  photoUploadComplete: (p?: PokefutaEventParams) => trackEvent('p_photo_upload_complete', p),
+  photoView:           (p?: PokefutaEventParams) => trackEvent('p_photo_view', p),
+  photoExpand:         (p?: PokefutaEventParams) => trackEvent('p_photo_expand', p),
+
+  // --- 回遊系 ---
+  manholeDetailOpen:   (p?: PokefutaEventParams) => trackEvent('p_manhole_detail_open', p),
+  prefectureOpen:      (p?: PokefutaEventParams) => trackEvent('p_prefecture_open', p),
+  userProfileOpen:     (p?: PokefutaEventParams) => trackEvent('p_user_profile_open', p),
+  mapReturn:           (p?: PokefutaEventParams) => trackEvent('p_map_return', p),
+
+  // --- ソーシャル共有系 ---
+  shareClick:          (p?: PokefutaEventParams) => trackEvent('p_share_click', p),
+  shareX:              (p?: PokefutaEventParams) => trackEvent('p_share_x', p),
+  shareLine:           (p?: PokefutaEventParams) => trackEvent('p_share_line', p),
+  copyLink:            (p?: PokefutaEventParams) => trackEvent('p_copy_link', p),
+
+  // --- 旅・位置情報系 ---
+  nearbyOpen:          (p?: PokefutaEventParams) => trackEvent('p_nearby_open', p),
+  geolocationEnable:   (p?: PokefutaEventParams) => trackEvent('p_geolocation_enable', p),
+  routeOpen:           (p?: PokefutaEventParams) => trackEvent('p_route_open', p),
 };
 
-/**
- * ファイルアップロードイベント
- */
-export const uploadEvents = {
-  start: (fileSize: number, fileType: string) =>
-    trackEvent('upload_start', { file_size: fileSize, file_type: fileType }),
+// ==========================================
+// 内部エラー追跡 (prefix なし、内部用)
+// ==========================================
 
-  success: (
-    fileSize: number,
-    fileType: string,
-    durationMs: number,
-    metadata?: GAEventParams
-  ) =>
-    trackEvent('file_upload', {
-      file_size: fileSize,
-      file_type: fileType,
-      upload_duration_ms: durationMs,
-      ...metadata,
-    }),
-
-  error: (
-    errorCode: string,
-    fileSize?: number,
-    metadata?: GAEventParams
-  ) =>
-    trackEvent('upload_error', {
-      error_code: errorCode,
-      file_size: fileSize,
-      ...metadata,
-    }),
-};
-
-/**
- * 検索イベント
- */
-export const searchEvents = {
-  search: (query: string, resultCount: number, metadata?: GAEventParams) =>
-    trackEvent('search', {
-      search_term: query,
-      result_count: resultCount,
-      ...metadata,
-    }),
-
-  filterApply: (filterType: string, filterValue: string, resultCount: number) =>
-    trackEvent('filter_apply', {
-      filter_type: filterType,
-      filter_value: filterValue,
-      result_count: resultCount,
-    }),
-};
-
-/**
- * ナビゲーション・クリックイベント
- */
-export const navigationEvents = {
-  click: (navItem: string) =>
-    trackEvent('navigation_click', {
-      nav_item: navItem,
-    }),
-
-  back: () =>
-    trackEvent('navigation_back'),
-};
-
-/**
- * エラーイベント
- */
 export const errorEvents = {
-  api: (
-    endpoint: string,
-    statusCode: number,
-    method: string = 'GET'
-  ) =>
+  api: (endpoint: string, statusCode: number, method: string = 'GET') =>
     trackEvent('error_event', {
       error_type: 'api_error',
       endpoint,
@@ -322,57 +217,20 @@ export const errorEvents = {
     }),
 
   auth: (errorCode: string) =>
-    trackEvent('auth_error', {
-      error_code: errorCode,
-    }),
+    trackEvent('auth_error', { error_code: errorCode }),
 
   app: (errorCode: string, errorType: string = 'unknown') =>
-    trackEvent('app_error', {
-      error_code: errorCode,
-      error_type: errorType,
-    }),
-};
-
-/**
- * エンゲージメントイベント（将来用）
- */
-export const engagementEvents = {
-  like: (targetType: string, targetId: string) =>
-    trackEvent('engagement_click', {
-      engagement_type: 'like',
-      target_type: targetType,
-      target_id: targetId,
-    }),
-
-  bookmark: (targetType: string, targetId: string) =>
-    trackEvent('bookmark_click', {
-      engagement_type: 'bookmark',
-      target_type: targetType,
-      target_id: targetId,
-    }),
-
-  comment: (targetType: string, targetId: string) =>
-    trackEvent('comment_submit', {
-      engagement_type: 'comment',
-      target_type: targetType,
-      target_id: targetId,
-    }),
+    trackEvent('app_error', { error_code: errorCode, error_type: errorType }),
 };
 
 // ==========================================
 // デバッグ・初期化関数
 // ==========================================
 
-/**
- * GA の初期化状態を確認
- */
 export function isGAInitialized(): boolean {
   return isGtagAvailable();
 }
 
-/**
- * GA 初期化情報をコンソール出力（開発用）
- */
 export function debugGA(): void {
   if (!isClientSide()) {
     console.log('[GA Debug] Not on client side');
@@ -387,7 +245,6 @@ export function debugGA(): void {
     cookiesEnabled: navigator.cookieEnabled,
   });
 
-  // dataLayer の内容を表示
   if (window.dataLayer) {
     console.log('[GA dataLayer]', window.dataLayer.slice(-5));
   }

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -1,226 +1,167 @@
-/**
- * Google Analytics カスタム Hook
- * コンポーネントでの GA イベント追跡を簡潔に
- */
-
 'use client';
 
 import { useCallback } from 'react';
 import {
   trackEvent,
+  trackPageView,
   setUserId,
   clearUserId,
-  trackPageView,
-  authEvents,
-  uploadEvents,
-  searchEvents,
-  navigationEvents,
+  setUserProperties,
+  pokefutaEvents,
   errorEvents,
   GAEventParams,
+  GAUserProperties,
+  PokefutaEventParams,
 } from '@/lib/analytics/gtag';
 
-/**
- * Google Analytics カスタム Hook
- *
- * @example
- * const { track, trackView, trackSignIn, trackUploadStart } = useAnalytics();
- *
- * // 基本的なイベント
- * track('custom_event', { custom_field: 'value' });
- *
- * // 認証イベント
- * trackSignIn();
- *
- * // ファイルアップロード
- * trackUploadStart(1024000, 'image/jpeg');
- * // 後でアップロード完了時に trackUploadSuccess を呼び出す
- */
-export function useAnalytics() {
-  // ==========================================
-  // 基本的なイベント追跡
-  // ==========================================
+// 後方互換用の内部ヘルパー
+const legacyEvents = {
+  search: (query: string, resultCount: number, metadata?: GAEventParams) =>
+    trackEvent('search', { search_term: query, result_count: resultCount, ...metadata }),
+  filterApply: (filterType: string, filterValue: string, resultCount: number) =>
+    trackEvent('filter_apply', { filter_type: filterType, filter_value: filterValue, result_count: resultCount }),
+  navClick: (navItem: string) =>
+    trackEvent('navigation_click', { nav_item: navItem }),
+};
 
+export function useAnalytics() {
+  // 汎用イベント
   const track = useCallback(
-    (eventName: string, params?: GAEventParams) => {
-      trackEvent(eventName, params);
-    },
+    (eventName: string, params?: GAEventParams) => trackEvent(eventName, params),
     []
   );
-
-  // ==========================================
-  // ページビュー追跡
-  // ==========================================
 
   const trackView = useCallback(
-    (pagePath: string, pageTitle: string, pageType?: string) => {
-      trackPageView(pagePath, pageTitle, pageType);
-    },
+    (pagePath: string, pageTitle: string, pageType?: string) =>
+      trackPageView(pagePath, pageTitle, pageType),
     []
   );
 
-  // ==========================================
-  // 認証イベント
-  // ==========================================
-
-  const trackSignIn = useCallback((metadata?: GAEventParams) => {
-    authEvents.signIn(metadata);
-  }, []);
-
-  const trackSignUp = useCallback((metadata?: GAEventParams) => {
-    authEvents.signUp(metadata);
-  }, []);
-
-  const trackSignOut = useCallback((metadata?: GAEventParams) => {
-    authEvents.signOut(metadata);
-  }, []);
-
-  // ==========================================
   // ユーザーID管理
-  // ==========================================
+  const setUser = useCallback((userId: string) => setUserId(userId), []);
+  const clearUser = useCallback(() => clearUserId(), []);
 
-  const setUser = useCallback((userId: string) => {
-    setUserId(userId);
-  }, []);
-
-  const clearUser = useCallback(() => {
-    clearUserId();
-  }, []);
-
-  // ==========================================
-  // ファイルアップロード
-  // ==========================================
-
-  const trackUploadStart = useCallback(
-    (fileSize: number, fileType: string) => {
-      uploadEvents.start(fileSize, fileType);
-    },
+  // User Properties
+  const updateUserProperties = useCallback(
+    (props: GAUserProperties) => setUserProperties(props),
     []
   );
 
-  const trackUploadSuccess = useCallback(
-    (
-      fileSize: number,
-      fileType: string,
-      durationMs: number,
-      metadata?: GAEventParams
-    ) => {
-      uploadEvents.success(fileSize, fileType, durationMs, metadata);
-    },
-    []
-  );
+  // --- 認証系 ---
+  const trackLoginStart    = useCallback((p?: PokefutaEventParams) => pokefutaEvents.loginStart(p), []);
+  const trackLoginSuccess  = useCallback((p?: PokefutaEventParams) => pokefutaEvents.loginSuccess(p), []);
+  const trackSignupStart   = useCallback((p?: PokefutaEventParams) => pokefutaEvents.signupStart(p), []);
+  const trackSignupComplete= useCallback((p?: PokefutaEventParams) => pokefutaEvents.signupComplete(p), []);
+  const trackLogout        = useCallback((p?: PokefutaEventParams) => pokefutaEvents.logout(p), []);
 
-  const trackUploadError = useCallback(
-    (
-      errorCode: string,
-      errorMessage?: string,
-      fileSize?: number,
-      metadata?: GAEventParams
-    ) => {
-      uploadEvents.error(errorCode, fileSize, metadata);
-    },
-    []
-  );
+  // --- 訪問記録系 ---
+  const trackVisitRegister = useCallback((p?: PokefutaEventParams) => pokefutaEvents.visitRegister(p), []);
+  const trackVisitDelete   = useCallback((p?: PokefutaEventParams) => pokefutaEvents.visitDelete(p), []);
+  const trackPassportOpen  = useCallback((p?: PokefutaEventParams) => pokefutaEvents.passportOpen(p), []);
+  const trackCollectionOpen= useCallback((p?: PokefutaEventParams) => pokefutaEvents.collectionOpen(p), []);
 
-  // ==========================================
-  // 検索・フィルタリング
-  // ==========================================
+  // --- 写真投稿系 ---
+  const trackPhotoUploadStart    = useCallback((p?: PokefutaEventParams) => pokefutaEvents.photoUploadStart(p), []);
+  const trackPhotoUploadComplete = useCallback((p?: PokefutaEventParams) => pokefutaEvents.photoUploadComplete(p), []);
+  const trackPhotoView           = useCallback((p?: PokefutaEventParams) => pokefutaEvents.photoView(p), []);
+  const trackPhotoExpand         = useCallback((p?: PokefutaEventParams) => pokefutaEvents.photoExpand(p), []);
 
+  // --- 回遊系 ---
+  const trackManholeDetailOpen = useCallback((p?: PokefutaEventParams) => pokefutaEvents.manholeDetailOpen(p), []);
+  const trackPrefectureOpen    = useCallback((p?: PokefutaEventParams) => pokefutaEvents.prefectureOpen(p), []);
+  const trackUserProfileOpen   = useCallback((p?: PokefutaEventParams) => pokefutaEvents.userProfileOpen(p), []);
+  const trackMapReturn         = useCallback((p?: PokefutaEventParams) => pokefutaEvents.mapReturn(p), []);
+
+  // --- ソーシャル共有系 ---
+  const trackShareClick = useCallback((p?: PokefutaEventParams) => pokefutaEvents.shareClick(p), []);
+  const trackShareX     = useCallback((p?: PokefutaEventParams) => pokefutaEvents.shareX(p), []);
+  const trackShareLine  = useCallback((p?: PokefutaEventParams) => pokefutaEvents.shareLine(p), []);
+  const trackCopyLink   = useCallback((p?: PokefutaEventParams) => pokefutaEvents.copyLink(p), []);
+
+  // --- 旅・位置情報系 ---
+  const trackNearbyOpen       = useCallback((p?: PokefutaEventParams) => pokefutaEvents.nearbyOpen(p), []);
+  const trackGeolocationEnable= useCallback((p?: PokefutaEventParams) => pokefutaEvents.geolocationEnable(p), []);
+  const trackRouteOpen        = useCallback((p?: PokefutaEventParams) => pokefutaEvents.routeOpen(p), []);
+
+  // --- 後方互換用 ---
   const trackSearch = useCallback(
-    (query: string, resultCount: number, metadata?: GAEventParams) => {
-      searchEvents.search(query, resultCount, metadata);
-    },
+    (query: string, resultCount: number, metadata?: GAEventParams) =>
+      legacyEvents.search(query, resultCount, metadata),
     []
   );
-
   const trackFilterApply = useCallback(
-    (filterType: string, filterValue: string, resultCount: number) => {
-      searchEvents.filterApply(filterType, filterValue, resultCount);
-    },
+    (filterType: string, filterValue: string, resultCount: number) =>
+      legacyEvents.filterApply(filterType, filterValue, resultCount),
     []
   );
+  const trackNavClick = useCallback((navItem: string) => legacyEvents.navClick(navItem), []);
 
-  // ==========================================
-  // ナビゲーション
-  // ==========================================
-
-  const trackNavClick = useCallback((navItem: string) => {
-    navigationEvents.click(navItem);
-  }, []);
-
-  const trackNavBack = useCallback(() => {
-    navigationEvents.back();
-  }, []);
-
-  // ==========================================
-  // エラー追跡
-  // ==========================================
-
-  const trackApiError = useCallback(
-    (
-      endpoint: string,
-      statusCode: number,
-      errorMessage?: string,
-      method?: string
-    ) => {
-      errorEvents.api(endpoint, statusCode, method);
-    },
+  // --- 内部エラー追跡 ---
+  const trackApiError  = useCallback(
+    (endpoint: string, statusCode: number, _errorMessage?: string, method?: string) =>
+      errorEvents.api(endpoint, statusCode, method),
     []
   );
-
   const trackAuthError = useCallback(
-    (errorCode: string, errorMessage?: string) => {
-      errorEvents.auth(errorCode);
-    },
+    (errorCode: string, _errorMessage?: string) => errorEvents.auth(errorCode),
     []
   );
-
-  const trackAppError = useCallback(
-    (errorCode: string, errorType?: string) => {
-      errorEvents.app(errorCode, errorType);
-    },
+  const trackAppError  = useCallback(
+    (errorCode: string, errorType?: string) => errorEvents.app(errorCode, errorType),
     []
   );
 
   return {
-    // ==========================================
-    // 基本機能
-    // ==========================================
     track,
     trackView,
-
-    // ==========================================
-    // ユーザー認証
-    // ==========================================
-    trackSignIn,
-    trackSignUp,
-    trackSignOut,
     setUser,
     clearUser,
+    updateUserProperties,
 
-    // ==========================================
-    // ファイルアップロード
-    // ==========================================
-    trackUploadStart,
-    trackUploadSuccess,
-    trackUploadError,
+    // 認証系
+    trackLoginStart,
+    trackLoginSuccess,
+    trackSignupStart,
+    trackSignupComplete,
+    trackLogout,
 
-    // ==========================================
-    // 検索・フィルタリング
-    // ==========================================
-    trackSearch,
-    trackFilterApply,
+    // 訪問記録系
+    trackVisitRegister,
+    trackVisitDelete,
+    trackPassportOpen,
+    trackCollectionOpen,
 
-    // ==========================================
-    // ナビゲーション
-    // ==========================================
-    trackNavClick,
-    trackNavBack,
+    // 写真投稿系
+    trackPhotoUploadStart,
+    trackPhotoUploadComplete,
+    trackPhotoView,
+    trackPhotoExpand,
 
-    // ==========================================
-    // エラー追跡
-    // ==========================================
+    // 回遊系
+    trackManholeDetailOpen,
+    trackPrefectureOpen,
+    trackUserProfileOpen,
+    trackMapReturn,
+
+    // ソーシャル共有系
+    trackShareClick,
+    trackShareX,
+    trackShareLine,
+    trackCopyLink,
+
+    // 旅・位置情報系
+    trackNearbyOpen,
+    trackGeolocationEnable,
+    trackRouteOpen,
+
+    // 内部エラー追跡
     trackApiError,
     trackAuthError,
     trackAppError,
+
+    // 後方互換
+    trackSearch,
+    trackFilterApply,
+    trackNavClick,
   };
 }


### PR DESCRIPTION
## Summary

- \`p_\` prefix を pokefuta.com 側イベント全体に統一し、data.pokefuta.com（地図/SEO系）イベントと BigQuery/GA Explore 上で明確に区別できるようにした
- \`gtag.ts\` に \`pokefutaEvents\` オブジェクトを新設し、spec で定義された20イベントを実装（残り2イベントは将来ページ実装後に追加予定）
- \`useAnalytics.ts\` の全メソッドを新しい \`p_\` prefix 版に置換

## 実装イベント一覧（24定義 / うち22が実際に呼ばれている）

| カテゴリ | イベント | 呼び出し |
|---|---|---|
| 認証 | \`p_login_start\`, \`p_login_success\` | login/page.tsx |
| 認証 | \`p_signup_start\`, \`p_signup_complete\` | signup/page.tsx |
| 認証 | \`p_logout\` | Header.tsx, MobileMenuDrawer.tsx |
| 訪問記録 | \`p_visit_register\`, \`p_photo_upload_start\`, \`p_photo_upload_complete\` | upload/page.tsx |
| 訪問記録 | \`p_visit_delete\` | manhole/[id]/page.tsx |
| 訪問記録 | \`p_passport_open\` | visits/page.tsx |
| 訪問記録 | \`p_collection_open\` | page.tsx (home) |
| 回遊 | \`p_manhole_detail_open\`, \`p_route_open\`, \`p_share_click\`, \`p_share_x\`, \`p_share_line\`, \`p_copy_link\` | manhole/[id]/page.tsx |
| 回遊 | \`p_prefecture_open\` | manholes/page.tsx |
| 位置情報 | \`p_nearby_open\`, \`p_geolocation_enable\` | nearby/page.tsx |
| 定義のみ | \`p_photo_view\`, \`p_photo_expand\` | 写真拡大UI実装時に追加予定 |
| 定義のみ | \`p_user_profile_open\`, \`p_map_return\` | ユーザープロフィールページ/地図連携実装時に追加予定 |

## 共有 UI 変更

デスクトップ環境（\`navigator.share\` 非対応）では、共有ボタン押下時に X / LINE / URLコピー の選択パネルを表示。各ボタンで \`p_share_x\`、\`p_share_line\`、\`p_copy_link\` を個別トラッキング。

## Event Parameters

全イベントで以下の共通パラメータを付与可能：\`manhole_id\`, \`prefecture\`, \`pokemon_ids\`, \`is_logged_in\`, \`source_app\`

## Test plan

- [ ] \`NODE_ENV=development\` でアプリ起動し、ブラウザコンソールに \`[GA Event] p_xxx\` が出力されることを確認
- [ ] ログイン → \`p_login_start\`, \`p_login_success\` が発火
- [ ] ログアウト成功後 → \`p_logout\` が発火
- [ ] マンホール詳細ページ → \`p_manhole_detail_open\` が発火
- [ ] 経路案内ボタン → \`p_route_open\` が発火
- [ ] 共有ボタン（デスクトップ）→ \`p_share_click\` 後に X/LINE/コピー パネル表示
- [ ] 写真アップロード成功 → \`p_photo_upload_start\`, \`p_photo_upload_complete\`, \`p_visit_register\` が発火
- [ ] スタンプ帳 → \`p_passport_open\` が発火
- [ ] 近くのポケふた（初回のみ） → \`p_nearby_open\` が発火
- [ ] 位置情報許可 → \`p_geolocation_enable\` が発火

🤖 Generated with [Claude Code](https://claude.com/claude-code)