### PR TITLE
Add local fontkit types for Amplify build

### DIFF
--- a/src/types/fontkit.d.ts
+++ b/src/types/fontkit.d.ts
@@ -1,0 +1,35 @@
+declare module 'fontkit' {
+  export interface GlyphPath {
+    toSVG(): string;
+  }
+
+  export interface Glyph {
+    id: number;
+    path: GlyphPath;
+  }
+
+  export interface GlyphPosition {
+    xAdvance: number;
+    yAdvance: number;
+    xOffset: number;
+    yOffset: number;
+  }
+
+  export interface GlyphRun {
+    glyphs: Glyph[];
+    positions: GlyphPosition[];
+    advanceWidth: number;
+  }
+
+  export interface Font {
+    unitsPerEm: number;
+    layout(text: string): GlyphRun;
+  }
+
+  export interface FontCollection {
+    fonts: Font[];
+  }
+
+  export function create(buffer: Buffer, postscriptName?: string): Font | FontCollection;
+  export function openSync(filename: string, postscriptName?: string): Font | FontCollection;
+}


### PR DESCRIPTION
## Summary
- Add a local `fontkit` module declaration for the small API surface used by OGP rendering.
- Avoid relying on `@types/fontkit` resolution in Amplify/production-only installs.

## Verification
- `npm run type-check`
- `npm run build`
- Linux container: `npm ci --omit=dev && npm run build`

## Notes
- This is intentionally scoped to the first Amplify error: `Could not find a declaration file for module fontkit`.
- OGP rendering behavior is unchanged in this PR.