### PR TITLE
Fix email confirmation redirect and GA conversion tracking

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,38 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+function getSafeRedirectPath(value: string | null) {
+  if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
+  return value;
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const code = requestUrl.searchParams.get('code');
+  const next = getSafeRedirectPath(requestUrl.searchParams.get('next'));
+  const conversion = requestUrl.searchParams.get('conversion');
+  const redirectUrl = new URL('/login', requestUrl.origin);
+
+  if (!code) {
+    redirectUrl.searchParams.set('auth_error', 'missing_auth_code');
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  const supabase = createRouteHandlerClient({ cookies });
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    redirectUrl.searchParams.set('auth_error', 'email_confirm_failed');
+    return NextResponse.redirect(redirectUrl);
+  }
+
+  redirectUrl.searchParams.set('from', 'email_confirmed');
+  redirectUrl.searchParams.set('redirect', next);
+
+  if (conversion === 'signup_email_confirmed') {
+    redirectUrl.searchParams.set('conversion', conversion);
+  }
+
+  return NextResponse.redirect(redirectUrl);
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -75,6 +75,8 @@ function LoginForm() {
   const redirectTo = getSafeRedirectPath(searchParams.get('redirect'));
   const hasRedirect = redirectTo !== '/';
   const fromRegister = searchParams.get('from') === 'register';
+  const fromEmailConfirmed = searchParams.get('from') === 'email_confirmed';
+  const conversion = searchParams.get('conversion');
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -84,12 +86,65 @@ function LoginForm() {
   const [rarePreviewItems, setRarePreviewItems] = useState<RarePreviewItem[]>([]);
 
   const supabase = createBrowserClient();
-  const { trackLoginStart, trackLoginSuccess, setUser, trackAuthError, updateUserProperties } = useAnalytics();
+  const {
+    trackLoginStart,
+    trackLoginSuccess,
+    trackSignupEmailConfirmed,
+    setUser,
+    trackAuthError,
+    updateUserProperties,
+  } = useAnalytics();
 
   // ページタイトル設定
   useEffect(() => {
     document.title = 'ログイン - ポケふた訪問記録';
   }, []);
+
+  useEffect(() => {
+    if (!fromEmailConfirmed || conversion !== 'signup_email_confirmed') return;
+
+    let isMounted = true;
+
+    const completeEmailConfirmation = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!isMounted || !session?.user?.id) return;
+
+      const storageKey = `pokefuta:signup_email_confirmed:${session.user.id}`;
+      if (sessionStorage.getItem(storageKey) !== 'true') {
+        setUser(session.user.id);
+        trackSignupEmailConfirmed({
+          conversion_type: 'signup_email_confirmed',
+          redirect_target: redirectTo,
+          auth_flow: 'email_confirmation',
+        });
+        updateUserProperties({ registered_user: true });
+        sessionStorage.setItem(storageKey, 'true');
+      }
+
+      router.replace(redirectTo);
+      router.refresh();
+    };
+
+    completeEmailConfirmation().catch((err) => {
+      console.error('メール確認後のログイン状態確認に失敗:', err);
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [
+    conversion,
+    fromEmailConfirmed,
+    redirectTo,
+    router,
+    setUser,
+    supabase,
+    trackSignupEmailConfirmed,
+    updateUserProperties,
+  ]);
 
   useEffect(() => {
     let isMounted = true;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, useMemo, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import BottomNav from '@/components/BottomNav';
@@ -33,6 +33,16 @@ type RarePreviewItem = {
 function getSafeRedirectPath(value: string | null) {
   if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
   return value;
+}
+
+function getAuthErrorMessage(value: string | null) {
+  if (value === 'missing_auth_code') {
+    return '確認リンクが無効です。メールのリンクをもう一度開いてください。';
+  }
+  if (value === 'email_confirm_failed') {
+    return 'メール確認に失敗しました。確認リンクの有効期限が切れている可能性があります。';
+  }
+  return null;
 }
 
 const getSortedTitles = (titles?: ManholeTitle[] | null) =>
@@ -77,6 +87,7 @@ function LoginForm() {
   const fromRegister = searchParams.get('from') === 'register';
   const fromEmailConfirmed = searchParams.get('from') === 'email_confirmed';
   const conversion = searchParams.get('conversion');
+  const authError = searchParams.get('auth_error');
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -85,7 +96,7 @@ function LoginForm() {
   const [error, setError] = useState<string | null>(null);
   const [rarePreviewItems, setRarePreviewItems] = useState<RarePreviewItem[]>([]);
 
-  const supabase = createBrowserClient();
+  const supabase = useMemo(() => createBrowserClient(), []);
   const {
     trackLoginStart,
     trackLoginSuccess,
@@ -99,6 +110,14 @@ function LoginForm() {
   useEffect(() => {
     document.title = 'ログイン - ポケふた訪問記録';
   }, []);
+
+  useEffect(() => {
+    const authErrorMessage = getAuthErrorMessage(authError);
+    if (!authError || !authErrorMessage) return;
+
+    setError(authErrorMessage);
+    trackAuthError(authError, authErrorMessage);
+  }, [authError, trackAuthError]);
 
   useEffect(() => {
     if (!fromEmailConfirmed || conversion !== 'signup_email_confirmed') return;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -21,7 +21,7 @@ function normalizeBaseUrl(value: string) {
 function isLocalBaseUrl(value: string) {
   try {
     const { hostname } = new URL(value);
-    return hostname === 'localhost' || hostname === '127.0.0.1';
+    return ['localhost', '127.0.0.1', '::1', '[::1]'].includes(hostname);
   } catch {
     return false;
   }

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -9,6 +9,47 @@ import TermsOfService from '@/components/TermsOfService';
 import BottomNav from '@/components/BottomNav';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
+const SIGNUP_CONFIRMATION_REDIRECT_PATH = '/upload';
+const SIGNUP_CONFIRMATION_CONVERSION = 'signup_email_confirmed';
+const PRODUCTION_APP_URL = 'https://pokefuta.com';
+
+function normalizeBaseUrl(value: string) {
+  const urlWithProtocol = value.startsWith('http') ? value : `https://${value}`;
+  return urlWithProtocol.replace(/\/$/, '');
+}
+
+function isLocalBaseUrl(value: string) {
+  try {
+    const { hostname } = new URL(value);
+    return hostname === 'localhost' || hostname === '127.0.0.1';
+  } catch {
+    return false;
+  }
+}
+
+function getAppBaseUrl() {
+  const configuredUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.NEXT_PUBLIC_APP_URL;
+  const normalizedConfiguredUrl = configuredUrl ? normalizeBaseUrl(configuredUrl) : null;
+
+  if (typeof window !== 'undefined') {
+    const currentOrigin = normalizeBaseUrl(window.location.origin);
+    if (isLocalBaseUrl(currentOrigin)) return currentOrigin;
+    if (normalizedConfiguredUrl && !isLocalBaseUrl(normalizedConfiguredUrl)) return normalizedConfiguredUrl;
+    return PRODUCTION_APP_URL;
+  }
+
+  if (normalizedConfiguredUrl && !isLocalBaseUrl(normalizedConfiguredUrl)) return normalizedConfiguredUrl;
+  return PRODUCTION_APP_URL;
+}
+
+function getSignupEmailRedirectUrl() {
+  const callbackUrl = new URL('/auth/callback', getAppBaseUrl());
+  callbackUrl.searchParams.set('next', SIGNUP_CONFIRMATION_REDIRECT_PATH);
+  callbackUrl.searchParams.set('conversion', SIGNUP_CONFIRMATION_CONVERSION);
+
+  return callbackUrl.toString();
+}
+
 export default function SignUpPage() {
   const router = useRouter();
 
@@ -46,6 +87,7 @@ export default function SignUpPage() {
         email,
         password,
         options: {
+          emailRedirectTo: getSignupEmailRedirectUrl(),
           data: {
             display_name: displayName || email.split('@')[0],
           },

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -179,6 +179,7 @@ export const pokefutaEvents = {
   loginSuccess:        (p?: PokefutaEventParams) => trackEvent('p_login_success', p),
   signupStart:         (p?: PokefutaEventParams) => trackEvent('p_signup_start', p),
   signupComplete:      (p?: PokefutaEventParams) => trackEvent('p_signup_complete', p),
+  signupEmailConfirmed:(p?: PokefutaEventParams) => trackEvent('p_signup_email_confirmed', p),
   logout:              (p?: PokefutaEventParams) => trackEvent('p_logout', p),
 
   // --- 訪問記録系 ---

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -52,6 +52,7 @@ export function useAnalytics() {
   const trackLoginSuccess  = useCallback((p?: PokefutaEventParams) => pokefutaEvents.loginSuccess(p), []);
   const trackSignupStart   = useCallback((p?: PokefutaEventParams) => pokefutaEvents.signupStart(p), []);
   const trackSignupComplete= useCallback((p?: PokefutaEventParams) => pokefutaEvents.signupComplete(p), []);
+  const trackSignupEmailConfirmed = useCallback((p?: PokefutaEventParams) => pokefutaEvents.signupEmailConfirmed(p), []);
   const trackLogout        = useCallback((p?: PokefutaEventParams) => pokefutaEvents.logout(p), []);
 
   // --- 訪問記録系 ---
@@ -127,6 +128,7 @@ export function useAnalytics() {
     trackLoginSuccess,
     trackSignupStart,
     trackSignupComplete,
+    trackSignupEmailConfirmed,
     trackLogout,
 
     // 訪問記録系


### PR DESCRIPTION
## Summary
- Add a Supabase auth callback route for email confirmation links.
- Send signup confirmation emails to `/auth/callback` with a safe app base URL.
- Track confirmed signup conversions with `p_signup_email_confirmed` after a session is established.

## Verification
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Deployment Notes
- Supabase Site URL should be `https://pokefuta.com/`.
- Supabase Redirect URLs should include `https://pokefuta.com/auth/callback`.
- Mark `p_signup_email_confirmed` as a GA4 key event for conversion tracking.