### PR TITLE
Add rare manhole preview to login

### DIFF
--- a/src/app/api/manholes/rare-preview/route.ts
+++ b/src/app/api/manholes/rare-preview/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import type { Database, ManholeTitle } from '@/types/database';
+
+type RarePreviewManhole = {
+  id: number;
+  prefecture: string | null;
+  municipality: string | null;
+  title: string | null;
+  pokemons: string[] | null;
+  titles: ManholeTitle[] | null;
+};
+
+const SELECT_FIELDS = 'id, prefecture, municipality, title, pokemons, titles';
+
+const getTopTitlePriority = (titles?: ManholeTitle[] | null) =>
+  Math.max(...(Array.isArray(titles) ? titles.map((title) => title.priority ?? 0) : [0]));
+
+export async function GET() {
+  try {
+    const supabase = createRouteHandlerClient<Database>({ cookies });
+
+    const { data, error } = await supabase
+      .from('manhole')
+      .select(SELECT_FIELDS)
+      .not('titles', 'is', null)
+      .limit(120);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const manholes = ((data ?? []) as RarePreviewManhole[])
+      .filter((manhole) => Array.isArray(manhole.titles) && manhole.titles.length > 0)
+      .sort((a, b) => getTopTitlePriority(b.titles) - getTopTitlePriority(a.titles))
+      .slice(0, 3);
+
+    return NextResponse.json({
+      success: true,
+      manholes,
+    });
+  } catch (error: unknown) {
+    return NextResponse.json(
+      {
+        success: false,
+        manholes: [],
+        error: 'Failed to get rare manhole preview',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/manholes/rare-preview/route.ts
+++ b/src/app/api/manholes/rare-preview/route.ts
@@ -13,6 +13,16 @@ type RarePreviewManhole = {
 };
 
 const SELECT_FIELDS = 'id, prefecture, municipality, title, pokemons, titles';
+const PREVIEW_TITLE_KEYS = [
+  'north_end',
+  'south_end',
+  'east_end',
+  'west_end',
+  'unique_pokemon',
+  'rare_pokemon',
+  'remote_island',
+  'only_in_pref',
+];
 
 const getTopTitlePriority = (titles?: ManholeTitle[] | null) =>
   Math.max(...(Array.isArray(titles) ? titles.map((title) => title.priority ?? 0) : [0]));
@@ -21,18 +31,31 @@ export async function GET() {
   try {
     const supabase = createRouteHandlerClient<Database>({ cookies });
 
-    const { data, error } = await supabase
-      .from('manhole')
-      .select(SELECT_FIELDS)
-      .not('title_tags', 'eq', '{}')
-      .order('id', { ascending: true })
-      .limit(120);
+    const results = await Promise.all(
+      PREVIEW_TITLE_KEYS.map((key) =>
+        supabase
+          .from('manhole')
+          .select(SELECT_FIELDS)
+          .contains('title_tags', [key])
+          .order('id', { ascending: true })
+          .limit(3)
+      )
+    );
+
+    const error = results.find((result) => result.error)?.error;
 
     if (error) {
       throw new Error(error.message);
     }
 
-    const manholes = ((data ?? []) as RarePreviewManhole[])
+    const byId = new Map<number, RarePreviewManhole>();
+    results.forEach((result) => {
+      ((result.data ?? []) as RarePreviewManhole[]).forEach((manhole) => {
+        byId.set(manhole.id, manhole);
+      });
+    });
+
+    const manholes = Array.from(byId.values())
       .filter((manhole) => Array.isArray(manhole.titles) && manhole.titles.length > 0)
       .sort((a, b) => getTopTitlePriority(b.titles) - getTopTitlePriority(a.titles))
       .slice(0, 3);

--- a/src/app/api/manholes/rare-preview/route.ts
+++ b/src/app/api/manholes/rare-preview/route.ts
@@ -24,7 +24,8 @@ export async function GET() {
     const { data, error } = await supabase
       .from('manhole')
       .select(SELECT_FIELDS)
-      .not('titles', 'is', null)
+      .not('title_tags', 'eq', '{}')
+      .order('id', { ascending: true })
       .limit(120);
 
     if (error) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -4,15 +4,70 @@ import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import BottomNav from '@/components/BottomNav';
-import { AlertCircle, Camera, Info, Lock, LogIn, Mail, Map, Stamp } from 'lucide-react';
+import { AlertCircle, Camera, Info, Lock, LogIn, Mail, Map, Sparkles, Stamp } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 import TermsOfService from '@/components/TermsOfService';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
+import type { ManholeTitle } from '@/types/database';
+
+type RarePreviewManhole = {
+  id: number;
+  prefecture?: string | null;
+  municipality?: string | null;
+  city?: string | null;
+  title?: string | null;
+  pokemons?: string[] | null;
+  titles?: ManholeTitle[] | null;
+  hashtags?: string[] | null;
+  title_tags?: string[] | null;
+};
+
+type RarePreviewItem = {
+  id: number;
+  badge: string;
+  title: string;
+  location: string;
+  pokemon: string;
+};
 
 function getSafeRedirectPath(value: string | null) {
   if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
   return value;
 }
+
+const getSortedTitles = (titles?: ManholeTitle[] | null) =>
+  [...(Array.isArray(titles) ? titles : [])].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+
+const getRareBadge = (title?: ManholeTitle) => {
+  if (!title) return '称号つき';
+  if (title.key === 'unique_pokemon') return '激レア';
+  if (title.key === 'rare_pokemon') return 'レア';
+  if (['north_end', 'south_end', 'east_end', 'west_end'].includes(title.key)) return '端っこ';
+  if (title.key === 'newest') return '新作';
+  return '発見候補';
+};
+
+const getLocationLabel = (manhole: RarePreviewManhole) =>
+  [manhole.prefecture, manhole.city || manhole.municipality].filter(Boolean).join(' ') || '場所未設定';
+
+const getRarePreviewItems = (manholes: RarePreviewManhole[]): RarePreviewItem[] =>
+  manholes
+    .map((manhole) => {
+      const topTitle = getSortedTitles(manhole.titles)[0];
+      if (!topTitle) return null;
+
+      return {
+        id: manhole.id,
+        badge: getRareBadge(topTitle),
+        title: topTitle.label,
+        location: getLocationLabel(manhole),
+        pokemon: Array.isArray(manhole.pokemons) && manhole.pokemons.length > 0
+          ? manhole.pokemons.slice(0, 2).join('・')
+          : manhole.title || 'ポケふた',
+      };
+    })
+    .filter((item): item is RarePreviewItem => item !== null)
+    .slice(0, 3);
 
 function LoginForm() {
   const router = useRouter();
@@ -26,6 +81,7 @@ function LoginForm() {
   const [showTerms, setShowTerms] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [rarePreviewItems, setRarePreviewItems] = useState<RarePreviewItem[]>([]);
 
   const supabase = createBrowserClient();
   const { trackLoginStart, trackLoginSuccess, setUser, trackAuthError, updateUserProperties } = useAnalytics();
@@ -33,6 +89,33 @@ function LoginForm() {
   // ページタイトル設定
   useEffect(() => {
     document.title = 'ログイン - ポケふた訪問記録';
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadRarePreview = async () => {
+      try {
+        const response = await fetch('/api/manholes/rare-preview');
+        const data = await response.json();
+        const manholes: RarePreviewManhole[] = Array.isArray(data?.manholes) ? data.manholes : [];
+        const previewItems = getRarePreviewItems(
+          manholes.filter((manhole) => Array.isArray(manhole.titles) && manhole.titles.length > 0)
+        );
+
+        if (isMounted) {
+          setRarePreviewItems(previewItems);
+        }
+      } catch (err) {
+        console.warn('レアポケふた候補の取得に失敗しました:', err);
+      }
+    };
+
+    loadRarePreview();
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
 
   const handleLogin = async (e: React.FormEvent) => {
@@ -157,6 +240,42 @@ function LoginForm() {
                   </div>
                 ))}
               </div>
+
+              {rarePreviewItems.length > 0 && (
+                <div className="mt-5 rounded-[8px] border border-[#DDA63A]/30 bg-[#FFF0C7]/80 p-4 shadow-sm">
+                  <div className="mb-3 flex items-center justify-between gap-3">
+                    <div>
+                      <p className="text-xs font-extrabold text-[#8C6315]">未発見のレアふたが待っています</p>
+                      <p className="mt-1 text-[11px] font-medium leading-relaxed text-[#6A4D36]">
+                        ログインすると訪問済みと照らし合わせて、称号つき候補を探せます。
+                      </p>
+                    </div>
+                    <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white text-[#B5483C]">
+                      <Sparkles className="h-4 w-4" />
+                    </div>
+                  </div>
+
+                  <div className="grid gap-2">
+                    {rarePreviewItems.map((item) => (
+                      <Link
+                        key={item.id}
+                        href={`/manhole/${item.id}`}
+                        className="group flex items-center gap-3 rounded-[7px] border border-[#8C6A4A]/15 bg-white/75 px-3 py-2 transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+                      >
+                        <span className="w-[58px] flex-shrink-0 rounded-full bg-[#B5483C]/10 px-2 py-1 text-center text-[10px] font-extrabold text-[#B5483C]">
+                          {item.badge}
+                        </span>
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-xs font-extrabold text-[#4F3828]">{item.title}</span>
+                          <span className="mt-0.5 block truncate text-[11px] font-medium text-[#6A4D36]">
+                            {item.location} / {item.pokemon}
+                          </span>
+                        </span>
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
 
             <div className="border-t border-[#8C6A4A]/15 bg-[#FFF8EB]/80 p-5 sm:p-8 lg:border-l lg:border-t-0 lg:p-10">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -98,6 +98,9 @@ function LoginForm() {
       try {
         const response = await fetch('/api/manholes/rare-preview');
         const data = await response.json();
+        if (!response.ok || data?.success === false) {
+          throw new Error(data?.details || data?.error || 'Failed to load rare manhole preview');
+        }
         const manholes: RarePreviewManhole[] = Array.isArray(data?.manholes) ? data.manholes : [];
         const previewItems = getRarePreviewItems(
           manholes.filter((manhole) => Array.isArray(manhole.titles) && manhole.titles.length > 0)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -504,6 +504,17 @@ export default function HomePage() {
                         </p>
                       </div>
                     )}
+                    {interestingCandidates.length > 0 && (
+                      <div className="mt-3">
+                        <a
+                          href="#rare-unvisited"
+                          className="inline-flex min-h-[36px] items-center gap-2 rounded-[7px] border border-[#B5483C]/25 bg-white/70 px-3 py-2 text-xs font-extrabold text-[#B5483C] shadow-sm transition hover:bg-[#F8D9C4] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+                        >
+                          <Sparkles className="h-4 w-4" />
+                          称号つき未訪問を探す
+                        </a>
+                      </div>
+                    )}
                   </div>
                 </section>
 
@@ -588,7 +599,7 @@ export default function HomePage() {
                       )}
                     </JourneyCandidateSection>
 
-                    <JourneyCandidateSection title="称号が気になる未訪問" description="写真がまだ少なく、titlesが個性的な発見候補">
+                    <JourneyCandidateSection id="rare-unvisited" title="称号が気になる未訪問" description="写真がまだ少なく、titlesが個性的な発見候補">
                       {interestingCandidates.length > 0 ? (
                         interestingCandidates.map((manhole) => (
                           <JourneyUnvisitedCard key={manhole.id} manhole={manhole} badge="発見" />
@@ -932,18 +943,20 @@ function JourneyHistoryCard({ manhole, visits }: { manhole: JourneyManhole; visi
 }
 
 function JourneyCandidateSection({
+  id,
   title,
   description,
   action,
   children,
 }: {
+  id?: string;
   title: string;
   description: string;
   action?: ReactNode;
   children: ReactNode;
 }) {
   return (
-    <div>
+    <div id={id}>
       <div className="mb-3 flex items-end justify-between gap-3">
         <div>
           <h2 className="text-lg font-extrabold text-[#4F3828]">{title}</h2>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -550,6 +550,16 @@ export default function HomePage() {
                         <a
                           href="/?tab=unvisited#rare-unvisited"
                           onClick={(event) => {
+                            if (
+                              event.defaultPrevented ||
+                              event.button !== 0 ||
+                              event.metaKey ||
+                              event.ctrlKey ||
+                              event.shiftKey ||
+                              event.altKey
+                            ) {
+                              return;
+                            }
                             event.preventDefault();
                             selectJourneyTab('unvisited', 'rare-unvisited');
                           }}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,6 +77,22 @@ const journeyTabs: Array<{ key: JourneyTab; label: string }> = [
   { key: 'unvisited', label: '未訪問' },
 ];
 
+const getJourneyTabFromUrl = (): JourneyTab => {
+  if (typeof window === 'undefined') return 'history';
+  return new URLSearchParams(window.location.search).get('tab') === 'unvisited' ? 'unvisited' : 'history';
+};
+
+const updateJourneyTabUrl = (tab: JourneyTab, hash?: string) => {
+  const url = new URL(window.location.href);
+  if (tab === 'history') {
+    url.searchParams.delete('tab');
+  } else {
+    url.searchParams.set('tab', tab);
+  }
+  url.hash = hash ? `#${hash}` : '';
+  window.history.pushState({}, '', `${url.pathname}${url.search}${url.hash}`);
+};
+
 const getDisplayName = (session: any) => {
   const metadataName = session?.user?.user_metadata?.display_name;
   const emailName = session?.user?.email?.split('@')[0];
@@ -148,6 +164,14 @@ export default function HomePage() {
   const feedPerPage = 24;
   const { trackView, trackCollectionOpen, updateUserProperties } = useAnalytics();
 
+  const selectJourneyTab = (tab: JourneyTab, hash?: string) => {
+    setJourneyTab(tab);
+    updateJourneyTabUrl(tab, hash);
+    if (hash) {
+      window.requestAnimationFrame(() => document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' }));
+    }
+  };
+
   useEffect(() => {
     document.title = 'ポケふた写真館 - ポケふた訪問記録';
     trackView('/', 'ホーム', 'home');
@@ -177,6 +201,23 @@ export default function HomePage() {
 
     loadSiteStats();
   }, []);
+
+  useEffect(() => {
+    setJourneyTab(getJourneyTabFromUrl());
+
+    const handlePopState = () => {
+      setJourneyTab(getJourneyTabFromUrl());
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  useEffect(() => {
+    if (!loading && journeyTab === 'unvisited' && window.location.hash === '#rare-unvisited') {
+      window.requestAnimationFrame(() => document.getElementById('rare-unvisited')?.scrollIntoView());
+    }
+  }, [journeyTab, loading]);
 
   useEffect(() => {
     loadFeed();
@@ -507,7 +548,11 @@ export default function HomePage() {
                     {interestingCandidates.length > 0 && (
                       <div className="mt-3">
                         <a
-                          href="#rare-unvisited"
+                          href="/?tab=unvisited#rare-unvisited"
+                          onClick={(event) => {
+                            event.preventDefault();
+                            selectJourneyTab('unvisited', 'rare-unvisited');
+                          }}
                           className="inline-flex min-h-[36px] items-center gap-2 rounded-[7px] border border-[#B5483C]/25 bg-white/70 px-3 py-2 text-xs font-extrabold text-[#B5483C] shadow-sm transition hover:bg-[#F8D9C4] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
                         >
                           <Sparkles className="h-4 w-4" />
@@ -527,7 +572,7 @@ export default function HomePage() {
                           <button
                             key={tab.key}
                             type="button"
-                            onClick={() => setJourneyTab(tab.key)}
+                            onClick={() => selectJourneyTab(tab.key)}
                             className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
                               isActive
                                 ? 'bg-[#4F3828] text-[#FFF7E5] shadow-sm'

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -67,6 +67,25 @@ const tabs: { id: PassportTab; label: string }[] = [
   { id: 'unvisited', label: '未訪問' },
 ];
 
+const passportTabIds = new Set<PassportTab>(tabs.map((tab) => tab.id));
+
+const getPassportTabFromUrl = (): PassportTab => {
+  if (typeof window === 'undefined') return 'stamps';
+  const tab = new URLSearchParams(window.location.search).get('tab') as PassportTab | null;
+  return tab && passportTabIds.has(tab) ? tab : 'stamps';
+};
+
+const updatePassportTabUrl = (tab: PassportTab) => {
+  const url = new URL(window.location.href);
+  if (tab === 'stamps') {
+    url.searchParams.delete('tab');
+  } else {
+    url.searchParams.set('tab', tab);
+  }
+  url.hash = '';
+  window.history.pushState({}, '', `${url.pathname}${url.search}`);
+};
+
 const formatVisitDate = (date: string, pattern = 'yyyy/MM/dd') => {
   const parsed = new Date(date);
   if (Number.isNaN(parsed.getTime())) return '日付なし';
@@ -91,11 +110,27 @@ export default function VisitsPage() {
   const sharePanelCleanupRef = useRef<(() => void) | null>(null);
   useEffect(() => { return () => { sharePanelCleanupRef.current?.(); }; }, []);
 
+  const selectPassportTab = (tab: PassportTab) => {
+    setActiveTab(tab);
+    updatePassportTabUrl(tab);
+  };
+
   useEffect(() => {
     document.title = 'ポケふた訪問パスポート - ポケふた訪問記録';
     trackView('/visits', 'ポケふた訪問パスポート', 'visits');
     trackPassportOpen();
     checkAuth();
+  }, []);
+
+  useEffect(() => {
+    setActiveTab(getPassportTabFromUrl());
+
+    const handlePopState = () => {
+      setActiveTab(getPassportTabFromUrl());
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
   }, []);
 
   const handleShare = async () => {
@@ -721,7 +756,8 @@ export default function VisitsPage() {
               {tabs.map((tab) => (
                 <button
                   key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
+                  type="button"
+                  onClick={() => selectPassportTab(tab.id)}
                   className={`min-h-[38px] rounded-md px-2 text-center font-pixelJp text-[11px] font-bold transition-colors sm:text-xs ${
                     activeTab === tab.id
                       ? 'bg-[#4F3828] text-[#FFF7E5]'


### PR DESCRIPTION
## Summary
- Add a lightweight rare manhole preview API for the login page.
- Show up to three title-bearing manholes as a small travel preview in the login left column.
- Replace the heavy `/api/manholes?limit=1000` login fetch with `/api/manholes/rare-preview`.
- Sync logged-in journey tabs with URL query params so history/unvisited states can be shared and restored.

## Review Fix
- Addressed the review concern about loading the full manhole catalog from the auth funnel.
- The new endpoint selects only `id`, location, title, Pokemon names, and titles, then returns only three preview rows.

## URL State
- Home journey tabs now support `/` for visit history and `/?tab=unvisited` for unvisited.
- The rare shortcut now points to `/?tab=unvisited#rare-unvisited`.
- Passport tabs now support `/visits`, `/visits?tab=prefectures`, and `/visits?tab=unvisited`.
- Browser back/forward updates the active tab.

## Verification
- `npm run type-check`
- `git diff --check`
- `curl -L http://127.0.0.1:3002/api/manholes/rare-preview` returned `success: true` with 3 manholes.
- `curl -I http://127.0.0.1:3002/login?redirect=/upload` returned `200 OK`.
- Puppeteer smoke checked `/login?redirect=/upload` at 390x844 and 1280x800: form visible, redirect notice visible, rare preview visible, no horizontal overflow.

## Notes
- `npm run build` compiled successfully, but failed during page data collection with an existing Next.js generated chunk resolution error for `/api/photo/[id]` (`Cannot find module ./8948.js`). This appears unrelated to the changed login preview route.