### PR TITLE
Track API errors in Google Analytics

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Script from 'next/script';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import DevDebugPanel from '@/components/DevDebugPanel';
+import ApiErrorAnalytics from '@/components/ApiErrorAnalytics';
 
 import { SITE_NAME, OGP_IMAGE_URL } from '@/lib/constants';
 
@@ -96,6 +97,7 @@ export default function RootLayout({
       </head>
       <body className={`${inter.className} antialiased`}>
         <div id="app" className="min-h-screen bg-[#F6EEDC]">
+          <ApiErrorAnalytics />
           {children}
           <DevDebugPanel />
         </div>

--- a/src/components/ApiErrorAnalytics.tsx
+++ b/src/components/ApiErrorAnalytics.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect } from 'react';
+import { errorEvents } from '@/lib/analytics/gtag';
+
+const API_ERROR_ANALYTICS_PATCHED = Symbol.for('pokefuta.apiErrorAnalyticsPatched');
+
+type PatchedWindow = Window & {
+  [API_ERROR_ANALYTICS_PATCHED]?: boolean;
+};
+
+function getApiPath(input: RequestInfo | URL): string | null {
+  const rawUrl =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+  try {
+    const url = new URL(rawUrl, window.location.origin);
+
+    if (url.origin !== window.location.origin || !url.pathname.startsWith('/api/')) {
+      return null;
+    }
+
+    return url.pathname;
+  } catch {
+    return null;
+  }
+}
+
+function getMethod(input: RequestInfo | URL, init?: RequestInit): string {
+  if (init?.method) return init.method.toUpperCase();
+  if (typeof input === 'object' && 'method' in input && input.method) {
+    return input.method.toUpperCase();
+  }
+  return 'GET';
+}
+
+export default function ApiErrorAnalytics() {
+  useEffect(() => {
+    const patchedWindow = window as PatchedWindow;
+
+    if (patchedWindow[API_ERROR_ANALYTICS_PATCHED]) return;
+    patchedWindow[API_ERROR_ANALYTICS_PATCHED] = true;
+
+    const originalFetch = window.fetch.bind(window);
+
+    window.fetch = async (input, init) => {
+      const apiPath = getApiPath(input);
+      const method = getMethod(input, init);
+
+      try {
+        const response = await originalFetch(input, init);
+
+        if (apiPath && !response.ok) {
+          errorEvents.api(apiPath, response.status, method, response.statusText);
+        }
+
+        return response;
+      } catch (error) {
+        if (apiPath) {
+          errorEvents.api(
+            apiPath,
+            0,
+            method,
+            error instanceof Error ? error.message : 'Network request failed'
+          );
+        }
+
+        throw error;
+      }
+    };
+  }, []);
+
+  return null;
+}

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -24,6 +24,14 @@ export interface PokefutaEventParams extends GAEventParams {
   source_app?: 'tracker' | 'map';
 }
 
+export interface ApiErrorEventParams extends GAEventParams {
+  api_path: string;
+  endpoint?: string;
+  status_code: number;
+  method: string;
+  error_message?: string;
+}
+
 // ==========================================
 // グローバル型拡張
 // ==========================================
@@ -211,13 +219,20 @@ export const pokefutaEvents = {
 // ==========================================
 
 export const errorEvents = {
-  api: (endpoint: string, statusCode: number, method: string = 'GET') =>
+  api: (
+    endpoint: string,
+    statusCode: number,
+    method: string = 'GET',
+    errorMessage?: string
+  ) =>
     trackEvent('error_event', {
       error_type: 'api_error',
+      api_path: endpoint,
       endpoint,
       status_code: statusCode,
       method,
-    }),
+      error_message: errorMessage?.slice(0, 100),
+    } satisfies ApiErrorEventParams),
 
   auth: (errorCode: string) =>
     trackEvent('auth_error', { error_code: errorCode }),


### PR DESCRIPTION
## Summary
- Add a client-side fetch wrapper that reports same-origin `/api/` failures to GA4.
- Include API path, method, status code, and a short error message in `error_event` params.
- Mount the tracker globally from the root layout.

## Verification
- `npm run type-check`
- `npm run build`

## Notes
- Existing Next.js dynamic route and metadataBase warnings appeared during build, but the build completed successfully.