### PR TITLE
Fix OGP font rendering on Linux

### DIFF
--- a/.github/workflows/ogp-linux.yml
+++ b/.github/workflows/ogp-linux.yml
@@ -1,0 +1,32 @@
+name: OGP Linux Verification
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify-ogp-linux:
+    runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: https://example.supabase.co
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ci-placeholder
+      SUPABASE_SERVICE_ROLE_KEY: ci-placeholder
+      NEXT_PUBLIC_APP_URL: https://pokefuta.com
+      NEXT_PUBLIC_MAP_DEFAULT_CENTER_LAT: "35.681236"
+      NEXT_PUBLIC_MAP_DEFAULT_CENTER_LNG: "139.767125"
+      R2_ACCESS_KEY_ID: ci-placeholder
+      R2_SECRET_ACCESS_KEY: ci-placeholder
+      R2_ENDPOINT: https://example.com
+      R2_BUCKET: image
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run type-check
+      - run: npm run build
+      - run: npm run verify:ogp-linux

--- a/next.config.js
+++ b/next.config.js
@@ -42,6 +42,23 @@ const nextConfig = {
   },
   experimental: {
     serverComponentsExternalPackages: ['sharp'],
+    outputFileTracingIncludes: {
+      '/manhole/[id]/opengraph-image': [
+        './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
+        './public/ogp/pokefuta_ogp_template.svg',
+        './public/ogp/pokefuta_ogp_background_1200x630.png',
+      ],
+      '/share/photo/[photoId]/opengraph-image': [
+        './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
+        './public/ogp/pokefuta_ogp_template.svg',
+        './public/ogp/pokefuta_ogp_background_1200x630.png',
+      ],
+      '/p/[photoId]/opengraph-image': [
+        './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
+        './public/ogp/pokefuta_ogp_template.svg',
+        './public/ogp/pokefuta_ogp_background_1200x630.png',
+      ],
+    },
   },
   images: {
     remotePatterns: [

--- a/package.json
+++ b/package.json
@@ -5,9 +5,11 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "postbuild": "node tools/copy-ogp-assets-to-build.js",
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
+    "verify:ogp-linux": "node tools/verify-ogp-linux.js",
     "capture": "node tools/capture/capture.js"
   },
   "dependencies": {

--- a/public/ogp/pokefuta_ogp_template.svg
+++ b/public/ogp/pokefuta_ogp_template.svg
@@ -1,12 +1,7 @@
 <svg width="1200" height="630" viewBox="0 0 1200 630" xmlns="http://www.w3.org/2000/svg">
   <defs>
-    <style>{{fontFaceCss}}</style>
     <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
       <feDropShadow dx="0" dy="14" stdDeviation="14" flood-color="#000000" flood-opacity="0.24"/>
-    </filter>
-    <filter id="titleShadow" x="-10%" y="-20%" width="120%" height="150%">
-      <feDropShadow dx="3" dy="5" stdDeviation="2" flood-color="#FFFFFF" flood-opacity="0.95"/>
-      <feDropShadow dx="0" dy="7" stdDeviation="4" flood-color="#000000" flood-opacity="0.25"/>
     </filter>
     <clipPath id="photoClip">
       <rect x="54" y="48" width="410" height="410" rx="36"/>
@@ -25,34 +20,22 @@
   <g filter="url(#shadow)">
     <rect x="70" y="420" width="330" height="54" rx="10" fill="#17614F"/>
     <path d="M400 420 L438 447 L400 474 Z" fill="#17614F"/>
-    <text x="100" y="456" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">📷 MY POKEFUTA PHOTO</text>
   </g>
 
   <g transform="translate(535 56) rotate(-3)">
     <rect x="0" y="0" width="205" height="50" rx="8" fill="#17614F"/>
     <rect x="8" y="8" width="189" height="34" rx="5" fill="none" stroke="#F3E0A8" stroke-width="2" stroke-dasharray="8 5"/>
-    <text x="102" y="34" text-anchor="middle" font-family="'Pokefuta OGP JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">{{prefecture}}</text>
   </g>
 
-  <text x="520" y="185" font-family="'Pokefuta OGP JP', sans-serif" font-size="64" font-weight="950" fill="#3A2C22" filter="url(#titleShadow)">{{city}}のポケふた</text>
   <rect x="520" y="202" width="430" height="18" rx="9" fill="#F2CD45" opacity="0.75"/>
-
-  <text x="528" y="265" font-family="'Pokefuta OGP JP', sans-serif" font-size="33" font-weight="900" fill="#17614F">{{pokemonNames}}</text>
 
   <g filter="url(#shadow)">
     <rect x="520" y="304" width="475" height="68" rx="34" fill="#FFF9EA"/>
     <rect x="535" y="316" width="445" height="44" rx="22" fill="none" stroke="#B88950" stroke-width="2" stroke-dasharray="9 5"/>
-    <text x="560" y="348" font-family="'Pokefuta OGP JP', sans-serif" font-size="29" font-weight="950" fill="#17614F">{{badgeEmoji}} {{badgeLabel}}</text>
   </g>
-
-  <text x="520" y="440" font-family="'Pokefuta OGP JP', sans-serif" font-size="31" font-weight="900" fill="#2F241C">旅先で見つける、全国のポケふたマップ</text>
-
-  <text x="90" y="585" font-family="'Pokefuta OGP JP', sans-serif" font-size="24" font-weight="900" fill="#FFFFFF">旅行・お出かけ・聖地巡りのお供に！</text>
-  <text x="520" y="585" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="900" fill="#FFFFFF">{{statsLabel}}</text>
 
   <g filter="url(#shadow)">
     <rect x="900" y="553" width="240" height="50" rx="25" fill="#FFF9EA"/>
-    <text x="1012" y="586" text-anchor="middle" font-family="'Pokefuta OGP JP', sans-serif" font-size="25" font-weight="950" fill="#17614F">pokefuta.com</text>
     <circle cx="1120" cy="578" r="18" fill="#1C2E28"/>
     <path d="M1115 568 L1115 588 L1130 578 Z" fill="#FFFFFF"/>
   </g>

--- a/src/app/manhole/[id]/opengraph-image/route.ts
+++ b/src/app/manhole/[id]/opengraph-image/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from 'next/server';
-import sharp from 'sharp';
 import { SITE_NAME } from '@/lib/constants';
-import { OGP_FONT_FAMILY, getOgpFontFaceCss, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
+import { renderOgpFallback, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
 import {
   loadManholeForOgp,
   loadPhotoForOgp,
@@ -11,49 +10,18 @@ import { getManholeLocationLabel, getSortedTitles } from '@/lib/shared-photo';
 
 export const runtime = 'nodejs';
 
-const WIDTH = 1200;
-const HEIGHT = 630;
-
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
+function buildDefaultFallback(): Promise<Buffer> {
+  return renderOgpFallback({
+    title: SITE_NAME,
+    subtitle: '旅先で見つけたポケふたを記録しよう',
+  });
 }
 
-async function buildFallbackSvg(locationLabel: string): Promise<Buffer> {
-  const fontFaceCss = await getOgpFontFaceCss();
-  const safeLabel = escapeXml(locationLabel.length > 20 ? `${locationLabel.slice(0, 19)}…` : locationLabel);
-  const svg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-      <style>${fontFaceCss}</style>
-    </defs>
-    <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
-    <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
-    <text x="100" y="280" font-family="${OGP_FONT_FAMILY}" font-size="64" font-weight="900" fill="#4F3828">${safeLabel}のポケふた</text>
-    <text x="104" y="360" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つける全国のポケモンマンホール</text>
-    <text x="104" y="420" font-family="${OGP_FONT_FAMILY}" font-size="28" font-weight="700" fill="#5D6E68">pokefuta.com</text>
-  </svg>`;
-  return Buffer.from(svg);
-}
-
-async function buildDefaultFallback(): Promise<Buffer> {
-  const fontFaceCss = await getOgpFontFaceCss();
-  const svg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
-    <defs>
-      <style>${fontFaceCss}</style>
-    </defs>
-    <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
-    <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
-    <text x="100" y="300" font-family="${OGP_FONT_FAMILY}" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
-    <text x="104" y="370" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
-  </svg>`;
-  return Buffer.from(svg);
-}
-
-async function renderFallbackPng(svgBuffer: Buffer): Promise<Buffer> {
-  return sharp(svgBuffer).png().toBuffer();
+function buildFallback(locationLabel: string): Promise<Buffer> {
+  return renderOgpFallback({
+    title: `${locationLabel}のポケふた`,
+    subtitle: '旅先で見つける全国のポケモンマンホール',
+  });
 }
 
 export async function GET(
@@ -62,14 +30,14 @@ export async function GET(
 ) {
   const manholeId = Number(params.id);
   if (isNaN(manholeId)) {
-    return new Response(await renderFallbackPng(await buildDefaultFallback()) as unknown as BodyInit, {
+    return new Response(await buildDefaultFallback() as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });
   }
 
   const manhole = await loadManholeForOgp(manholeId);
   if (!manhole) {
-    return new Response(await renderFallbackPng(await buildDefaultFallback()) as unknown as BodyInit, {
+    return new Response(await buildDefaultFallback() as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });
   }
@@ -86,7 +54,7 @@ export async function GET(
   }
 
   if (!photo?.signed_url) {
-    const png = await renderFallbackPng(await buildFallbackSvg(locationLabel));
+    const png = await buildFallback(locationLabel);
     return new Response(png as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400' },
     });
@@ -120,7 +88,7 @@ export async function GET(
     });
   } catch (error) {
     console.error('Failed to render manhole OGP:', error);
-    const png = await renderFallbackPng(await buildFallbackSvg(locationLabel));
+    const png = await buildFallback(locationLabel);
     return new Response(png as unknown as BodyInit, {
       headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
     });

--- a/src/app/share/photo/[photoId]/opengraph-image/route.ts
+++ b/src/app/share/photo/[photoId]/opengraph-image/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from 'next/server';
-import sharp from 'sharp';
 import { SITE_NAME } from '@/lib/constants';
-import { OGP_FONT_FAMILY, getOgpFontFaceCss, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
+import { renderOgpFallback, renderPokefutaOgpTemplate } from '@/lib/pokefuta-ogp-template';
 import {
   getSortedTitles,
   loadPublicSharedPhoto,
@@ -9,31 +8,11 @@ import {
 
 export const runtime = 'nodejs';
 
-const WIDTH = 1200;
-const HEIGHT = 630;
-
-function escapeXml(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;');
-}
-
 async function fallbackImage() {
-  const fontFaceCss = await getOgpFontFaceCss();
-  const svg = Buffer.from(`
-    <svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
-      <defs>
-        <style>${fontFaceCss}</style>
-      </defs>
-      <rect width="1200" height="630" fill="#F6EEDC" />
-      <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4" />
-      <text x="100" y="300" font-family="${OGP_FONT_FAMILY}" font-size="72" font-weight="900" fill="#4F3828">${escapeXml(SITE_NAME)}</text>
-      <text x="104" y="370" font-family="${OGP_FONT_FAMILY}" font-size="34" font-weight="800" fill="#7B63A8">旅先で見つけたポケふたを記録しよう</text>
-    </svg>
-  `);
-  return sharp(svg).png().toBuffer();
+  return renderOgpFallback({
+    title: SITE_NAME,
+    subtitle: '旅先で見つけたポケふたを記録しよう',
+  });
 }
 
 export async function GET(

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const SITE_NAME = 'ポケふたスタンプ帳';
 export const SITE_URL = 'https://pokefuta.com';
-export const OGP_IMAGE_VERSION = '20260520-font';
+export const OGP_IMAGE_VERSION = '20260521-linux-fontfile';
 export const OGP_IMAGE_URL = `${SITE_URL}/opengraph-image?v=${OGP_IMAGE_VERSION}`;

--- a/src/lib/pokefuta-ogp-template.ts
+++ b/src/lib/pokefuta-ogp-template.ts
@@ -1,14 +1,18 @@
 import 'server-only';
+import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
 import sharp from 'sharp';
 
 const WIDTH = 1200;
 const HEIGHT = 630;
-const OGP_FONT_PATH = path.join(process.cwd(), 'public', 'ogp', 'fonts', 'NotoSansCJKjp-Bold.otf');
-const TEMPLATE_PATH = path.join(process.cwd(), 'public', 'ogp', 'pokefuta_ogp_template.svg');
-const BACKGROUND_PATH = path.join(process.cwd(), 'public', 'ogp', 'pokefuta_ogp_background_1200x630.png');
-export const OGP_FONT_FAMILY = "'Pokefuta OGP JP', sans-serif";
+const OGP_FONT_NAME = 'Noto Sans CJK JP';
+const OGP_FONT_RELATIVE_PATH = path.join('public', 'ogp', 'fonts', 'NotoSansCJKjp-Bold.otf');
+const TEMPLATE_RELATIVE_PATH = path.join('public', 'ogp', 'pokefuta_ogp_template.svg');
+const BACKGROUND_RELATIVE_PATH = path.join('public', 'ogp', 'pokefuta_ogp_background_1200x630.png');
+const OGP_FONT_PATH = resolveOgpAssetPath(OGP_FONT_RELATIVE_PATH);
+const TEMPLATE_PATH = resolveOgpAssetPath(TEMPLATE_RELATIVE_PATH);
+const BACKGROUND_PATH = resolveOgpAssetPath(BACKGROUND_RELATIVE_PATH);
 
 type PokefutaOgpTemplateInput = {
   photoBuffer: Buffer;
@@ -20,7 +24,39 @@ type PokefutaOgpTemplateInput = {
   statsLabel?: string;
 };
 
-function escapeXml(value: string): string {
+type TextLayerInput = {
+  text: string;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  fontSize: number;
+  color: string;
+  align?: 'left' | 'center' | 'right';
+};
+
+export function getOgpFontPath(): string {
+  return OGP_FONT_PATH;
+}
+
+function resolveOgpAssetPath(relativePath: string): string {
+  const cwd = process.cwd();
+  const candidates = [
+    path.resolve(cwd, relativePath),
+    path.resolve(cwd, '.next', relativePath),
+    path.resolve(cwd, '..', relativePath),
+  ];
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
+}
+
+export function assertOgpFontExists(fontPath = OGP_FONT_PATH): void {
+  if (!existsSync(fontPath)) {
+    throw new Error(`OGP font file is missing: ${fontPath}`);
+  }
+}
+
+function escapePango(value: string): string {
   return value
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
@@ -40,27 +76,63 @@ function imageDataUri(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString('base64')}`;
 }
 
-function fontFaceCss(fontBuffer: Buffer): string {
-  return `@font-face{font-family:'Pokefuta OGP JP';src:url('${imageDataUri(fontBuffer, 'font/otf')}') format('opentype');font-weight:700 950;font-style:normal;font-display:block;}`;
-}
-
 const templateAssetsPromise = Promise.all([
   readFile(TEMPLATE_PATH, 'utf8'),
   readFile(BACKGROUND_PATH),
-  readFile(OGP_FONT_PATH),
-]).then(([template, backgroundBuffer, fontBuffer]) => ({
+]).then(([template, backgroundBuffer]) => ({
   template,
   backgroundDataUri: imageDataUri(backgroundBuffer, 'image/png'),
-  fontFaceCss: fontFaceCss(fontBuffer),
 }));
 
-export async function getOgpFontFaceCss(): Promise<string> {
-  const { fontFaceCss } = await templateAssetsPromise;
-  return fontFaceCss;
+function textTopFromBaseline(baseline: number, fontSize: number): number {
+  return Math.max(0, Math.round(baseline - fontSize * 0.9));
+}
+
+async function renderTextLayer(input: TextLayerInput): Promise<sharp.OverlayOptions> {
+  assertOgpFontExists();
+
+  const markup = `<span foreground="${input.color}" font_desc="${OGP_FONT_NAME} ${input.fontSize}">${escapePango(input.text)}</span>`;
+  const inputBuffer = await sharp({
+    text: {
+      text: markup,
+      font: OGP_FONT_NAME,
+      fontfile: OGP_FONT_PATH,
+      width: input.width,
+      height: input.height,
+      align: input.align ?? 'left',
+      rgba: true,
+    },
+  })
+    .png()
+    .toBuffer();
+
+  return {
+    input: inputBuffer,
+    left: input.left,
+    top: input.top,
+  };
+}
+
+async function buildTextLayers(layers: TextLayerInput[]): Promise<sharp.OverlayOptions[]> {
+  return Promise.all(layers.map((layer) => renderTextLayer(layer)));
+}
+
+async function renderBaseSvg(template: string, replacements: Record<string, string>): Promise<Buffer> {
+  let svg = template;
+  for (const [search, replacement] of Object.entries(replacements)) {
+    svg = replaceAll(svg, search, replacement);
+  }
+
+  const fontFaceToken = ['@font', 'face'].join('-');
+  if (svg.includes(fontFaceToken)) {
+    throw new Error(`OGP SVG must not depend on ${fontFaceToken}`);
+  }
+
+  return sharp(Buffer.from(svg)).resize(WIDTH, HEIGHT).png().toBuffer();
 }
 
 export async function renderPokefutaOgpTemplate(input: PokefutaOgpTemplateInput): Promise<Buffer> {
-  const [{ template, backgroundDataUri, fontFaceCss }, photoBuffer] = await Promise.all([
+  const [{ template, backgroundDataUri }, photoBuffer] = await Promise.all([
     templateAssetsPromise,
     sharp(input.photoBuffer)
       .resize(820, 820, { fit: 'cover' })
@@ -70,22 +142,150 @@ export async function renderPokefutaOgpTemplate(input: PokefutaOgpTemplateInput)
 
   const photoDataUri = imageDataUri(photoBuffer, 'image/jpeg');
   const badgeLabel = input.badgeLabel ?? '見つけたポケふた';
+  const cityTitle = `${truncate(input.city, 10)}のポケふた`;
+  const statsLabel = truncate(input.statsLabel ?? '全国のポケふた写真をシェア', 28);
+  const base = await renderBaseSvg(template, {
+    './pokefuta_ogp_background_1200x630.png': backgroundDataUri,
+    '{{photoDataUri}}': photoDataUri,
+  });
 
-  let svg = template;
-  svg = replaceAll(svg, '{{fontFaceCss}}', fontFaceCss);
-  svg = replaceAll(svg, './pokefuta_ogp_background_1200x630.png', backgroundDataUri);
-  svg = replaceAll(svg, '📷 MY POKEFUTA PHOTO', 'MY POKEFUTA PHOTO');
-  svg = replaceAll(svg, '{{photoDataUri}}', photoDataUri);
-  svg = replaceAll(svg, '{{prefecture}}', escapeXml(truncate(input.prefecture, 8)));
-  svg = replaceAll(svg, '{{city}}', escapeXml(truncate(input.city, 10)));
-  svg = replaceAll(svg, '{{pokemonNames}}', escapeXml(truncate(input.pokemonNames, 20)));
-  svg = replaceAll(svg, '{{badgeEmoji}}', escapeXml(input.badgeEmoji ?? '📍'));
-  svg = replaceAll(svg, '{{badgeLabel}}', escapeXml(truncate(badgeLabel, 14)));
-  svg = replaceAll(
-    svg,
-    '{{statsLabel}}',
-    escapeXml(truncate(input.statsLabel ?? '全国のポケふた写真をシェア', 28))
-  );
+  const textLayers = await buildTextLayers([
+    {
+      text: 'MY POKEFUTA PHOTO',
+      left: 100,
+      top: textTopFromBaseline(456, 25),
+      width: 285,
+      height: 46,
+      fontSize: 25,
+      color: '#FFFFFF',
+    },
+    {
+      text: truncate(input.prefecture, 8),
+      left: 535,
+      top: 61,
+      width: 205,
+      height: 44,
+      fontSize: 24,
+      color: '#FFFFFF',
+      align: 'center',
+    },
+    {
+      text: cityTitle,
+      left: 523,
+      top: textTopFromBaseline(190, 64),
+      width: 650,
+      height: 90,
+      fontSize: 64,
+      color: '#FFFFFF',
+    },
+    {
+      text: cityTitle,
+      left: 520,
+      top: textTopFromBaseline(185, 64),
+      width: 650,
+      height: 90,
+      fontSize: 64,
+      color: '#3A2C22',
+    },
+    {
+      text: truncate(input.pokemonNames, 20),
+      left: 528,
+      top: textTopFromBaseline(265, 33),
+      width: 610,
+      height: 54,
+      fontSize: 33,
+      color: '#17614F',
+    },
+    {
+      text: `${input.badgeEmoji ?? ''} ${truncate(badgeLabel, 14)}`.trim(),
+      left: 560,
+      top: textTopFromBaseline(348, 29),
+      width: 410,
+      height: 52,
+      fontSize: 29,
+      color: '#17614F',
+    },
+    {
+      text: '旅先で見つける、全国のポケふたマップ',
+      left: 520,
+      top: textTopFromBaseline(440, 31),
+      width: 640,
+      height: 56,
+      fontSize: 31,
+      color: '#2F241C',
+    },
+    {
+      text: '旅行・お出かけ・聖地巡りのお供に！',
+      left: 90,
+      top: textTopFromBaseline(585, 24),
+      width: 390,
+      height: 44,
+      fontSize: 24,
+      color: '#FFFFFF',
+    },
+    {
+      text: statsLabel,
+      left: 520,
+      top: textTopFromBaseline(585, 25),
+      width: 370,
+      height: 44,
+      fontSize: 25,
+      color: '#FFFFFF',
+    },
+    {
+      text: 'pokefuta.com',
+      left: 900,
+      top: textTopFromBaseline(586, 25),
+      width: 224,
+      height: 44,
+      fontSize: 25,
+      color: '#17614F',
+      align: 'center',
+    },
+  ]);
 
-  return sharp(Buffer.from(svg)).resize(WIDTH, HEIGHT).png().toBuffer();
+  return sharp(base).composite(textLayers).png().toBuffer();
+}
+
+export async function renderOgpFallback(input: {
+  title: string;
+  subtitle: string;
+  siteLabel?: string;
+}): Promise<Buffer> {
+  const baseSvg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+    <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
+    <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
+  </svg>`;
+  const base = await sharp(Buffer.from(baseSvg)).png().toBuffer();
+  const textLayers = await buildTextLayers([
+    {
+      text: truncate(input.title, 24),
+      left: 100,
+      top: textTopFromBaseline(300, 64),
+      width: 980,
+      height: 90,
+      fontSize: 64,
+      color: '#4F3828',
+    },
+    {
+      text: truncate(input.subtitle, 34),
+      left: 104,
+      top: textTopFromBaseline(370, 34),
+      width: 980,
+      height: 58,
+      fontSize: 34,
+      color: '#7B63A8',
+    },
+    {
+      text: input.siteLabel ?? 'pokefuta.com',
+      left: 104,
+      top: textTopFromBaseline(430, 28),
+      width: 520,
+      height: 48,
+      fontSize: 28,
+      color: '#5D6E68',
+    },
+  ]);
+
+  return sharp(base).composite(textLayers).png().toBuffer();
 }

--- a/tools/copy-ogp-assets-to-build.js
+++ b/tools/copy-ogp-assets-to-build.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const ASSET_PATHS = [
+  path.join('public', 'ogp', 'fonts', 'NotoSansCJKjp-Bold.otf'),
+  path.join('public', 'ogp', 'pokefuta_ogp_template.svg'),
+  path.join('public', 'ogp', 'pokefuta_ogp_background_1200x630.png'),
+];
+
+for (const relativePath of ASSET_PATHS) {
+  const source = path.join(ROOT, relativePath);
+  const destination = path.join(ROOT, '.next', relativePath);
+
+  if (!fs.existsSync(source)) {
+    throw new Error(`Missing OGP asset: ${source}`);
+  }
+
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.copyFileSync(source, destination);
+  console.log(`[postbuild] Copied ${relativePath} to .next build output`);
+}

--- a/tools/verify-ogp-linux.js
+++ b/tools/verify-ogp-linux.js
@@ -1,0 +1,129 @@
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+const ROOT = path.resolve(__dirname, '..');
+const FONT_RELATIVE_PATH = path.join('public', 'ogp', 'fonts', 'NotoSansCJKjp-Bold.otf');
+const FONT_PATH = path.resolve(ROOT, FONT_RELATIVE_PATH);
+const BUILD_FONT_PATH = path.resolve(ROOT, '.next', FONT_RELATIVE_PATH);
+const BUILT_ROUTE_PATH = path.join(
+  ROOT,
+  '.next',
+  'server',
+  'app',
+  'manhole',
+  '[id]',
+  'opengraph-image',
+  'route.js'
+);
+const SOURCE_TEMPLATE_PATH = path.join(ROOT, 'src', 'lib', 'pokefuta-ogp-template.ts');
+const SVG_TEMPLATE_PATH = path.join(ROOT, 'public', 'ogp', 'pokefuta_ogp_template.svg');
+
+function fail(message) {
+  console.error(`[verify:ogp-linux] ${message}`);
+  process.exit(1);
+}
+
+function pass(message) {
+  console.log(`[verify:ogp-linux] ${message}`);
+}
+
+function findFiles(startDir, fileName, results = []) {
+  if (!fs.existsSync(startDir)) return results;
+
+  for (const entry of fs.readdirSync(startDir, { withFileTypes: true })) {
+    const fullPath = path.join(startDir, entry.name);
+    if (entry.isDirectory()) {
+      findFiles(fullPath, fileName, results);
+    } else if (entry.isFile() && entry.name === fileName) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+function readRequired(filePath) {
+  if (!fs.existsSync(filePath)) fail(`Missing required file: ${filePath}`);
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+async function verifyJapaneseTextPixels() {
+  const rendered = await sharp({
+    text: {
+      text: '<span foreground="#3A2C22" font_desc="Noto Sans CJK JP 64">刈谷市のポケふた</span>',
+      font: 'Noto Sans CJK JP',
+      fontfile: FONT_PATH,
+      width: 760,
+      height: 110,
+      rgba: true,
+    },
+  })
+    .png()
+    .toBuffer();
+
+  const { data, info } = await sharp(rendered)
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  let opaquePixels = 0;
+  for (let index = 3; index < data.length; index += info.channels) {
+    if (data[index] > 0) opaquePixels += 1;
+  }
+
+  if (opaquePixels < 1000) {
+    fail(`Japanese text appears blank; opaque pixel count was ${opaquePixels}`);
+  }
+
+  pass(`Japanese text rendered on Linux via sharp fontfile; opaque pixels=${opaquePixels}`);
+}
+
+async function main() {
+  if (process.platform !== 'linux') {
+    fail(`This check is only valid on Linux. Current platform: ${process.platform}`);
+  }
+
+  const buildOutputFonts = findFiles(path.join(ROOT, '.next'), 'NotoSansCJKjp-Bold.otf');
+  if (buildOutputFonts.length === 0) {
+    fail('NotoSansCJKjp-Bold.otf was not found in .next build output');
+  }
+  pass(`Font included in build output: ${buildOutputFonts.map((p) => path.relative(ROOT, p)).join(', ')}`);
+
+  if (!fs.existsSync(FONT_PATH)) {
+    fail(`Runtime absolute font path does not exist: ${FONT_PATH}`);
+  }
+  pass(`Runtime absolute font path exists: ${FONT_PATH}`);
+
+  if (!fs.existsSync(BUILD_FONT_PATH)) {
+    fail(`Build-output runtime font path does not exist: ${BUILD_FONT_PATH}`);
+  }
+  pass(`Build-output runtime font path exists: ${BUILD_FONT_PATH}`);
+
+  const sourceTemplate = readRequired(SOURCE_TEMPLATE_PATH);
+  if (!sourceTemplate.includes('fontfile: OGP_FONT_PATH')) {
+    fail('sharp text overlay is not passing the absolute OGP font path as fontfile');
+  }
+  if (!sourceTemplate.includes('path.resolve(cwd, relativePath)')) {
+    fail('OGP font path is not resolved as an absolute path from process.cwd()');
+  }
+  pass('sharp text overlay uses an absolute fontfile path');
+
+  const svgTemplate = readRequired(SVG_TEMPLATE_PATH);
+  if (svgTemplate.includes('@font-face')) {
+    fail('SVG template still contains @font-face');
+  }
+  pass('SVG template does not contain @font-face');
+
+  const builtRoute = readRequired(BUILT_ROUTE_PATH);
+  if (builtRoute.includes('@font-face')) {
+    fail('Built OGP route still contains @font-face');
+  }
+  pass('Built OGP route does not contain @font-face');
+
+  await verifyJapaneseTextPixels();
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Render OGP text with sharp text overlays using an absolute NotoSansCJK fontfile path instead of SVG @font-face.
- Include OGP font/background/template assets in Next build output and tracing, with a postbuild copy step.
- Add Linux-only OGP verification and a GitHub Actions workflow for Ubuntu/Node 20.

## Verification
- `npm run type-check`
- `npm run build`
- Local production OGP smoke: `/manhole/404/opengraph-image?v=20260521-linux-fontfile` returned 1200x630 PNG and nonblank text-region pixel checks.

## Notes
- Mac local smoke is not treated as the acceptance gate. The required gate is the new Linux CI verification.
- Attempted local Docker Linux verification, but `docker pull node:20-bookworm` hung in Docker credential helper, so the Linux result is expected from CI.