### PR TITLE
Fix Japanese OGP font rendering

### DIFF
--- a/public/ogp/fonts/LICENSE-NotoSansCJK.txt
+++ b/public/ogp/fonts/LICENSE-NotoSansCJK.txt
@@ -1,0 +1,106 @@
+Noto Sans CJK JP Bold
+
+Copyright notice:
+© 2014-2021 Adobe (http://www.adobe.com/).
+
+Trademark notice:
+Noto is a trademark of Google Inc.
+
+Designers:
+Ryoko NISHIZUKA 西塚涼子 (kana, bopomofo & ideographs);
+Paul D. Hunt (Latin, Greek & Cyrillic);
+Sandoll Communications 산돌커뮤니케이션, Soo-young JANG 장수영 &
+Joo-yeon KANG 강주연 (hangul elements, letters & syllables).
+
+This Font Software is licensed under the SIL Open Font License,
+Version 1.1.
+
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
+
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font
+creation efforts of academic and linguistic communities, and to
+provide a free and open framework in which fonts may be shared and
+improved in partnership with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply to
+any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software
+components as distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to,
+deleting, or substituting -- in part or in whole -- any of the
+components of the Original Version, by changing formats or by porting
+the Font Software to a new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed,
+modify, redistribute, and sell modified and unmodified copies of the
+Font Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components, in
+Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the
+corresponding Copyright Holder. This restriction only applies to the
+primary font name as presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created using
+the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/public/ogp/pokefuta_ogp_template.svg
+++ b/public/ogp/pokefuta_ogp_template.svg
@@ -1,5 +1,6 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
   <defs>
+    <style>{{fontFaceCss}}</style>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#000000" flood-opacity="0.24"/>
     </filter>
@@ -24,34 +25,34 @@
   <g filter="url(#shadow)">
     <rect x="70" y="420" width="330" height="54" rx="10" fill="#17614F"/>
     <path d="M400 420 L438 447 L400 474 Z" fill="#17614F"/>
-    <text x="100" y="456" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">📷 MY POKEFUTA PHOTO</text>
+    <text x="100" y="456" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">📷 MY POKEFUTA PHOTO</text>
   </g>
 
   <g transform="translate(535 56) rotate(-3)">
     <rect x="0" y="0" width="205" height="50" rx="8" fill="#17614F"/>
     <rect x="8" y="8" width="189" height="34" rx="5" fill="none" stroke="#F3E0A8" stroke-width="2" stroke-dasharray="8 5"/>
-    <text x="102" y="34" text-anchor="middle" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">{{prefecture}}</text>
+    <text x="102" y="34" text-anchor="middle" font-family="'Pokefuta OGP JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">{{prefecture}}</text>
   </g>
 
-  <text x="520" y="185" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="64" font-weight="950" fill="#3A2C22" filter="url(#titleShadow)">{{city}}のポケふた</text>
+  <text x="520" y="185" font-family="'Pokefuta OGP JP', sans-serif" font-size="64" font-weight="950" fill="#3A2C22" filter="url(#titleShadow)">{{city}}のポケふた</text>
   <rect x="520" y="202" width="430" height="18" rx="9" fill="#F2CD45" opacity="0.75"/>
 
-  <text x="528" y="265" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="33" font-weight="900" fill="#17614F">{{pokemonNames}}</text>
+  <text x="528" y="265" font-family="'Pokefuta OGP JP', sans-serif" font-size="33" font-weight="900" fill="#17614F">{{pokemonNames}}</text>
 
   <g filter="url(#shadow)">
     <rect x="520" y="304" width="475" height="68" rx="34" fill="#FFF9EA"/>
     <rect x="535" y="316" width="445" height="44" rx="22" fill="none" stroke="#B88950" stroke-width="2" stroke-dasharray="9 5"/>
-    <text x="560" y="348" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="29" font-weight="950" fill="#17614F">{{badgeEmoji}} {{badgeLabel}}</text>
+    <text x="560" y="348" font-family="'Pokefuta OGP JP', sans-serif" font-size="29" font-weight="950" fill="#17614F">{{badgeEmoji}} {{badgeLabel}}</text>
   </g>
 
-  <text x="520" y="440" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="31" font-weight="900" fill="#2F241C">旅先で見つける、全国のポケふたマップ</text>
+  <text x="520" y="440" font-family="'Pokefuta OGP JP', sans-serif" font-size="31" font-weight="900" fill="#2F241C">旅先で見つける、全国のポケふたマップ</text>
 
-  <text x="90" y="585" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">旅行・お出かけ・聖地巡りのお供に！</text>
-  <text x="520" y="585" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">{{statsLabel}}</text>
+  <text x="90" y="585" font-family="'Pokefuta OGP JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">旅行・お出かけ・聖地巡りのお供に！</text>
+  <text x="520" y="585" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">{{statsLabel}}</text>
 
   <g filter="url(#shadow)">
     <rect x="900" y="553" width="240" height="50" rx="25" fill="#FFF9EA"/>
-    <text x="1012" y="586" text-anchor="middle" font-family="system-ui, -apple-system, 'Noto Sans JP', sans-serif" font-size="25" font-weight="950" fill="#17614F">pokefuta.com</text>
+    <text x="1012" y="586" text-anchor="middle" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="950" fill="#17614F">pokefuta.com</text>
     <circle cx="1120" cy="578" r="18" fill="#1C2E28"/>
     <path d="M1115 568 L1115 588 L1130 578 Z" fill="#FFFFFF"/>
   </g>

--- a/src/app/manhole/[id]/opengraph-image/route.ts
+++ b/src/app/manhole/[id]/opengraph-image/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import sharp from 'sharp';
 import { SITE_NAME } from '@/lib/constants';
-import { renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
+import { OGP_FONT_FAMILY, getOgpFontFaceCss, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
 import {
   loadManholeForOgp,
   loadPhotoForOgp,
@@ -22,24 +22,32 @@ function escapeXml(value: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function buildFallbackSvg(locationLabel: string): Buffer {
+async function buildFallbackSvg(locationLabel: string): Promise<Buffer> {
+  const fontFaceCss = await getOgpFontFaceCss();
   const safeLabel = escapeXml(locationLabel.length > 20 ? `${locationLabel.slice(0, 19)}…` : locationLabel);
   const svg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <style>${fontFaceCss}</style>
+    </defs>
     <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
     <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
-    <text x="100" y="280" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="64" font-weight="900" fill="#4F3828">${safeLabel}のポケふた</text>
-    <text x="104" y="360" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つける全国のポケモンマンホール</text>
-    <text x="104" y="420" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="28" font-weight="700" fill="#5D6E68">pokefuta.com</text>
+    <text x="100" y="280" font-family="${OGP_FONT_FAMILY}" font-size="64" font-weight="900" fill="#4F3828">${safeLabel}のポケふた</text>
+    <text x="104" y="360" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つける全国のポケモンマンホール</text>
+    <text x="104" y="420" font-family="${OGP_FONT_FAMILY}" font-size="28" font-weight="700" fill="#5D6E68">pokefuta.com</text>
   </svg>`;
   return Buffer.from(svg);
 }
 
-function buildDefaultFallback(): Buffer {
+async function buildDefaultFallback(): Promise<Buffer> {
+  const fontFaceCss = await getOgpFontFaceCss();
   const svg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <style>${fontFaceCss}</style>
+    </defs>
     <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
     <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
-    <text x="100" y="300" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
-    <text x="104" y="370" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
+    <text x="100" y="300" font-family="${OGP_FONT_FAMILY}" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
+    <text x="104" y="370" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
   </svg>`;
   return Buffer.from(svg);
 }
@@ -54,14 +62,14 @@ export async function GET(
 ) {
   const manholeId = Number(params.id);
   if (isNaN(manholeId)) {
-    return new Response(await renderFallbackPng(buildDefaultFallback()) as unknown as BodyInit, {
+    return new Response(await renderFallbackPng(await buildDefaultFallback()) as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });
   }
 
   const manhole = await loadManholeForOgp(manholeId);
   if (!manhole) {
-    return new Response(await renderFallbackPng(buildDefaultFallback()) as unknown as BodyInit, {
+    return new Response(await renderFallbackPng(await buildDefaultFallback()) as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });
   }
@@ -78,7 +86,7 @@ export async function GET(
   }
 
   if (!photo?.signed_url) {
-    const png = await renderFallbackPng(buildFallbackSvg(locationLabel));
+    const png = await renderFallbackPng(await buildFallbackSvg(locationLabel));
     return new Response(png as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400' },
     });
@@ -112,7 +120,7 @@ export async function GET(
     });
   } catch (error) {
     console.error('Failed to render manhole OGP:', error);
-    const png = await renderFallbackPng(buildFallbackSvg(locationLabel));
+    const png = await renderFallbackPng(await buildFallbackSvg(locationLabel));
     return new Response(png as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });

--- a/src/app/manhole/[id]/page.tsx
+++ b/src/app/manhole/[id]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next';
 import ManholePage from './ManholePage';
 import { loadManholeForOgp, loadPhotoForOgp } from '@/lib/manhole-ogp';
 import { getManholeLocationLabel, getSortedTitles } from '@/lib/shared-photo';
-import { SITE_NAME, SITE_URL } from '@/lib/constants';
+import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 
 type Props = {
   params: { id: string };
@@ -35,8 +35,8 @@ export async function generateMetadata({ params, searchParams }: Props): Promise
   const pageUrl = `${SITE_URL}/manhole/${manholeId}`;
   const canonicalUrl = validPhotoId ? `${pageUrl}?photo=${validPhotoId}` : pageUrl;
   const ogImageUrl = validPhotoId
-    ? `${SITE_URL}/manhole/${manholeId}/opengraph-image?photo=${validPhotoId}`
-    : `${SITE_URL}/manhole/${manholeId}/opengraph-image`;
+    ? `${SITE_URL}/manhole/${manholeId}/opengraph-image?photo=${validPhotoId}&v=${OGP_IMAGE_VERSION}`
+    : `${SITE_URL}/manhole/${manholeId}/opengraph-image?v=${OGP_IMAGE_VERSION}`;
 
   const title = topTitle
     ? `${topTitle.label} | ${locationLabel}のポケふた | ${SITE_NAME}`

--- a/src/app/p/[photoId]/page.tsx
+++ b/src/app/p/[photoId]/page.tsx
@@ -4,7 +4,7 @@ import { notFound } from 'next/navigation';
 import { ArrowLeft, Camera, MapPin, Sparkles } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import { formatDateJa } from '@/lib/date';
-import { SITE_NAME, SITE_URL } from '@/lib/constants';
+import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import {
   getManholeLocationLabel,
   getSortedTitles,
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     ? photo.visit.comment
     : `${locationLabel}で見つけたポケふた写真です。`;
   const pageUrl = `${SITE_URL}/p/${photo.id}`;
-  const imageUrl = `${pageUrl}/opengraph-image`;
+  const imageUrl = `${pageUrl}/opengraph-image?v=${OGP_IMAGE_VERSION}`;
 
   return {
     title,

--- a/src/app/share/photo/[photoId]/opengraph-image/route.ts
+++ b/src/app/share/photo/[photoId]/opengraph-image/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import sharp from 'sharp';
 import { SITE_NAME } from '@/lib/constants';
-import { renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
+import { OGP_FONT_FAMILY, getOgpFontFaceCss, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
 import {
   getSortedTitles,
   loadPublicSharedPhoto,
@@ -21,12 +21,16 @@ function escapeXml(value: string): string {
 }
 
 async function fallbackImage() {
+  const fontFaceCss = await getOgpFontFaceCss();
   const svg = Buffer.from(`
     <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <style>${fontFaceCss}</style>
+      </defs>
       <rect width="1200" height="630" fill="#F6EEDC" />
       <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4" />
-      <text x="100" y="300" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
-      <text x="104" y="370" font-family="Noto Sans JP, Hiragino Sans, sans-serif" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
+      <text x="100" y="300" font-family="${OGP_FONT_FAMILY}" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
+      <text x="104" y="370" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
     </svg>
   `);
   return sharp(svg).png().toBuffer();

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,4 @@
 export const SITE_NAME = 'ポケふたスタンプ帳';
 export const SITE_URL = 'https://pokefuta.com';
-export const OGP_IMAGE_URL = `${SITE_URL}/opengraph-image`;
+export const OGP_IMAGE_VERSION = '20260520-font';
+export const OGP_IMAGE_URL = `${SITE_URL}/opengraph-image?v=${OGP_IMAGE_VERSION}`;

--- a/src/lib/pokefuta-ogp-template.ts
+++ b/src/lib/pokefuta-ogp-template.ts
@@ -5,8 +5,10 @@ import sharp from 'sharp';
 
 const WIDTH = 1200;
 const HEIGHT = 630;
+const OGP_FONT_PATH = path.join(process.cwd(), 'public', 'ogp', 'fonts', 'NotoSansCJKjp-Bold.otf');
 const TEMPLATE_PATH = path.join(process.cwd(), 'public', 'ogp', 'pokefuta_ogp_template.svg');
 const BACKGROUND_PATH = path.join(process.cwd(), 'public', 'ogp', 'pokefuta_ogp_background_1200x630.png');
+export const OGP_FONT_FAMILY = "'Pokefuta OGP JP', sans-serif";
 
 type PokefutaOgpTemplateInput = {
   photoBuffer: Buffer;
@@ -38,16 +40,27 @@ function imageDataUri(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString('base64')}`;
 }
 
+function fontFaceCss(fontBuffer: Buffer): string {
+  return `@font-face{font-family:'Pokefuta OGP JP';src:url('${imageDataUri(fontBuffer, 'font/otf')}') format('opentype');font-weight:700 950;font-style:normal;font-display:block;}`;
+}
+
 const templateAssetsPromise = Promise.all([
   readFile(TEMPLATE_PATH, 'utf8'),
   readFile(BACKGROUND_PATH),
-]).then(([template, backgroundBuffer]) => ({
+  readFile(OGP_FONT_PATH),
+]).then(([template, backgroundBuffer, fontBuffer]) => ({
   template,
   backgroundDataUri: imageDataUri(backgroundBuffer, 'image/png'),
+  fontFaceCss: fontFaceCss(fontBuffer),
 }));
 
+export async function getOgpFontFaceCss(): Promise<string> {
+  const { fontFaceCss } = await templateAssetsPromise;
+  return fontFaceCss;
+}
+
 export async function renderPokefutaOgpTemplate(input: PokefutaOgpTemplateInput): Promise<Buffer> {
-  const [{ template, backgroundDataUri }, photoBuffer] = await Promise.all([
+  const [{ template, backgroundDataUri, fontFaceCss }, photoBuffer] = await Promise.all([
     templateAssetsPromise,
     sharp(input.photoBuffer)
       .resize(820, 820, { fit: 'cover' })
@@ -59,6 +72,7 @@ export async function renderPokefutaOgpTemplate(input: PokefutaOgpTemplateInput)
   const badgeLabel = input.badgeLabel ?? '見つけたポケふた';
 
   let svg = template;
+  svg = replaceAll(svg, '{{fontFaceCss}}', fontFaceCss);
   svg = replaceAll(svg, './pokefuta_ogp_background_1200x630.png', backgroundDataUri);
   svg = replaceAll(svg, '📷 MY POKEFUTA PHOTO', 'MY POKEFUTA PHOTO');
   svg = replaceAll(svg, '{{photoDataUri}}', photoDataUri);


### PR DESCRIPTION
## Summary
- Bundle Noto Sans CJK JP Bold for server-side OGP rendering.
- Inject the bundled font into sharp-rendered SVG templates and fallbacks.
- Add an OGP image version query to force X/Twitter to refetch generated cards.

## Verification
- Generated local OGP PNGs and confirmed Japanese text renders correctly.
- `npm run type-check`
- `npm run build`

## Notes
- Build still emits existing Dynamic server usage and Edge/Supabase warnings, but completes successfully.