### PR TITLE
Render OGP text paths with fontkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "@types/crypto-js": "^4.2.1",
         "@types/leaflet": "^1.9.8",
         "@types/node": "^20.0.0",
-        "@types/opentype.js": "^1.3.9",
         "@types/react": "^18.0.0",
         "@types/react-dom": "^18.0.0",
         "autoprefixer": "^10.4.16",
@@ -23,11 +22,11 @@
         "crypto-js": "^4.2.0",
         "date-fns": "^2.30.0",
         "exifr": "^7.1.3",
+        "fontkit": "^2.0.4",
         "leaflet": "^1.9.4",
         "lucide-react": "^0.294.0",
         "next": "^14.0.0",
         "next-pwa": "^5.6.0",
-        "opentype.js": "^2.0.0",
         "postcss": "^8.4.31",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -42,6 +41,7 @@
         "typescript": "^5.0.0"
       },
       "devDependencies": {
+        "@types/fontkit": "^2.0.9",
         "@types/swagger-ui-react": "^5.18.0",
         "eslint": "^8.0.0",
         "eslint-config-next": "^14.0.0",
@@ -4637,6 +4637,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/fontkit": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@types/fontkit/-/fontkit-2.0.9.tgz",
+      "integrity": "sha512-qNYerFky3muCmZPq+R+B3cUDRA5OONw/oh6aGGFxx2LOBz6yu8eamKusrhkHnC6rc2fm76+G9z9QoWSB2SaQaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/geojson": {
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
@@ -4698,12 +4708,6 @@
       "dependencies": {
         "undici-types": "~6.21.0"
       }
-    },
-    "node_modules/@types/opentype.js": {
-      "version": "1.3.9",
-      "resolved": "https://registry.npmjs.org/@types/opentype.js/-/opentype.js-1.3.9.tgz",
-      "integrity": "sha512-KOGywvDPncA4/tTWV5xKNhjpsoSSAHIx3mHOhL5l3XX+c6Xu2dQnHvGs7mRNQsQRte1EqmQ0cPQQ8Z14lkv+yw==",
-      "license": "MIT"
     },
     "node_modules/@types/phoenix": {
       "version": "1.6.6",
@@ -6287,6 +6291,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
+      }
+    },
     "node_modules/browser-image-compression": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
@@ -6677,6 +6690,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color": {
@@ -7203,6 +7225,12 @@
       "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -8363,6 +8391,32 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/fontkit/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/for-each": {
@@ -10646,15 +10700,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/opentype.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/opentype.js/-/opentype.js-2.0.0.tgz",
-      "integrity": "sha512-kCyjv6xdDY1W/jLWZ/L3QhhTlKUqDZMQ5+Jdlw12b3dXkKNpYBqqlMMj0YDQPShWFTMwgZI1hG14kN3XUDSg/A==",
-      "license": "MIT",
-      "bin": {
-        "ot": "bin/ot"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10773,6 +10818,12 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -11922,6 +11973,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
+    },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
     },
     "node_modules/ret": {
       "version": "0.2.2",
@@ -13439,6 +13496,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -13822,6 +13885,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
     "node_modules/unicode-property-aliases-ecmascript": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
@@ -13829,6 +13902,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
       }
     },
     "node_modules/unique-string": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@types/crypto-js": "^4.2.1",
     "@types/leaflet": "^1.9.8",
     "@types/node": "^20.0.0",
-    "@types/opentype.js": "^1.3.9",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
     "autoprefixer": "^10.4.16",
@@ -28,11 +27,11 @@
     "crypto-js": "^4.2.0",
     "date-fns": "^2.30.0",
     "exifr": "^7.1.3",
+    "fontkit": "^2.0.4",
     "leaflet": "^1.9.4",
     "lucide-react": "^0.294.0",
     "next": "^14.0.0",
     "next-pwa": "^5.6.0",
-    "opentype.js": "^2.0.0",
     "postcss": "^8.4.31",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
@@ -47,6 +46,7 @@
     "typescript": "^5.0.0"
   },
   "devDependencies": {
+    "@types/fontkit": "^2.0.9",
     "@types/swagger-ui-react": "^5.18.0",
     "eslint": "^8.0.0",
     "eslint-config-next": "^14.0.0",

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,4 +1,4 @@
 export const SITE_NAME = 'ポケふたスタンプ帳';
 export const SITE_URL = 'https://pokefuta.com';
-export const OGP_IMAGE_VERSION = '20260521-opentype-paths';
+export const OGP_IMAGE_VERSION = '20260522-fontkit-paths';
 export const OGP_IMAGE_URL = `${SITE_URL}/opengraph-image?v=${OGP_IMAGE_VERSION}`;

--- a/src/lib/pokefuta-ogp-template.ts
+++ b/src/lib/pokefuta-ogp-template.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import { existsSync, readFileSync } from 'fs';
 import { readFile } from 'fs/promises';
 import path from 'path';
-import * as opentype from 'opentype.js';
+import * as fontkit from 'fontkit';
 import sharp from 'sharp';
 
 const WIDTH = 1200;
@@ -13,7 +13,7 @@ const BACKGROUND_RELATIVE_PATH = path.join('public', 'ogp', 'pokefuta_ogp_backgr
 const OGP_FONT_PATH = resolveOgpAssetPath(OGP_FONT_RELATIVE_PATH);
 const TEMPLATE_PATH = resolveOgpAssetPath(TEMPLATE_RELATIVE_PATH);
 const BACKGROUND_PATH = resolveOgpAssetPath(BACKGROUND_RELATIVE_PATH);
-let ogpFontPromise: Promise<opentype.Font> | null = null;
+let ogpFontPromise: Promise<fontkit.Font> | null = null;
 
 type PokefutaOgpTemplateInput = {
   photoBuffer: Buffer;
@@ -89,40 +89,75 @@ function textTopFromBaseline(baseline: number, fontSize: number): number {
   return Math.max(0, Math.round(baseline - fontSize * 0.9));
 }
 
-function bufferToArrayBuffer(buffer: Buffer): ArrayBuffer {
-  const arrayBuffer = new ArrayBuffer(buffer.byteLength);
-  new Uint8Array(arrayBuffer).set(buffer);
-  return arrayBuffer;
-}
-
-async function loadOgpFont(): Promise<opentype.Font> {
+async function loadOgpFont(): Promise<fontkit.Font> {
   assertOgpFontExists();
 
-  ogpFontPromise ??= Promise.resolve().then(() =>
-    opentype.parse(bufferToArrayBuffer(readFileSync(OGP_FONT_PATH)))
-  );
+  if (!ogpFontPromise) {
+    ogpFontPromise = Promise.resolve().then(() => {
+      const parsedFont = fontkit.create(readFileSync(OGP_FONT_PATH));
+      if ('fonts' in parsedFont) {
+        const firstFont = parsedFont.fonts[0];
+        if (!firstFont) {
+          throw new Error(`OGP font collection is empty: ${OGP_FONT_PATH}`);
+        }
+        return firstFont;
+      }
+
+      return parsedFont;
+    });
+  }
 
   return ogpFontPromise;
+}
+
+function escapeSvgPathData(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}
+
+function renderFontkitPathData(
+  font: fontkit.Font,
+  text: string,
+  x: number,
+  baseline: number,
+  fontSize: number
+): string {
+  const run = font.layout(text);
+  const scale = fontSize / font.unitsPerEm;
+  let cursorX = x;
+
+  return run.glyphs
+    .map((glyph, index) => {
+      const position = run.positions[index];
+      const glyphPath = glyph.path.toSVG();
+      if (!glyphPath) return '';
+
+      const glyphX = cursorX + position.xOffset * scale;
+      const glyphBaseline = baseline - position.yOffset * scale;
+      cursorX += position.xAdvance * scale;
+
+      return `<path d="${escapeSvgPathData(glyphPath)}" transform="translate(${glyphX.toFixed(2)} ${glyphBaseline.toFixed(2)}) scale(${scale.toFixed(5)} ${(-scale).toFixed(5)})"/>`;
+    })
+    .join('');
 }
 
 async function renderTextLayer(input: TextLayerInput): Promise<sharp.OverlayOptions> {
   const font = await loadOgpFont();
   let fontSize = input.fontSize;
-  let textWidth = font.getAdvanceWidth(input.text, fontSize, { kerning: true });
+  let textWidth = font.layout(input.text).advanceWidth * (fontSize / font.unitsPerEm);
   if (textWidth > input.width) {
     fontSize = Math.max(12, Math.floor((fontSize * input.width) / textWidth));
-    textWidth = font.getAdvanceWidth(input.text, fontSize, { kerning: true });
+    textWidth = font.layout(input.text).advanceWidth * (fontSize / font.unitsPerEm);
   }
   const baseline = Math.round(fontSize * 0.9);
   const x =
     input.align === 'center'
       ? Math.max(0, (input.width - textWidth) / 2)
       : input.align === 'right'
-        ? Math.max(0, input.width - textWidth)
-        : 0;
-  const pathData = font.getPath(input.text, x, baseline, fontSize, { kerning: true }).toPathData(2);
+      ? Math.max(0, input.width - textWidth)
+      : 0;
+  const paths = renderFontkitPathData(font, input.text, x, baseline, fontSize);
   const svg = `<svg width="${input.width}" height="${input.height}" viewBox="0 0 ${input.width} ${input.height}" xmlns="http://www.w3.org/2000/svg">
-    <path d="${escapeXmlAttribute(pathData)}" fill="${escapeXmlAttribute(input.color)}"/>
+    <g fill="${escapeXmlAttribute(input.color)}">${paths}</g>
   </svg>`;
   const inputBuffer = await sharp(Buffer.from(svg))
     .png()

--- a/tools/verify-ogp-linux.js
+++ b/tools/verify-ogp-linux.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const opentype = require('opentype.js');
+const fontkit = require('fontkit');
 const sharp = require('sharp');
 
 const ROOT = path.resolve(__dirname, '..');
@@ -50,15 +50,36 @@ function readRequired(filePath) {
 }
 
 async function verifyJapaneseTextPixels() {
-  const buffer = fs.readFileSync(FONT_PATH);
-  const font = opentype.parse(buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength));
-  const pathData = font.getPath('刈谷市のポケふた', 0, 58, 64, { kerning: true }).toPathData(2);
-  if (!pathData || pathData.length < 100) {
-    fail('Japanese text did not produce usable glyph path data');
+  const text = '刈谷市のポケふた';
+  const font = fontkit.openSync(FONT_PATH);
+  const run = font.layout(text);
+  if (run.glyphs.length !== Array.from(text).length) {
+    fail(`Japanese text glyph count mismatch: expected ${Array.from(text).length}, got ${run.glyphs.length}`);
   }
 
+  const missingGlyphs = run.glyphs
+    .map((glyph, index) => ({ glyph, char: Array.from(text)[index] }))
+    .filter(({ glyph }) => glyph.id === 0);
+  if (missingGlyphs.length > 0) {
+    fail(`Japanese text resolved to .notdef glyphs: ${missingGlyphs.map(({ char }) => char).join('')}`);
+  }
+
+  const fontSize = 64;
+  const scale = fontSize / font.unitsPerEm;
+  let cursorX = 0;
+  const paths = run.glyphs
+    .map((glyph, index) => {
+      const position = run.positions[index];
+      const pathData = glyph.path.toSVG();
+      const glyphX = cursorX + position.xOffset * scale;
+      const glyphBaseline = 64 - position.yOffset * scale;
+      cursorX += position.xAdvance * scale;
+      return `<path d="${pathData.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}" transform="translate(${glyphX.toFixed(2)} ${glyphBaseline.toFixed(2)}) scale(${scale.toFixed(5)} ${(-scale).toFixed(5)})"/>`;
+    })
+    .join('');
+
   const svg = `<svg width="760" height="110" viewBox="0 0 760 110" xmlns="http://www.w3.org/2000/svg">
-    <path d="${pathData.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}" fill="#3A2C22"/>
+    <g fill="#3A2C22">${paths}</g>
   </svg>`;
   const rendered = await sharp(Buffer.from(svg))
     .png()
@@ -77,7 +98,7 @@ async function verifyJapaneseTextPixels() {
     fail(`Japanese text appears blank; opaque pixel count was ${opaquePixels}`);
   }
 
-  pass(`Japanese text rendered on Linux via opentype SVG paths; opaque pixels=${opaquePixels}`);
+  pass(`Japanese text rendered on Linux via fontkit SVG paths; opaque pixels=${opaquePixels}`);
 }
 
 async function main() {
@@ -102,8 +123,8 @@ async function main() {
   pass(`Build-output runtime font path exists: ${BUILD_FONT_PATH}`);
 
   const sourceTemplate = readRequired(SOURCE_TEMPLATE_PATH);
-  if (!sourceTemplate.includes('opentype.parse')) {
-    fail('OGP rendering is not parsing the bundled font into SVG paths');
+  if (!sourceTemplate.includes('fontkit.create')) {
+    fail('OGP rendering is not parsing the bundled font with fontkit');
   }
   if (sourceTemplate.includes('fontfile:')) {
     fail('OGP rendering still depends on sharp text overlay fontfile');
@@ -114,7 +135,7 @@ async function main() {
   if (!sourceTemplate.includes('path.resolve(cwd, relativePath)')) {
     fail('OGP font path is not resolved as an absolute path from process.cwd()');
   }
-  pass('OGP text uses bundled font glyph paths instead of sharp text overlay');
+  pass('OGP text uses bundled fontkit glyph paths instead of sharp text overlay');
 
   const svgTemplate = readRequired(SVG_TEMPLATE_PATH);
   if (svgTemplate.includes('@font-face')) {


### PR DESCRIPTION
## Summary
- Replace the OGP Japanese text outline renderer from `opentype.js` to `fontkit`, so CJK CID glyphs are resolved before rasterizing SVG paths with sharp.
- Remove the opentype dependency and bump the OGP cache version to `20260522-fontkit-paths`.
- Strengthen `verify:ogp-linux` to fail when Japanese text resolves to `.notdef` glyphs, which catches the square-box failure seen in production.

## Verification
- `npm run type-check`
- `npm run build`
- Docker Linux: `npm ci && npm run build && npm run verify:ogp-linux`
- Local production smoke: `http://127.0.0.1:3004/manhole/404/opengraph-image?v=20260522-fontkit-paths` rendered Japanese text

## Notes
- Existing build warnings remain: Browserslist/baseline data age, Supabase Edge Runtime warnings, and dynamic server usage logs for cookie/request-url API routes during static generation.
- The current production URL with `20260521-opentype-paths` still renders square glyphs, so this PR intentionally changes approach rather than adjusting cache only.