### PR TITLE
Add photos and stats to manhole cards

### DIFF
--- a/database/migrations/009_add_manhole_photo_summaries.sql
+++ b/database/migrations/009_add_manhole_photo_summaries.sql
@@ -1,0 +1,62 @@
+-- ==========================================
+-- ポケふた - マンホール別写真集計
+-- ==========================================
+-- 目的: /api/manholes でカード用の写真枚数と最新写真をDB側で集計する
+
+CREATE OR REPLACE FUNCTION public.get_manhole_photo_summaries(p_manhole_ids INTEGER[])
+RETURNS TABLE(
+  manhole_id INTEGER,
+  photo_count BIGINT,
+  latest_photo_id UUID,
+  latest_storage_key TEXT,
+  latest_thumbnail_320 TEXT,
+  latest_thumbnail_800 TEXT,
+  latest_thumbnail_1600 TEXT
+)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH filtered_photos AS (
+    SELECT
+      p.id,
+      p.manhole_id,
+      p.storage_key,
+      p.thumbnail_320,
+      p.thumbnail_800,
+      p.thumbnail_1600,
+      p.created_at
+    FROM public.photo p
+    WHERE p.manhole_id = ANY(p_manhole_ids)
+  ),
+  counts AS (
+    SELECT
+      fp.manhole_id,
+      COUNT(*)::BIGINT AS photo_count
+    FROM filtered_photos fp
+    GROUP BY fp.manhole_id
+  ),
+  latest AS (
+    SELECT DISTINCT ON (fp.manhole_id)
+      fp.manhole_id,
+      fp.id AS latest_photo_id,
+      fp.storage_key AS latest_storage_key,
+      fp.thumbnail_320 AS latest_thumbnail_320,
+      fp.thumbnail_800 AS latest_thumbnail_800,
+      fp.thumbnail_1600 AS latest_thumbnail_1600
+    FROM filtered_photos fp
+    ORDER BY fp.manhole_id, fp.created_at DESC, fp.id DESC
+  )
+  SELECT
+    c.manhole_id,
+    c.photo_count,
+    l.latest_photo_id,
+    l.latest_storage_key,
+    l.latest_thumbnail_320,
+    l.latest_thumbnail_800,
+    l.latest_thumbnail_1600
+  FROM counts c
+  JOIN latest l ON l.manhole_id = c.manhole_id;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.get_manhole_photo_summaries(INTEGER[]) TO anon, authenticated;

--- a/src/app/api/manholes/route.ts
+++ b/src/app/api/manholes/route.ts
@@ -6,54 +6,64 @@ import { extractCoordinatesFromWKB, calculateDistance } from '@/lib/location';
 
 type ManholePhotoSummary = {
   count: number;
-  latestPhotoId: string | null;
+  latestPhotoUrl: string | null;
 };
 
-const PHOTO_SUMMARY_BATCH_SIZE = 1000;
+type ManholePhotoSummaryRow =
+  Database['public']['Functions']['get_manhole_photo_summaries']['Returns'][number];
+
+function encodeStorageKey(key: string) {
+  return key.split('/').map(part => encodeURIComponent(part)).join('/');
+}
+
+function buildPublicStorageUrl(key: string | null) {
+  if (!key) return null;
+
+  const publicUrl = process.env.R2_PUBLIC_URL || process.env.R2_ENDPOINT;
+  const bucket = process.env.R2_BUCKET || 'image';
+
+  if (!publicUrl) return null;
+
+  const baseUrl = publicUrl.replace(/\/$/, '');
+  const encodedKey = encodeStorageKey(key);
+
+  if (baseUrl.includes('r2.cloudflarestorage.com')) {
+    return `${baseUrl}/${bucket}/${encodedKey}`;
+  }
+
+  return `${baseUrl}/${encodedKey}`;
+}
 
 async function loadPhotoSummaries(
   supabase: ReturnType<typeof createRouteHandlerClient<Database>>,
   manholeIds: number[]
 ) {
-  const summaries = new Map<number, ManholePhotoSummary>();
-  let offset = 0;
-
-  while (true) {
-    const { data: photosData, error } = await supabase
-      .from('photo')
-      .select('id, manhole_id, created_at')
-      .in('manhole_id', manholeIds)
-      .not('manhole_id', 'is', null)
-      .order('created_at', { ascending: false })
-      .range(offset, offset + PHOTO_SUMMARY_BATCH_SIZE - 1);
-
-    if (error) {
-      console.error('Photo summary query error:', error);
-      throw new Error(`Photo summary query failed: ${error.message}`);
-    }
-
-    if (!photosData || photosData.length === 0) {
-      break;
-    }
-
-    photosData.forEach(photo => {
-      const current = summaries.get(photo.manhole_id) || {
-        count: 0,
-        latestPhotoId: null,
-      };
-      current.count += 1;
-      if (!current.latestPhotoId) {
-        current.latestPhotoId = photo.id;
-      }
-      summaries.set(photo.manhole_id, current);
-    });
-
-    if (photosData.length < PHOTO_SUMMARY_BATCH_SIZE) {
-      break;
-    }
-
-    offset += PHOTO_SUMMARY_BATCH_SIZE;
+  if (manholeIds.length === 0) {
+    return new Map<number, ManholePhotoSummary>();
   }
+
+  const { data, error } = await supabase.rpc('get_manhole_photo_summaries', {
+    p_manhole_ids: manholeIds,
+  });
+
+  if (error) {
+    console.error('Photo summary RPC error:', error);
+    throw new Error(`Photo summary RPC failed: ${error.message}`);
+  }
+
+  const summaries = new Map<number, ManholePhotoSummary>();
+  ((data || []) as ManholePhotoSummaryRow[]).forEach(summary => {
+    const latestStorageKey =
+      summary.latest_thumbnail_320 ||
+      summary.latest_thumbnail_800 ||
+      summary.latest_thumbnail_1600 ||
+      summary.latest_storage_key;
+
+    summaries.set(summary.manhole_id, {
+      count: Number(summary.photo_count || 0),
+      latestPhotoUrl: buildPublicStorageUrl(latestStorageKey),
+    });
+  });
 
   return summaries;
 }
@@ -242,9 +252,7 @@ export async function GET(request: NextRequest) {
               is_visited: isVisited,
               last_visit: visitData?.last_visit || null,
               photo_count: photoSummary?.count || 0,
-              latest_photo_url: photoSummary?.latestPhotoId
-                ? `/api/photo/${photoSummary.latestPhotoId}?size=small`
-                : null,
+              latest_photo_url: photoSummary?.latestPhotoUrl || null,
               distance: distance
             };
           })
@@ -291,9 +299,7 @@ export async function GET(request: NextRequest) {
             is_visited: isVisited,
             last_visit: visitData?.last_visit || null,
             photo_count: photoSummary?.count || 0,
-            latest_photo_url: photoSummary?.latestPhotoId
-              ? `/api/photo/${photoSummary.latestPhotoId}?size=small`
-              : null
+            latest_photo_url: photoSummary?.latestPhotoUrl || null
           };
         })
         .filter(manhole => manhole !== null)

--- a/src/app/api/manholes/route.ts
+++ b/src/app/api/manholes/route.ts
@@ -4,6 +4,60 @@ import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { extractCoordinatesFromWKB, calculateDistance } from '@/lib/location';
 
+type ManholePhotoSummary = {
+  count: number;
+  latestPhotoId: string | null;
+};
+
+const PHOTO_SUMMARY_BATCH_SIZE = 1000;
+
+async function loadPhotoSummaries(
+  supabase: ReturnType<typeof createRouteHandlerClient<Database>>,
+  manholeIds: number[]
+) {
+  const summaries = new Map<number, ManholePhotoSummary>();
+  let offset = 0;
+
+  while (true) {
+    const { data: photosData, error } = await supabase
+      .from('photo')
+      .select('id, manhole_id, created_at')
+      .in('manhole_id', manholeIds)
+      .not('manhole_id', 'is', null)
+      .order('created_at', { ascending: false })
+      .range(offset, offset + PHOTO_SUMMARY_BATCH_SIZE - 1);
+
+    if (error) {
+      console.error('Photo summary query error:', error);
+      throw new Error(`Photo summary query failed: ${error.message}`);
+    }
+
+    if (!photosData || photosData.length === 0) {
+      break;
+    }
+
+    photosData.forEach(photo => {
+      const current = summaries.get(photo.manhole_id) || {
+        count: 0,
+        latestPhotoId: null,
+      };
+      current.count += 1;
+      if (!current.latestPhotoId) {
+        current.latestPhotoId = photo.id;
+      }
+      summaries.set(photo.manhole_id, current);
+    });
+
+    if (photosData.length < PHOTO_SUMMARY_BATCH_SIZE) {
+      break;
+    }
+
+    offset += PHOTO_SUMMARY_BATCH_SIZE;
+  }
+
+  return summaries;
+}
+
 /**
  * @swagger
  * /api/manholes:
@@ -158,17 +212,8 @@ export async function GET(request: NextRequest) {
         });
       }
 
-      // 取得したマンホールの写真有無を確認
       const manholeIds = allManholes.map(m => m.id);
-      const { data: photosData } = await supabase
-        .from('photo')
-        .select('manhole_id')
-        .in('manhole_id', manholeIds)
-        .not('manhole_id', 'is', null);
-
-      const manholesWithPhotosSet = new Set(
-        photosData?.map(p => p.manhole_id) || []
-      );
+      const photoSummaryByManholeId = await loadPhotoSummaries(supabase, manholeIds);
 
       if (isNearbySearch) {
         console.log(`Searching for manholes within ${radius}km of ${lat}, ${lng}`);
@@ -184,7 +229,7 @@ export async function GET(request: NextRequest) {
 
             const distance = calculateDistance(lat!, lng!, realCoords.lat, realCoords.lng);
 
-            const hasPhotos = manholesWithPhotosSet.has(manhole.id);
+            const photoSummary = photoSummaryByManholeId.get(manhole.id);
             const isVisited = visitedManholeIds.has(manhole.id);
             const visitData = visitedManholeData.get(manhole.id);
 
@@ -196,7 +241,10 @@ export async function GET(request: NextRequest) {
               longitude: realCoords.lng,
               is_visited: isVisited,
               last_visit: visitData?.last_visit || null,
-              photo_count: hasPhotos ? 1 : 0,
+              photo_count: photoSummary?.count || 0,
+              latest_photo_url: photoSummary?.latestPhotoId
+                ? `/api/photo/${photoSummary.latestPhotoId}?size=small`
+                : null,
               distance: distance
             };
           })
@@ -230,7 +278,7 @@ export async function GET(request: NextRequest) {
             return null; // Skip manholes without extractable coordinates
           }
 
-          const hasPhotos = manholesWithPhotosSet.has(manhole.id);
+          const photoSummary = photoSummaryByManholeId.get(manhole.id);
           const isVisited = visitedManholeIds.has(manhole.id);
           const visitData = visitedManholeData.get(manhole.id);
 
@@ -242,7 +290,10 @@ export async function GET(request: NextRequest) {
             longitude: realCoords.lng,
             is_visited: isVisited,
             last_visit: visitData?.last_visit || null,
-            photo_count: hasPhotos ? 1 : 0
+            photo_count: photoSummary?.count || 0,
+            latest_photo_url: photoSummary?.latestPhotoId
+              ? `/api/photo/${photoSummary.latestPhotoId}?size=small`
+              : null
           };
         })
         .filter(manhole => manhole !== null)

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
-import { Camera, MapPin, Search } from 'lucide-react';
+import { Camera, Image as ImageIcon, MapPin, Search } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import { createBrowserClient } from '@/lib/supabase/client';
@@ -81,7 +81,15 @@ export default function ManholesPage() {
   }, [filteredManholes, query]);
 
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
-  const prefectureCount = new Set(manholes.map((manhole) => manhole.prefecture).filter(Boolean)).size;
+  const visiblePrefectureCount = new Set(filteredManholes.map((manhole) => manhole.prefecture).filter(Boolean)).size;
+  const visibleMunicipalityCount = new Set(
+    filteredManholes
+      .map((manhole) => manhole.municipality || manhole.city)
+      .filter(Boolean)
+  ).size;
+  const visiblePokemonCount = new Set(
+    filteredManholes.flatMap((manhole) => manhole.pokemons || []).filter(Boolean)
+  ).size;
 
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
@@ -121,18 +129,22 @@ export default function ManholesPage() {
             </Link>
           </div>
 
-          <div className="mt-4 grid grid-cols-3 gap-3">
+          <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
             <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
               <div className="text-xl font-extrabold leading-none text-[#7B63A8]">{manholes.length}</div>
               <div className="mt-1 text-xs font-bold text-[#6B6B6B]">総数</div>
             </div>
             <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-              <div className="text-xl font-extrabold leading-none text-[#FF8F1F]">{prefectureCount}</div>
+              <div className="text-xl font-extrabold leading-none text-[#FF8F1F]">{visiblePrefectureCount}</div>
               <div className="mt-1 text-xs font-bold text-[#6B6B6B]">都道府県</div>
             </div>
             <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-              <div className="text-xl font-extrabold leading-none text-[#2D846C]">{filteredManholes.length}</div>
-              <div className="mt-1 text-xs font-bold text-[#6B6B6B]">表示中</div>
+              <div className="text-xl font-extrabold leading-none text-[#2D846C]">{visibleMunicipalityCount}</div>
+              <div className="mt-1 text-xs font-bold text-[#6B6B6B]">市町村</div>
+            </div>
+            <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
+              <div className="text-xl font-extrabold leading-none text-[#D94F70]">{visiblePokemonCount}</div>
+              <div className="mt-1 text-xs font-bold text-[#6B6B6B]">ポケモン種類</div>
             </div>
           </div>
         </section>
@@ -152,39 +164,61 @@ export default function ManholesPage() {
                 <Link
                   key={manhole.id}
                   href={`/manhole/${manhole.id}`}
-                  className="rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
+                  className="overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg"
                 >
-                  <div className="mb-3 flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
-                        {manhole.title || `${manhole.prefecture || ''}${manhole.municipality || manhole.city || ''}`}
-                      </h2>
-                      <p className="mt-1 text-xs font-bold text-[#6B6B6B]">
-                        {manhole.prefecture} {manhole.municipality || manhole.city || ''}
-                      </p>
-                    </div>
-                    <span className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-sm font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">
-                      #{manhole.id}
+                  <div className="relative aspect-[16/9] bg-[#F6EEDC]">
+                    {manhole.latest_photo_url ? (
+                      <img
+                        src={manhole.latest_photo_url}
+                        alt={`${manhole.title || manhole.municipality || manhole.city || 'ポケふた'}の写真`}
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center bg-[linear-gradient(135deg,#FFF8EB_0%,#F6EEDC_52%,#E7F1EC_100%)]">
+                        <div className="flex h-14 w-14 items-center justify-center rounded-full border border-[#7B63A8]/15 bg-white/70 text-[#7B63A8] shadow-sm">
+                          <ImageIcon className="h-7 w-7" />
+                        </div>
+                      </div>
+                    )}
+                    <span className="absolute bottom-2 right-2 rounded-full bg-white/95 px-2.5 py-1 text-xs font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">
+                      写真 {manhole.photo_count || 0}枚
                     </span>
                   </div>
 
-                  {manhole.pokemons && manhole.pokemons.length > 0 && (
-                    <div className="flex flex-wrap gap-1.5">
-                      {manhole.pokemons.slice(0, 4).map((pokemon, index) => (
-                        <span
-                          key={`${manhole.id}-${pokemon}-${index}`}
-                          className="rounded-full bg-[#FFB347]/25 px-2.5 py-1 text-xs font-bold text-[#2A2A2A]"
-                        >
-                          {pokemon}
-                        </span>
-                      ))}
-                      {manhole.pokemons.length > 4 && (
-                        <span className="px-1 py-1 text-xs font-bold text-[#6B6B6B]">
-                          +{manhole.pokemons.length - 4}
-                        </span>
-                      )}
+                  <div className="p-4">
+                    <div className="mb-3 flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
+                          {manhole.title || `${manhole.prefecture || ''}${manhole.municipality || manhole.city || ''}`}
+                        </h2>
+                        <p className="mt-1 text-xs font-bold text-[#6B6B6B]">
+                          {manhole.prefecture} {manhole.municipality || manhole.city || ''}
+                        </p>
+                      </div>
+                      <span className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-sm font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">
+                        #{manhole.id}
+                      </span>
                     </div>
-                  )}
+
+                    {manhole.pokemons && manhole.pokemons.length > 0 && (
+                      <div className="flex flex-wrap gap-1.5">
+                        {manhole.pokemons.slice(0, 4).map((pokemon, index) => (
+                          <span
+                            key={`${manhole.id}-${pokemon}-${index}`}
+                            className="rounded-full bg-[#FFB347]/25 px-2.5 py-1 text-xs font-bold text-[#2A2A2A]"
+                          >
+                            {pokemon}
+                          </span>
+                        ))}
+                        {manhole.pokemons.length > 4 && (
+                          <span className="px-1 py-1 text-xs font-bold text-[#6B6B6B]">
+                            +{manhole.pokemons.length - 4}
+                          </span>
+                        )}
+                      </div>
+                    )}
+                  </div>
                 </Link>
               ))}
             </div>

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
+import Image from 'next/image';
 import { Camera, Image as ImageIcon, MapPin, Search } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
@@ -81,6 +82,7 @@ export default function ManholesPage() {
   }, [filteredManholes, query]);
 
   const uploadHref = isLoggedIn ? '/upload' : '/login?redirect=/upload';
+  const visibleManholeCount = filteredManholes.length;
   const visiblePrefectureCount = new Set(filteredManholes.map((manhole) => manhole.prefecture).filter(Boolean)).size;
   const visibleMunicipalityCount = new Set(
     filteredManholes
@@ -131,7 +133,7 @@ export default function ManholesPage() {
 
           <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
             <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-              <div className="text-xl font-extrabold leading-none text-[#7B63A8]">{manholes.length}</div>
+              <div className="text-xl font-extrabold leading-none text-[#7B63A8]">{visibleManholeCount}</div>
               <div className="mt-1 text-xs font-bold text-[#6B6B6B]">総数</div>
             </div>
             <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
@@ -168,10 +170,12 @@ export default function ManholesPage() {
                 >
                   <div className="relative aspect-[16/9] bg-[#F6EEDC]">
                     {manhole.latest_photo_url ? (
-                      <img
+                      <Image
                         src={manhole.latest_photo_url}
                         alt={`${manhole.title || manhole.municipality || manhole.city || 'ポケふた'}の写真`}
-                        className="h-full w-full object-cover"
+                        fill
+                        sizes="(min-width: 1280px) 33vw, (min-width: 768px) 50vw, 100vw"
+                        className="object-cover"
                         loading="lazy"
                       />
                     ) : (

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -522,4 +522,5 @@ export type Manhole = Database['public']['Tables']['manhole']['Row'] & {
   is_visited?: boolean;
   last_visit?: string | null;
   photo_count?: number;
+  latest_photo_url?: string | null;
 };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -393,6 +393,20 @@ export interface Database {
       };
     };
     Functions: {
+      get_manhole_photo_summaries: {
+        Args: {
+          p_manhole_ids: number[];
+        };
+        Returns: {
+          manhole_id: number;
+          photo_count: number;
+          latest_photo_id: string;
+          latest_storage_key: string;
+          latest_thumbnail_320: string | null;
+          latest_thumbnail_800: string | null;
+          latest_thumbnail_1600: string | null;
+        }[];
+      };
       get_unvisited_manholes: {
         Args: {
           user_uuid: string;


### PR DESCRIPTION
## Summary
- Add latest submitted photo thumbnails and per-manhole photo counts to `/manholes` cards.
- Replace the displayed-count stat with filtered total, prefecture, municipality, and Pokemon species counts.
- Move manhole photo summary aggregation into a Postgres RPC so `/api/manholes` fetches grouped counts/latest photo metadata in one bounded server-side query.
- Return direct public storage URLs and render cards with `next/image` instead of routing every card image through `/api/photo`.

## Review Response
- Added deterministic DB-side latest photo selection with `ORDER BY created_at DESC, id DESC` inside `get_manhole_photo_summaries`.
- Removed offset pagination and long `.in()` photo-row scans from the route handler.
- Avoided per-card `/api/photo` redirects by returning public R2 URLs from `/api/manholes`.
- Switched card images from plain `<img>` to `next/image`.
- Made the stat row use the same filtered result set for all four values.

## Verification
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Notes
- Added migration `database/migrations/009_add_manhole_photo_summaries.sql`.
- Existing build warnings remain for dynamic API routes and missing `metadataBase`, but the build completes successfully.