### PR TITLE
Refresh login journey UI

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -50,7 +50,7 @@ export default function AboutPage() {
                     1. アカウント作成・ログイン
                   </h3>
                   <p className="font-pixelJp text-xs text-rpg-textDark leading-relaxed">
-                    メールアドレスまたはGoogleアカウントで無料登録できます。登録後、訪問記録の保存や写真のアップロードが可能になります。
+                    メールアドレスで無料登録できます。登録後、訪問記録の保存や写真のアップロードが可能になります。
                   </p>
                 </div>
               </div>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,15 +4,21 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import BottomNav from '@/components/BottomNav';
-import { LogIn, Mail, Lock, AlertCircle, Info } from 'lucide-react';
+import { AlertCircle, Camera, Info, Lock, LogIn, Mail, Map, Stamp } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 import TermsOfService from '@/components/TermsOfService';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
+function getSafeRedirectPath(value: string | null) {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
+  return value;
+}
+
 function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirect') || '/';
+  const redirectTo = getSafeRedirectPath(searchParams.get('redirect'));
+  const hasRedirect = redirectTo !== '/';
   const fromRegister = searchParams.get('from') === 'register';
 
   const [email, setEmail] = useState('');
@@ -101,133 +107,171 @@ function LoginForm() {
     }
   };
 
+  const benefitItems = [
+    {
+      icon: <Stamp className="h-5 w-5" />,
+      title: 'スタンプ帳の続き',
+      description: '集めた訪問履歴と達成率をそのまま確認できます',
+    },
+    {
+      icon: <Camera className="h-5 w-5" />,
+      title: '写真投稿に戻る',
+      description: '旅先で撮ったポケふた写真をすぐ記録できます',
+    },
+    {
+      icon: <Map className="h-5 w-5" />,
+      title: '都道府県別の進捗',
+      description: '次に巡る場所や未訪問の候補を探せます',
+    },
+  ];
+
   return (
-    <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] flex items-center justify-center p-4">
-      <div className="w-full max-w-md">
-        {/* Header */}
-        <div className="rpg-window text-center mb-6">
-          <div className="inline-block mb-3">
-            <div className="w-16 h-16 bg-rpg-yellow border border-[#7B63A8]/15 flex items-center justify-center mx-auto">
-              <LogIn className="w-8 h-8 text-rpg-textDark" />
+    <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
+      <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-4 py-6 sm:py-10">
+        <section className="relative w-full overflow-hidden rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
+          <div className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+          <div className="relative grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="p-5 sm:p-8 lg:p-10">
+              <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+                <LogIn className="h-3.5 w-3.5" />
+                旅の続き
+              </div>
+
+              <h1 className="max-w-xl text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
+                旅の続きにログイン
+              </h1>
+              <p className="mt-4 max-w-xl text-sm font-medium leading-relaxed text-[#6A4D36] sm:text-base">
+                保存した訪問履歴、スタンプ帳、写真投稿画面に戻れます。次に巡るポケふたも、ここからまた探せます。
+              </p>
+
+              <div className="mt-6 grid gap-3">
+                {benefitItems.map((item) => (
+                  <div key={item.title} className="flex items-start gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-white/65 p-4">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#7B63A8]/10 text-[#7B63A8]">
+                      {item.icon}
+                    </div>
+                    <div>
+                      <h2 className="text-sm font-extrabold text-[#4F3828]">{item.title}</h2>
+                      <p className="mt-1 text-xs font-medium leading-relaxed text-[#6A4D36]">{item.description}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
             </div>
-          </div>
-          <h1 className="font-pixelJp text-lg text-[#7B63A8] font-bold">ログイン</h1>
-          <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mt-1">
-            アカウント作成済みの方はこちら
-          </p>
-          {fromRegister && (
-            <div className="mt-3 pt-3 border-t border-[#7B63A8]/15">
-              <div className="bg-rpg-yellow/20 border-2 border-rpg-yellow p-2 rounded">
-                <div className="flex items-start gap-2">
-                  <Mail className="w-4 h-4 text-rpg-yellow flex-shrink-0 mt-0.5" />
-                  <div>
-                    <p className="font-pixelJp text-xs font-bold text-rpg-textDark mb-1">
-                      登録完了！
-                    </p>
-                    <p className="font-pixelJp text-[11px] text-rpg-textDark leading-relaxed">
-                      登録したメールアドレスに確認メールが送信されました。メール内のリンクをクリックして確認を完了してください。
-                    </p>
+
+            <div className="border-t border-[#8C6A4A]/15 bg-[#FFF8EB]/80 p-5 sm:p-8 lg:border-l lg:border-t-0 lg:p-10">
+              {fromRegister && (
+                <div className="mb-4 rounded-[8px] border border-[#FFB347]/50 bg-[#FFF0C7] p-3">
+                  <div className="flex items-start gap-2">
+                    <Mail className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#9B5C2E]" />
+                    <div>
+                      <p className="text-xs font-extrabold text-[#4F3828]">登録完了！</p>
+                      <p className="mt-1 text-[11px] font-medium leading-relaxed text-[#6A4D36]">
+                        登録したメールアドレスに確認メールが送信されました。メール内のリンクをクリックして確認を完了してください。
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          )}
-        </div>
+              )}
 
-        {/* Login Form */}
-        <div className="rpg-window">
-          <form onSubmit={handleLogin} className="space-y-4">
-            {/* Error Message */}
-            {error && (
-              <div className="bg-rpg-red/20 border-2 border-rpg-red p-3">
-                <div className="flex items-center gap-2 text-rpg-red">
-                  <AlertCircle className="w-4 h-4" />
-                  <span className="font-pixelJp text-xs">{error}</span>
+              {hasRedirect && (
+                <div className="mb-4 rounded-[8px] border border-[#7B63A8]/20 bg-white/70 p-3">
+                  <p className="text-xs font-bold leading-relaxed text-[#7B63A8]">
+                    ログイン後、指定されたページに移動します。
+                  </p>
                 </div>
+              )}
+
+              <form onSubmit={handleLogin} className="space-y-4">
+                {error && (
+                  <div className="rounded-[8px] border border-[#B5483C]/30 bg-[#F8D9C4] p-3">
+                    <div className="flex items-center gap-2 text-[#B5483C]">
+                      <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                      <span className="text-xs font-bold">{error}</span>
+                    </div>
+                  </div>
+                )}
+
+                <div>
+                  <label className="mb-2 flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                    <Mail className="h-4 w-4" />
+                    メールアドレス
+                  </label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    className="w-full rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-3 text-sm font-medium text-[#2A2A2A] outline-none transition focus:border-[#7B63A8] focus:ring-2 focus:ring-[#7B63A8]/15"
+                    placeholder="your@email.com"
+                    required
+                    disabled={loading}
+                  />
+                </div>
+
+                <div>
+                  <label className="mb-2 flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                    <Lock className="h-4 w-4" />
+                    パスワード
+                  </label>
+                  <input
+                    type="password"
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="w-full rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-3 text-sm font-medium text-[#2A2A2A] outline-none transition focus:border-[#7B63A8] focus:ring-2 focus:ring-[#7B63A8]/15"
+                    placeholder="••••••••"
+                    required
+                    disabled={loading}
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  className="inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299] disabled:opacity-60"
+                  disabled={loading}
+                >
+                  <LogIn className="h-4 w-4" />
+                  <span>{loading ? 'ログイン中...' : '旅の続きへ戻る'}</span>
+                </button>
+              </form>
+
+              <div className="mt-4">
+                <button
+                  type="button"
+                  onClick={() => setShowTerms(!showTerms)}
+                  className="mx-auto flex items-center gap-1 text-xs font-bold text-[#7B63A8] transition hover:opacity-70"
+                >
+                  <Info className="h-3 w-3" />
+                  <span>利用規約を確認</span>
+                </button>
               </div>
-            )}
 
-            {/* Email Input */}
-            <div>
-              <label className="flex items-center gap-2 font-pixelJp text-sm text-rpg-textDark mb-2">
-                <Mail className="w-4 h-4" />
-                メールアドレス
-              </label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full bg-white/70 border border-[#7B63A8]/15 p-3 font-pixelJp text-sm text-rpg-textDark focus:border-rpg-yellow focus:outline-none"
-                placeholder="your@email.com"
-                required
-                disabled={loading}
-              />
+              {showTerms && (
+                <div className="mt-3">
+                  <TermsOfService
+                    isChecked={false}
+                    onCheckChange={() => {}}
+                    className="border-[#FFB347]"
+                  />
+                </div>
+              )}
+
+              <div className="mt-6 border-t border-[#8C6A4A]/15 pt-4 text-center">
+                <p className="mb-2 text-xs font-medium text-[#6A4D36]">
+                  まだ記録を始めていない方
+                </p>
+                <Link
+                  href="/signup"
+                  className="inline-flex items-center justify-center rounded-lg border border-[#7B63A8] bg-white px-4 py-2 text-xs font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
+                >
+                  無料でスタンプ帳をはじめる
+                </Link>
+              </div>
             </div>
-
-            {/* Password Input */}
-            <div>
-              <label className="flex items-center gap-2 font-pixelJp text-sm text-rpg-textDark mb-2">
-                <Lock className="w-4 h-4" />
-                パスワード
-              </label>
-              <input
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                className="w-full bg-white/70 border border-[#7B63A8]/15 p-3 font-pixelJp text-sm text-rpg-textDark focus:border-rpg-yellow focus:outline-none"
-                placeholder="••••••••"
-                required
-                disabled={loading}
-              />
-            </div>
-
-            {/* Login Button */}
-            <button
-              type="submit"
-              className="w-full rpg-button rpg-button-primary py-3"
-              disabled={loading}
-            >
-              <span className="font-pixelJp">
-                {loading ? 'ログイン中...' : 'ログイン'}
-              </span>
-            </button>
-          </form>
-
-          {/* Terms of Service Link */}
-          <div className="mt-4">
-            <button
-              type="button"
-              onClick={() => setShowTerms(!showTerms)}
-              className="flex items-center gap-1 font-pixelJp text-xs text-rpg-blue hover:opacity-70 transition-opacity mx-auto"
-            >
-              <Info className="w-3 h-3" />
-              <span>利用規約を確認</span>
-            </button>
           </div>
+        </section>
+      </main>
 
-          {showTerms && (
-            <div className="mt-3">
-              <TermsOfService
-                isChecked={false}
-                onCheckChange={() => {}}
-                className="border-rpg-yellow"
-              />
-            </div>
-          )}
-
-          {/* Sign Up Link */}
-          <div className="mt-6 pt-4 border-t border-[#7B63A8]/15 text-center">
-            <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mb-2">
-              アカウントをお持ちでない方
-            </p>
-            <Link href="/signup" className="rpg-button text-xs">
-              <span className="font-pixelJp">新規登録</span>
-            </Link>
-          </div>
-        </div>
-      </div>
-
-        <BottomNav />
+      <BottomNav />
     </div>
   );
 }

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -733,7 +733,7 @@ export default function ManholeDetailPage() {
                       className="rpg-button flex items-center justify-center gap-1 px-2 bg-white/70 border border-[#7B63A8] hover:bg-[#7B63A8]/5"
                     >
                       <Camera className="w-4 h-4 text-[#7B63A8]" />
-                      <span className="font-pixelJp text-xs text-[#7B63A8]">ログインして記録</span>
+                      <span className="font-pixelJp text-xs text-[#7B63A8]">旅の続きで記録</span>
                     </button>
                   )}
                   <button
@@ -936,7 +936,7 @@ export default function ManholeDetailPage() {
               </form>
             ) : (
               <div className="mt-4 pt-4 border-t border-[#7B63A8]/15">
-                <p className="font-pixelJp text-xs text-rpg-textDark opacity-70">ログインするとコメントを投稿できます</p>
+                <p className="font-pixelJp text-xs text-rpg-textDark opacity-70">ログインすると旅の記録にコメントを投稿できます</p>
               </div>
             )}
           </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -692,7 +692,7 @@ export default function HomePage() {
                         className="mt-5 inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
                       >
                         <Camera className="w-4 h-4" />
-                        <span>ログインして投稿</span>
+                        <span>旅の続きで投稿</span>
                       </Link>
                     </div>
                   ) : (

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -129,7 +129,7 @@ export default function PopularPage() {
             </h1>
             <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed text-[#6B6B6B] sm:text-lg">
               全国のユーザーが記録した写真から、次に行きたい場所を見つけられます。
-              ログインすると、あなたも旅の記録を保存できます。
+              ログインすると、あなたの旅の続きとして記録を保存できます。
             </p>
 
             {!isLoggedIn && (
@@ -297,7 +297,7 @@ export default function PopularPage() {
                 <Sparkles className="mx-auto mb-3 h-10 w-10 text-[#7B63A8]" />
                 <h3 className="text-xl font-extrabold">この旅を自分のスタンプ帳に保存しませんか？</h3>
                 <p className="mt-2 text-sm font-medium text-[#6B6B6B]">
-                  ログインすると、訪問済みや行きたい場所を記録できます。
+                  ログインすると、旅の続きとして訪問済みや行きたい場所を記録できます。
                   全国制覇率や都道府県別の進捗も見られます。
                 </p>
                 <div className="mt-6 flex flex-wrap justify-center gap-3">
@@ -312,7 +312,7 @@ export default function PopularPage() {
                     href="/login"
                     className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8] bg-white px-6 py-3 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
                   >
-                    ログイン
+                    旅の続きへ
                   </Link>
                 </div>
               </section>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { UserPlus, Mail, Lock, User, AlertCircle, CheckCircle } from 'lucide-react';
+import { AlertCircle, Camera, CheckCircle, Lock, Mail, Map, Shield, Stamp, User, UserPlus } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 import TermsOfService from '@/components/TermsOfService';
 import BottomNav from '@/components/BottomNav';
@@ -86,142 +86,168 @@ export default function SignUpPage() {
     }
   };
 
+  const benefitItems = [
+    {
+      icon: <Stamp className="h-5 w-5" />,
+      title: '自分だけのスタンプ帳',
+      description: '訪問済みのポケふたを集めて、全国制覇率を確認できます',
+    },
+    {
+      icon: <Camera className="h-5 w-5" />,
+      title: '写真を旅の記録に',
+      description: '撮影した写真を投稿して、あとから思い出を見返せます',
+    },
+    {
+      icon: <Map className="h-5 w-5" />,
+      title: '次に行く場所を探す',
+      description: '都道府県別の進捗や未訪問候補から次の目的地を見つけられます',
+    },
+  ];
+
   return (
-    <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC]">
-      <div className="w-full max-w-md mx-auto p-4">
-        {/* Header */}
-        <div className="rpg-window text-center mb-6">
-          <div className="inline-block mb-3">
-            <div className="w-16 h-16 bg-rpg-blue border border-[#7B63A8]/15 flex items-center justify-center mx-auto">
-              <UserPlus className="w-8 h-8 text-white" />
-            </div>
-          </div>
-          <h1 className="font-pixelJp text-lg text-[#7B63A8] font-bold">アカウント作成</h1>
-          <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mt-1">
-            登録すると訪問履歴が使えるようになります
-          </p>
-          <div className="mt-3 pt-3 border-t border-[#7B63A8]/15">
-            <p className="font-pixelJp text-[11px] text-rpg-textDark opacity-80 leading-relaxed">
-              GPS位置情報を公開して共有するため、メール確認が必要です。
-            </p>
-          </div>
-        </div>
+    <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
+      <main className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-4 py-6 sm:py-10">
+        <section className="relative w-full overflow-hidden rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
+          <div className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+          <div className="relative grid gap-0 lg:grid-cols-[1.1fr_0.9fr]">
+            <div className="p-5 sm:p-8 lg:p-10">
+              <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+                <UserPlus className="h-3.5 w-3.5" />
+                旅をはじめる
+              </div>
 
-        {/* Sign Up Form */}
-        <div className="rpg-window">
-          {success ? (
-            <div className="text-center py-8">
-              <CheckCircle className="w-16 h-16 text-rpg-green mx-auto mb-4" />
-              <h2 className="font-pixelJp text-lg text-rpg-green mb-2">登録完了!</h2>
-              <p className="font-pixelJp text-sm text-rpg-textDark opacity-70">
-                ログインページに移動します...
+              <h1 className="max-w-xl text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
+                スタンプ帳を作成
+              </h1>
+              <p className="mt-4 max-w-xl text-sm font-medium leading-relaxed text-[#6A4D36] sm:text-base">
+                メールアドレスで無料登録すると、訪問履歴・写真投稿・都道府県別の進捗を保存できます。
               </p>
-            </div>
-          ) : (
-            <form onSubmit={handleSignUp} className="space-y-4">
-              {/* Error Message */}
-              {error && (
-                <div className="bg-rpg-red/20 border-2 border-rpg-red p-3">
-                  <div className="flex items-center gap-2 text-rpg-red">
-                    <AlertCircle className="w-4 h-4" />
-                    <span className="font-pixelJp text-xs">{error}</span>
+
+              <div className="mt-6 grid gap-3">
+                {benefitItems.map((item) => (
+                  <div key={item.title} className="flex items-start gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-white/65 p-4">
+                    <div className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-[#7B63A8]/10 text-[#7B63A8]">
+                      {item.icon}
+                    </div>
+                    <div>
+                      <h2 className="text-sm font-extrabold text-[#4F3828]">{item.title}</h2>
+                      <p className="mt-1 text-xs font-medium leading-relaxed text-[#6A4D36]">{item.description}</p>
+                    </div>
                   </div>
-                </div>
-              )}
-
-              {/* Display Name Input */}
-              <div>
-                <label className="flex items-center gap-2 font-pixelJp text-sm text-rpg-textDark mb-2">
-                  <User className="w-4 h-4" />
-                  表示名（任意）
-                </label>
-                <input
-                  type="text"
-                  value={displayName}
-                  onChange={(e) => setDisplayName(e.target.value)}
-                  className="w-full bg-white/70 border border-[#7B63A8]/15 p-3 font-pixelJp text-sm text-rpg-textDark focus:border-rpg-blue focus:outline-none"
-                  placeholder="トレーナー名"
-                  disabled={loading}
-                />
+                ))}
               </div>
-
-              {/* Email Input */}
-              <div>
-                <label className="flex items-center gap-2 font-pixelJp text-sm text-rpg-textDark mb-2">
-                  <Mail className="w-4 h-4" />
-                  メールアドレス
-                </label>
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full bg-white/70 border border-[#7B63A8]/15 p-3 font-pixelJp text-sm text-rpg-textDark focus:border-rpg-blue focus:outline-none"
-                  placeholder="your@email.com"
-                  required
-                  disabled={loading}
-                />
-              </div>
-
-              {/* Password Input */}
-              <div>
-                <label className="flex items-center gap-2 font-pixelJp text-sm text-rpg-textDark mb-2">
-                  <Lock className="w-4 h-4" />
-                  パスワード（6文字以上）
-                </label>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full bg-white/70 border border-[#7B63A8]/15 p-3 font-pixelJp text-sm text-rpg-textDark focus:border-rpg-blue focus:outline-none"
-                  placeholder="••••••••"
-                  required
-                  disabled={loading}
-                />
-              </div>
-
-              {/* Terms of Service */}
-              <TermsOfService
-                isChecked={agreedToTerms}
-                onCheckChange={setAgreedToTerms}
-              />
-
-              {/* Sign Up Button */}
-              <button
-                type="submit"
-                className="w-full rpg-button rpg-button-primary py-3"
-                disabled={loading || !agreedToTerms}
-              >
-                <span className="font-pixelJp">
-                  {loading ? '登録中...' : '登録する'}
-                </span>
-              </button>
-
-              {/* Conversion helper */}
-              <div className="bg-white/70 border border-[#7B63A8]/15 p-3">
-                <p className="font-pixelJp text-xs text-rpg-textDark font-bold mb-1">
-                  登録すると使える機能（例）
-                </p>
-                <ul className="space-y-1 font-pixelJp text-xs text-rpg-textDark opacity-80">
-                  <li>・写真の登録が「訪問履歴」としてたまる</li>
-                  <li>・あとで一覧/マップで見返せる</li>
-                  <li>・公開/非公開の設定ができる</li>
-                </ul>
-              </div>
-            </form>
-          )}
-
-          {!success && (
-            <div className="mt-6 pt-4 border-t border-[#7B63A8]/15 text-center">
-              <p className="font-pixelJp text-xs text-rpg-textDark opacity-70 mb-2">
-                すでにアカウントをお持ちの方
-              </p>
-              <Link href="/login" className="rpg-button text-xs">
-                <span className="font-pixelJp">ログイン</span>
-              </Link>
             </div>
-          )}
-        </div>
-      </div>
+
+            <div className="border-t border-[#8C6A4A]/15 bg-[#FFF8EB]/80 p-5 sm:p-8 lg:border-l lg:border-t-0 lg:p-10">
+              {success ? (
+                <div className="rounded-[8px] border border-[#2D846C]/25 bg-white/75 px-5 py-8 text-center">
+                  <CheckCircle className="mx-auto mb-4 h-14 w-14 text-[#2D846C]" />
+                  <h2 className="text-xl font-extrabold text-[#2D846C]">登録完了!</h2>
+                  <p className="mt-2 text-sm font-medium leading-relaxed text-[#6A4D36]">
+                    確認メールを送信しました。ログインページに移動します...
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div className="mb-4 rounded-[8px] border border-[#7B63A8]/20 bg-white/70 p-3">
+                    <div className="flex items-start gap-2">
+                      <Shield className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#7B63A8]" />
+                      <p className="text-xs font-bold leading-relaxed text-[#6A4D36]">
+                        写真や位置情報を扱うため、登録後にメール確認が必要です。
+                      </p>
+                    </div>
+                  </div>
+
+                  <form onSubmit={handleSignUp} className="space-y-4">
+                    {error && (
+                      <div className="rounded-[8px] border border-[#B5483C]/30 bg-[#F8D9C4] p-3">
+                        <div className="flex items-center gap-2 text-[#B5483C]">
+                          <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                          <span className="text-xs font-bold">{error}</span>
+                        </div>
+                      </div>
+                    )}
+
+                    <div>
+                      <label className="mb-2 flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                        <User className="h-4 w-4" />
+                        表示名（任意）
+                      </label>
+                      <input
+                        type="text"
+                        value={displayName}
+                        onChange={(e) => setDisplayName(e.target.value)}
+                        className="w-full rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-3 text-sm font-medium text-[#2A2A2A] outline-none transition focus:border-[#7B63A8] focus:ring-2 focus:ring-[#7B63A8]/15"
+                        placeholder="トレーナー名"
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <div>
+                      <label className="mb-2 flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                        <Mail className="h-4 w-4" />
+                        メールアドレス
+                      </label>
+                      <input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        className="w-full rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-3 text-sm font-medium text-[#2A2A2A] outline-none transition focus:border-[#7B63A8] focus:ring-2 focus:ring-[#7B63A8]/15"
+                        placeholder="your@email.com"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <div>
+                      <label className="mb-2 flex items-center gap-2 text-sm font-extrabold text-[#4F3828]">
+                        <Lock className="h-4 w-4" />
+                        パスワード（6文字以上）
+                      </label>
+                      <input
+                        type="password"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="w-full rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-3 text-sm font-medium text-[#2A2A2A] outline-none transition focus:border-[#7B63A8] focus:ring-2 focus:ring-[#7B63A8]/15"
+                        placeholder="••••••••"
+                        required
+                        disabled={loading}
+                      />
+                    </div>
+
+                    <TermsOfService
+                      isChecked={agreedToTerms}
+                      onCheckChange={setAgreedToTerms}
+                      className="rounded-[8px] border-[#8C6A4A]/20"
+                    />
+
+                    <button
+                      type="submit"
+                      className="inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-5 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299] disabled:opacity-60"
+                      disabled={loading || !agreedToTerms}
+                    >
+                      <UserPlus className="h-4 w-4" />
+                      <span>{loading ? '登録中...' : '無料でスタンプ帳をはじめる'}</span>
+                    </button>
+                  </form>
+
+                  <div className="mt-6 border-t border-[#8C6A4A]/15 pt-4 text-center">
+                    <p className="mb-2 text-xs font-medium text-[#6A4D36]">
+                      すでにアカウントをお持ちの方
+                    </p>
+                    <Link
+                      href="/login"
+                      className="inline-flex items-center justify-center rounded-lg border border-[#7B63A8] bg-white px-4 py-2 text-xs font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
+                    >
+                      旅の続きへログイン
+                    </Link>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </section>
+      </main>
 
       <BottomNav />
     </div>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -491,7 +491,7 @@ export default function VisitsPage() {
                 ポケふた訪問パスポート
               </h1>
               <p className="mt-3 text-sm font-medium text-[#6A4D36]">
-                ログインすると、全国{totalManholes || '470'}箇所以上のポケふたをコレクションできます
+                ログインすると、あなたの旅の続きとして全国{totalManholes || '470'}箇所以上のポケふたをコレクションできます
               </p>
 
               {/* Sample Progress Bar */}
@@ -521,7 +521,7 @@ export default function VisitsPage() {
                   href="/login?redirect=/visits"
                   className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8] bg-white px-6 py-3 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
                 >
-                  ログイン
+                  旅の続きへ
                 </Link>
               </div>
             </div>
@@ -594,7 +594,7 @@ export default function VisitsPage() {
               ))}
             </div>
             <p className="mt-3 text-center text-xs text-[#6A4D36]">
-              ログインして、あなたの旅を記録しましょう
+              ログインして、あなたの旅の続きを記録しましょう
             </p>
           </section>
 
@@ -605,7 +605,7 @@ export default function VisitsPage() {
               旅の記録を保存しませんか？
             </h3>
             <p className="mt-2 text-sm font-medium text-[#6B6B6B]">
-              ログインすると、訪問済みや行きたい場所を記録できます。<br />
+              ログインすると、旅の続きとして訪問済みや行きたい場所を記録できます。<br />
               全国制覇率や都道府県別の進捗も見られます。
             </p>
             <div className="mt-5 flex flex-wrap justify-center gap-3">
@@ -620,7 +620,7 @@ export default function VisitsPage() {
                 href="/login?redirect=/visits"
                 className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8] bg-white px-6 py-3 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
               >
-                ログイン
+                旅の続きへ
               </Link>
             </div>
           </section>

--- a/src/components/UnauthFooter.tsx
+++ b/src/components/UnauthFooter.tsx
@@ -15,7 +15,7 @@ export default function UnauthFooter() {
 
   const items = [
     { href: '/', label: 'ホーム', icon: <Home className="w-6 h-6 mb-1" /> },
-    { href: '/login?redirect=/upload', label: 'ログイン', icon: <LogIn className="w-6 h-6 mb-1" /> },
+    { href: '/login?redirect=/upload', label: '旅の続き', icon: <LogIn className="w-6 h-6 mb-1" /> },
     { href: '/signup', label: 'アカウント作成', icon: <UserPlus className="w-6 h-6 mb-1" /> },
   ];
 


### PR DESCRIPTION
## Summary
- Refresh the login and signup pages into the current paper-style journey UI.
- Add concise retention/onboarding copy for stamp book, photo posting, and prefecture progress.
- Align unauthenticated CTA copy around “旅の続き” and correct the about page registration description to email-only.

## Verification
- `npm run type-check`
- `git diff --check`
- `npm run build` completed successfully with existing Dynamic Server Usage/Browserslist warnings.
- Puppeteer smoke checks covered `/signup` and `/login` on `localhost:3000` at 390px and 1280px with no horizontal overflow.
- Earlier smoke checks also covered `/login?redirect=/upload`, `/login?from=register&redirect=/upload`, `/`, `/visits`, `/popular`, and `/manhole/1` with no horizontal overflow.