### PR TITLE
Add production sitemap entries

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,10 @@
 import { MetadataRoute } from 'next';
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pokefuta.example.com';
+const baseUrl = (
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  'https://pokefuta.com'
+).replace(/\/$/, '');
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -10,6 +14,8 @@ export default function robots(): MetadataRoute.Robots {
         allow: '/',
         disallow: [
           '/api/',           // APIエンドポイント
+          '/login',          // 認証ページ
+          '/signup',         // 認証ページ
           '/upload',         // アップロードページ（認証が必要）
           '/visits',         // 個人の訪問記録（認証が必要）
         ],

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -14,6 +14,7 @@ export default function robots(): MetadataRoute.Robots {
         allow: '/',
         disallow: [
           '/api/',           // APIエンドポイント
+          '/api-docs',       // 開発環境向けAPIドキュメント
           '/login',          // 認証ページ
           '/signup',         // 認証ページ
           '/upload',         // アップロードページ（認証が必要）

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -51,12 +51,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily',
       priority: 0.7,
     },
-    {
-      url: `${baseUrl}/api-docs`,
-      lastModified,
-      changeFrequency: 'monthly',
-      priority: 0.4,
-    },
   ];
 
   let dynamicPages: MetadataRoute.Sitemap = [];
@@ -71,6 +65,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       const { data: manholes, error } = await supabase
         .from('manhole')
         .select('id, created_at')
+        .eq('is_active', true)
         .order('id', { ascending: true });
 
       if (error) {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,74 +2,63 @@ import { MetadataRoute } from 'next';
 import { createClient } from '@supabase/supabase-js';
 import { Database } from '@/types/database';
 
-const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://pokefuta.example.com';
+const baseUrl = (
+  process.env.NEXT_PUBLIC_SITE_URL ||
+  process.env.NEXT_PUBLIC_APP_URL ||
+  'https://pokefuta.com'
+).replace(/\/$/, '');
+
+export const revalidate = 86400;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  // 静的ページ
+  const lastModified = new Date();
+
+  // Public pages suitable for search indexing.
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: baseUrl,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'daily',
       priority: 1.0,
     },
     {
       url: `${baseUrl}/about`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.8,
     },
     {
       url: `${baseUrl}/map`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'weekly',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/manholes`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'daily',
       priority: 0.9,
     },
     {
       url: `${baseUrl}/nearby`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'weekly',
       priority: 0.7,
     },
     {
-      url: `${baseUrl}/login`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/signup`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.5,
-    },
-    {
-      url: `${baseUrl}/upload`,
-      lastModified: new Date(),
-      changeFrequency: 'monthly',
-      priority: 0.6,
-    },
-    {
-      url: `${baseUrl}/visits`,
-      lastModified: new Date(),
-      changeFrequency: 'weekly',
+      url: `${baseUrl}/popular`,
+      lastModified,
+      changeFrequency: 'daily',
       priority: 0.7,
     },
     {
       url: `${baseUrl}/api-docs`,
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: 'monthly',
       priority: 0.4,
     },
   ];
 
-  // 動的ページ（マンホール詳細ページ）
   let dynamicPages: MetadataRoute.Sitemap = [];
 
   try {
@@ -79,16 +68,19 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     if (supabaseUrl && supabaseKey && !supabaseUrl.includes('dummy')) {
       const supabase = createClient<Database>(supabaseUrl, supabaseKey);
 
-      // 全マンホールのIDと更新日時を取得
-      const { data: manholes } = await supabase
+      const { data: manholes, error } = await supabase
         .from('manhole')
-        .select('id, updated_at, created_at')
+        .select('id, created_at')
         .order('id', { ascending: true });
 
+      if (error) {
+        throw error;
+      }
+
       if (manholes && manholes.length > 0) {
-        dynamicPages = manholes.map((manhole: { id: number; updated_at: string; created_at: string }) => ({
+        dynamicPages = manholes.map((manhole: { id: number; created_at: string }) => ({
           url: `${baseUrl}/manhole/${manhole.id}`,
-          lastModified: new Date(manhole.updated_at || manhole.created_at),
+          lastModified: new Date(manhole.created_at),
           changeFrequency: 'weekly' as const,
           priority: 0.8,
         }));
@@ -96,7 +88,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   } catch (error) {
     console.error('Error fetching manholes for sitemap:', error);
-    // エラーが発生しても静的ページのサイトマップは返す
   }
 
   return [...staticPages, ...dynamicPages];


### PR DESCRIPTION
## Summary
- Use the configured public app URL, with `https://pokefuta.com` as the production fallback, for sitemap and robots output.
- Keep the sitemap focused on indexable public pages, add `/popular`, and remove auth/private/dev-only pages.
- Include active manhole detail URLs from Supabase using the production-safe `created_at` column and revalidate daily.
- Keep robots.txt aligned with non-indexable auth/private/API/dev-doc routes.

## Verification
- `npm run type-check`
- `git diff --check`
- `npm run build`
- Confirmed generated `.next/server/app/sitemap.xml.body` includes `/popular` and `/manhole/{id}` entries, with `/api-docs` excluded.

## Notes
- Existing Next.js dynamic API warnings appear during build for cookie/request-url routes, but the build completes successfully.