### PR TITLE
feat: FooterにポケモンマンホールXリンクを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 manhole_images/*
 *.raw.ndjson
 *.log

--- a/src/components/MobileMenuDrawer.tsx
+++ b/src/components/MobileMenuDrawer.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 import {
+  ExternalLink,
   Home,
   Info,
   LogOut,
@@ -26,7 +27,7 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
   const [supabase, setSupabase] = useState<SupabaseClient | null>(null);
   const [supabaseError, setSupabaseError] = useState<string | null>(null);
 
-  const { trackLogout, clearUser } = useAnalytics();
+  const { trackLogout, clearUser, trackFooterXClick } = useAnalytics();
 
   useEffect(() => {
     if (!open) return;
@@ -205,6 +206,26 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
               </div>
             )}
           </nav>
+
+          {/* 公式X リンク */}
+          <div className="mt-4 pt-3 border-t border-[#7B63A8]/15">
+            <a
+              href="https://x.com/pokemonmanhole"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-2 px-3 py-2 font-pixelJp text-xs text-rpg-textDark opacity-60 hover:opacity-100 hover:bg-white/70 transition-opacity"
+              onClick={() =>
+                trackFooterXClick({
+                  location: 'footer',
+                  source_app: 'tracker',
+                  is_logged_in: Boolean(user),
+                })
+              }
+            >
+              <ExternalLink className="w-3.5 h-3.5 flex-shrink-0" />
+              <span>公式X @pokemonmanhole</span>
+            </a>
+          </div>
 
           {supabaseError && (
             <div className="mt-3 p-2 bg-rpg-red/20 border-2 border-rpg-red">

--- a/src/components/MobileMenuDrawer.tsx
+++ b/src/components/MobileMenuDrawer.tsx
@@ -213,14 +213,15 @@ export default function MobileMenuDrawer({ open, onClose }: Props) {
               href="https://x.com/pokemonmanhole"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 px-3 py-2 font-pixelJp text-xs text-rpg-textDark opacity-60 hover:opacity-100 hover:bg-white/70 transition-opacity"
-              onClick={() =>
+              className="flex items-center gap-2 px-3 py-2 font-pixelJp text-xs text-rpg-textDark opacity-60 hover:opacity-100 hover:bg-white/70 transition-all"
+              onClick={() => {
                 trackFooterXClick({
                   location: 'footer',
                   source_app: 'tracker',
                   is_logged_in: Boolean(user),
-                })
-              }
+                });
+                onClose();
+              }}
             >
               <ExternalLink className="w-3.5 h-3.5 flex-shrink-0" />
               <span>公式X @pokemonmanhole</span>

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -201,6 +201,9 @@ export const pokefutaEvents = {
   nearbyOpen:          (p?: PokefutaEventParams) => trackEvent('p_nearby_open', p),
   geolocationEnable:   (p?: PokefutaEventParams) => trackEvent('p_geolocation_enable', p),
   routeOpen:           (p?: PokefutaEventParams) => trackEvent('p_route_open', p),
+
+  // --- SNS導線系 ---
+  footerXClick:        (p?: PokefutaEventParams) => trackEvent('p_footer_x_click', p),
 };
 
 // ==========================================

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -83,6 +83,9 @@ export function useAnalytics() {
   const trackGeolocationEnable= useCallback((p?: PokefutaEventParams) => pokefutaEvents.geolocationEnable(p), []);
   const trackRouteOpen        = useCallback((p?: PokefutaEventParams) => pokefutaEvents.routeOpen(p), []);
 
+  // --- SNS導線系 ---
+  const trackFooterXClick = useCallback((p?: PokefutaEventParams) => pokefutaEvents.footerXClick(p), []);
+
   // --- 後方互換用 ---
   const trackSearch = useCallback(
     (query: string, resultCount: number, metadata?: GAEventParams) =>
@@ -153,6 +156,9 @@ export function useAnalytics() {
     trackNearbyOpen,
     trackGeolocationEnable,
     trackRouteOpen,
+
+    // SNS導線系
+    trackFooterXClick,
 
     // 内部エラー追跡
     trackApiError,


### PR DESCRIPTION
## Summary

- メニュードロワー (`MobileMenuDrawer`) の最下部に公式X [@pokemonmanhole](https://x.com/pokemonmanhole) へのリンクを追加
- 検索流入 → SNSフォロー → 再訪の導線を構築するための実装
- `gtag.ts` / `useAnalytics.ts` に `p_footer_x_click` イベントを追加

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/components/MobileMenuDrawer.tsx` | X リンクをドロワー最下部に追加、クリックイベント計測 |
| `src/lib/analytics/gtag.ts` | `footerXClick` イベント定義を追加 |
| `src/lib/hooks/useAnalytics.ts` | `trackFooterXClick` をフックに追加 |

## Analytics

```
event: p_footer_x_click
params:
  location: "footer"
  source_app: "tracker"
  is_logged_in: true/false
```

## Test plan

- [ ] メニュードロワーを開いて最下部に「公式X @pokemonmanhole」リンクが表示されること
- [ ] クリックで `https://x.com/pokemonmanhole` が新しいタブで開くこと
- [ ] ログイン/未ログイン両方でリンクが表示されること
- [ ] GA4でクリック時に `p_footer_x_click` イベントが送信されること（is_logged_in が正しく設定されること）
- [ ] モバイル表示でドロワーの高さが圧迫感なく収まること
- [ ] クリックイベントの重複送信がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)