### PR TITLE
Add public prefecture progress sharing

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -58,6 +58,9 @@ const nextConfig = {
         './public/ogp/pokefuta_ogp_template.svg',
         './public/ogp/pokefuta_ogp_background_1200x630.png',
       ],
+      '/users/[userId]/prefectures/opengraph-image': [
+        './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
+      ],
     },
   },
   images: {

--- a/src/app/api/users/[userId]/prefectures/route.ts
+++ b/src/app/api/users/[userId]/prefectures/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { loadPublicUserPrefectureProgress } from '@/lib/user-prefecture-progress';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: {
+    userId: string;
+  };
+};
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  try {
+    const progress = await loadPublicUserPrefectureProgress(params.userId);
+
+    if (!progress) {
+      return NextResponse.json(
+        { success: false, error: 'User not found' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      user: {
+        id: progress.userId,
+        displayName: progress.displayName,
+      },
+      summary: {
+        completedPrefectureCount: progress.completedPrefectureCount,
+        totalPrefectureCount: progress.totalPrefectureCount,
+        visitedManholeCount: progress.visitedManholeCount,
+        totalManholeCount: progress.totalManholeCount,
+        completionRate: progress.completionRate,
+      },
+      prefectures: progress.prefectures,
+    });
+  } catch (error) {
+    console.error('Failed to load public user prefecture progress:', error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'Failed to load user prefecture progress',
+      },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -150,6 +150,7 @@ const hasCoordinates = (manhole?: Pick<JourneyManhole, 'latitude' | 'longitude'>
 
 export default function HomePage() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [userName, setUserName] = useState('タコさん');
   const [loading, setLoading] = useState(true);
   const [totalManholes, setTotalManholes] = useState(0);
@@ -187,6 +188,7 @@ export default function HomePage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
+        setCurrentUserId(session?.user?.id ?? null);
         trackCollectionOpen({ is_logged_in: loggedIn });
         if (loggedIn) {
           setUserName(getDisplayName(session));
@@ -636,6 +638,7 @@ export default function HomePage() {
                           <JourneyPrefectureOverview
                             completedPrefectures={completedPrefectures}
                             continuingPrefecture={continuingPrefecture}
+                            userId={currentUserId}
                           />
                         </div>
 
@@ -654,6 +657,7 @@ export default function HomePage() {
                                   key={prefecture.name}
                                   prefecture={prefecture}
                                   label={prefecture.label}
+                                  userId={currentUserId}
                                 />
                               ))}
                             </div>
@@ -1006,9 +1010,11 @@ export default function HomePage() {
 function JourneyPrefectureOverview({
   completedPrefectures,
   continuingPrefecture,
+  userId,
 }: {
   completedPrefectures: PrefectureProgress[];
   continuingPrefecture: PrefectureProgress | null;
+  userId: string | null;
 }) {
   return (
     <div className="mt-5 space-y-4">
@@ -1024,6 +1030,7 @@ function JourneyPrefectureOverview({
                 key={prefecture.name}
                 prefecture={prefecture}
                 label="制覇済み"
+                userId={userId}
               />
             ))}
           </div>
@@ -1040,7 +1047,7 @@ function JourneyPrefectureOverview({
           旅の続き
         </div>
         {continuingPrefecture ? (
-          <JourneyPrefectureStat prefecture={continuingPrefecture} label="旅の続き" />
+          <JourneyPrefectureStat prefecture={continuingPrefecture} label="旅の続き" userId={userId} />
         ) : (
           <div className="rounded-[7px] border border-dashed border-[#8C6A4A]/25 bg-[#FFF7E5] px-3 py-3 text-xs font-bold text-[#6A4D36]">
             訪問を記録すると、続きにしたい県がここに出ます。
@@ -1054,15 +1061,16 @@ function JourneyPrefectureOverview({
 function JourneyPrefectureStat({
   prefecture,
   label,
+  userId,
 }: {
   prefecture: PrefectureProgress;
   label?: PrefectureCandidate['label'];
+  userId?: string | null;
 }) {
   const complete = prefecture.total > 0 && prefecture.remaining === 0;
   const displayLabel = label || (complete ? '制覇済み' : '旅の続き');
-
-  return (
-    <div className="rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm">
+  const content = (
+    <>
       <div className="mb-2 flex items-start justify-between gap-2">
         <div className="min-w-0">
           <p className="truncate text-sm font-extrabold text-[#4F3828]">{prefecture.name}</p>
@@ -1092,7 +1100,25 @@ function JourneyPrefectureStat({
         <span>{complete ? '制覇済み' : `あと${prefecture.remaining}枚`}</span>
         <span>{prefecture.rate.toFixed(0)}%</span>
       </div>
-    </div>
+    </>
+  );
+
+  if (!userId) {
+    return (
+      <div className="rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={`/users/${encodeURIComponent(userId)}/prefectures?prefecture=${encodeURIComponent(prefecture.name)}`}
+      className="block rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+      aria-label={`${prefecture.name}の達成状況を見る`}
+    >
+      {content}
+    </Link>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -188,13 +188,18 @@ export default function HomePage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
-        setCurrentUserId(session?.user?.id ?? null);
         trackCollectionOpen({ is_logged_in: loggedIn });
-        if (loggedIn) {
+        if (loggedIn && session?.user?.id) {
           setUserName(getDisplayName(session));
           updateUserProperties({ registered_user: true });
           setLoading(false);
           loadJourney();
+          const { data: appUser } = await supabase
+            .from('app_user')
+            .select('id')
+            .eq('auth_uid', session.user.id)
+            .maybeSingle();
+          setCurrentUserId(appUser?.id ?? null);
         }
       } catch (error) {
         console.error('Session check error:', error);

--- a/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
+++ b/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
@@ -32,7 +32,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
   ]);
 
   if (!progress) {
-    return new Response('Not found', { status: 404 });
+    return new Response('Not found', { status: 404, headers: { 'Cache-Control': 'public, max-age=300' } });
   }
 
   const completionRate = `${progress.completionRate.toFixed(1)}%`;
@@ -110,6 +110,9 @@ export async function GET(_request: Request, { params }: RouteContext) {
             },
           ]
         : [],
+      headers: {
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
     }
   );
 }

--- a/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
+++ b/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
@@ -1,0 +1,134 @@
+import { ImageResponse } from 'next/og';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { loadPublicUserPrefectureProgress } from '@/lib/user-prefecture-progress';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const alt = 'ポケふた都道府県達成状況';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+type RouteContext = {
+  params: {
+    userId: string;
+  };
+};
+
+async function loadNotoSansCjk(): Promise<ArrayBuffer | null> {
+  try {
+    const fontPath = join(process.cwd(), 'public/ogp/fonts/NotoSansCJKjp-Bold.otf');
+    const font = await readFile(fontPath);
+    return new Uint8Array(font).buffer;
+  } catch {
+    return null;
+  }
+}
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  const [progress, fontData] = await Promise.all([
+    loadPublicUserPrefectureProgress(params.userId),
+    loadNotoSansCjk(),
+  ]);
+
+  if (!progress) {
+    return new Response('Not found', { status: 404 });
+  }
+
+  const completionRate = `${progress.completionRate.toFixed(1)}%`;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          background: '#F6EEDC',
+          color: '#4F3828',
+          padding: 56,
+          fontFamily: 'NotoSansCJK, sans-serif',
+          position: 'relative',
+          overflow: 'hidden',
+        }}
+      >
+        <div
+          style={{
+            position: 'absolute',
+            inset: 0,
+            backgroundImage:
+              'linear-gradient(90deg, rgba(140,106,74,0.10) 1px, transparent 1px), linear-gradient(rgba(140,106,74,0.10) 1px, transparent 1px)',
+            backgroundSize: '32px 32px',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            inset: 32,
+            border: '4px solid rgba(140,106,74,0.18)',
+            borderRadius: 20,
+          }}
+        />
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 18, zIndex: 1 }}>
+          <div
+            style={{
+              display: 'flex',
+              width: 'fit-content',
+              borderRadius: 999,
+              background: '#F8D9C4',
+              color: '#B5483C',
+              padding: '10px 20px',
+              fontSize: 26,
+              fontWeight: 800,
+            }}
+          >
+            ポケふた都道府県達成状況
+          </div>
+          <div style={{ fontSize: 72, fontWeight: 900, lineHeight: 1.1 }}>
+            {progress.displayName}のポケふた旅
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 24, zIndex: 1 }}>
+          <OgpStat label="制覇都道府県" value={`${progress.completedPrefectureCount}/${progress.totalPrefectureCount}`} />
+          <OgpStat label="公開訪問スタンプ" value={`${progress.visitedManholeCount}/${progress.totalManholeCount}`} />
+          <OgpStat label="全国達成率" value={completionRate} />
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: fontData
+        ? [
+            {
+              name: 'NotoSansCJK',
+              data: fontData,
+              weight: 700,
+            },
+          ]
+        : [],
+    }
+  );
+}
+
+function OgpStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        border: '3px solid rgba(140,106,74,0.18)',
+        borderRadius: 16,
+        background: 'rgba(255,247,229,0.92)',
+        padding: 24,
+      }}
+    >
+      <div style={{ fontSize: 24, fontWeight: 800, color: '#6A4D36' }}>{label}</div>
+      <div style={{ marginTop: 10, fontSize: 54, fontWeight: 900, color: '#B5483C' }}>{value}</div>
+    </div>
+  );
+}

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -1,0 +1,223 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ArrowLeft, CheckCircle2, CircleDot, Compass, Trophy } from 'lucide-react';
+import BottomNav from '@/components/BottomNav';
+import Header from '@/components/Header';
+import PrefectureProgressShareButton from '@/components/users/PrefectureProgressShareButton';
+import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
+import {
+  PublicPrefectureProgress,
+  loadPublicUserPrefectureProgress,
+} from '@/lib/user-prefecture-progress';
+
+type PageProps = {
+  params: {
+    userId: string;
+  };
+  searchParams?: {
+    prefecture?: string;
+  };
+};
+
+export const dynamic = 'force-dynamic';
+
+const getPageUrl = (userId: string) => `${SITE_URL}/users/${encodeURIComponent(userId)}/prefectures`;
+
+const formatRate = (rate: number, digits = 1) => `${rate.toFixed(digits)}%`;
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const progress = await loadPublicUserPrefectureProgress(params.userId);
+
+  if (!progress) {
+    return {
+      title: `都道府県達成状況が見つかりません | ${SITE_NAME}`,
+    };
+  }
+
+  const pageUrl = getPageUrl(progress.userId);
+  const title = `${progress.displayName}の都道府県達成状況 | ${SITE_NAME}`;
+  const description = `${progress.completedPrefectureCount}/${progress.totalPrefectureCount}都道府県制覇、全国達成率${formatRate(progress.completionRate)}。ポケふた巡りの達成状況を公開中です。`;
+  const imageUrl = `${pageUrl}/opengraph-image?v=${OGP_IMAGE_VERSION}`;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: pageUrl,
+    },
+    openGraph: {
+      title,
+      description,
+      url: pageUrl,
+      siteName: SITE_NAME,
+      type: 'profile',
+      images: [{ url: imageUrl, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [imageUrl],
+    },
+  };
+}
+
+export default async function UserPrefecturesPage({ params, searchParams }: PageProps) {
+  const progress = await loadPublicUserPrefectureProgress(params.userId);
+
+  if (!progress) notFound();
+
+  const selectedPrefecture = searchParams?.prefecture;
+  const selectedProgress = selectedPrefecture
+    ? progress.prefectures.find((prefecture) => prefecture.name === selectedPrefecture)
+    : null;
+  const shareUrl = selectedPrefecture
+    ? `${getPageUrl(progress.userId)}?prefecture=${encodeURIComponent(selectedPrefecture)}`
+    : getPageUrl(progress.userId);
+
+  return (
+    <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <Header
+        title={SITE_NAME}
+        actions={
+          <Link href="/" className="inline-flex items-center gap-2 text-sm font-bold text-[#4F3828]">
+            <ArrowLeft className="h-4 w-4" />
+            ホームへ
+          </Link>
+        }
+      />
+
+      <main className="mx-auto max-w-5xl px-4 pb-8 pt-5 sm:pt-8">
+        <section className="relative overflow-hidden rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] px-5 py-6 shadow-[0_12px_30px_rgba(95,68,42,0.13)] sm:px-8 sm:py-8">
+          <div className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+          <div className="relative">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#B5483C]/25 bg-[#F8D9C4] px-3 py-1 text-xs font-bold text-[#B5483C]">
+              <Trophy className="h-3.5 w-3.5" />
+              都道府県達成状況
+            </div>
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+              <div>
+                <h1 className="text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
+                  {progress.displayName}のポケふた旅
+                </h1>
+                <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[#6A4D36] sm:text-base">
+                  公開中の訪問記録をもとにした、都道府県ごとの達成状況です。
+                </p>
+              </div>
+              <PrefectureProgressShareButton
+                displayName={progress.displayName}
+                completedPrefectureCount={progress.completedPrefectureCount}
+                totalPrefectureCount={progress.totalPrefectureCount}
+                shareUrl={shareUrl}
+              />
+            </div>
+
+            <div className="mt-6 grid gap-3 sm:grid-cols-3">
+              <HeroStat label="制覇都道府県" value={`${progress.completedPrefectureCount}/${progress.totalPrefectureCount}`} />
+              <HeroStat label="公開訪問スタンプ" value={`${progress.visitedManholeCount}/${progress.totalManholeCount}`} />
+              <HeroStat label="全国達成率" value={formatRate(progress.completionRate)} />
+            </div>
+
+            <div className="mt-5 h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/20 bg-[#E4D4B8]">
+              <div
+                className="h-full bg-gradient-to-r from-[#8C6A4A] via-[#DDA63A] to-[#2C765E]"
+                style={{ width: `${Math.min(progress.completionRate, 100)}%` }}
+              />
+            </div>
+          </div>
+        </section>
+
+        {selectedProgress && (
+          <section className="mt-5 rounded-[8px] border border-[#DDA63A]/35 bg-[#FFF8EB] p-4 shadow-sm">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs font-extrabold text-[#8C6A4A]">選択中の都道府県</p>
+                <h2 className="mt-1 text-xl font-extrabold text-[#4F3828]">{selectedProgress.name}</h2>
+              </div>
+              <ProgressPill prefecture={selectedProgress} />
+            </div>
+          </section>
+        )}
+
+        <section className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {progress.prefectures.map((prefecture) => (
+            <PrefectureProgressCard
+              key={prefecture.name}
+              prefecture={prefecture}
+              highlighted={prefecture.name === selectedPrefecture}
+            />
+          ))}
+        </section>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}
+
+function HeroStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="rounded-[7px] border border-[#8C6A4A]/15 bg-white/70 px-4 py-3">
+      <p className="text-[11px] font-extrabold text-[#6A4D36]">{label}</p>
+      <p className="mt-1 font-pixel text-2xl leading-none text-[#B5483C]">{value}</p>
+    </div>
+  );
+}
+
+function ProgressPill({ prefecture }: { prefecture: PublicPrefectureProgress }) {
+  return (
+    <div className={`inline-flex items-center gap-2 rounded-[7px] px-3 py-2 text-sm font-extrabold ${
+      prefecture.complete
+        ? 'bg-[#E6F4DD] text-[#2C765E]'
+        : 'bg-[#F8D9C4] text-[#B5483C]'
+    }`}>
+      {prefecture.complete ? <CheckCircle2 className="h-4 w-4" /> : <Compass className="h-4 w-4" />}
+      {prefecture.complete ? '制覇済み' : `あと${prefecture.remaining}枚`}
+    </div>
+  );
+}
+
+function PrefectureProgressCard({
+  prefecture,
+  highlighted,
+}: {
+  prefecture: PublicPrefectureProgress;
+  highlighted: boolean;
+}) {
+  return (
+    <article
+      className={`rounded-[8px] border bg-[#FFF7E5] p-4 shadow-sm ${
+        highlighted
+          ? 'border-[#DDA63A] ring-2 ring-[#DDA63A]/30'
+          : 'border-[#8C6A4A]/15'
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-base font-extrabold text-[#4F3828]">{prefecture.name}</h2>
+          <p className="mt-1 font-pixel text-lg leading-none text-[#B5483C]">
+            {prefecture.visited} / {prefecture.total}
+          </p>
+        </div>
+        <ProgressPill prefecture={prefecture} />
+      </div>
+
+      <div className="mt-4 h-3 overflow-hidden rounded-sm border border-[#8C6A4A]/15 bg-[#E4D4B8]">
+        <div
+          className={`h-full ${prefecture.complete ? 'bg-[#2C765E]' : 'bg-[#8C6A4A]'}`}
+          style={{ width: `${Math.min(prefecture.rate, 100)}%` }}
+        />
+      </div>
+
+      <div className="mt-3 flex items-center justify-between gap-2 text-[11px] font-bold text-[#6A4D36]">
+        <span className="inline-flex items-center gap-1">
+          <CircleDot className="h-3.5 w-3.5" />
+          公開訪問ベース
+        </span>
+        <span>{formatRate(prefecture.rate, 0)}</span>
+      </div>
+    </article>
+  );
+}
+

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, CheckCircle2, CircleDot, Compass, Trophy } from 'lucide-react';
+import { ArrowLeft, Camera, CheckCircle2, CircleDot, Compass, MapPin, Trophy } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PrefectureProgressShareButton from '@/components/users/PrefectureProgressShareButton';
 import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import {
+  PublicPrefectureManhole,
   PublicPrefectureProgress,
   loadPublicUserPrefectureProgress,
 } from '@/lib/user-prefecture-progress';
@@ -140,6 +141,27 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
           </section>
         )}
 
+        {selectedProgress && (
+          <section className="mt-5">
+            <div className="mb-3 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <p className="text-xs font-extrabold text-[#8C6A4A]">県内のポケふた</p>
+                <h2 className="text-xl font-extrabold text-[#4F3828]">
+                  {selectedProgress.name}のマンホール一覧
+                </h2>
+              </div>
+              <p className="text-sm font-bold text-[#6A4D36]">
+                公開訪問 {selectedProgress.visited} / {selectedProgress.total}
+              </p>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {selectedProgress.manholes.map((manhole) => (
+                <PrefectureManholeCard key={manhole.id} manhole={manhole} />
+              ))}
+            </div>
+          </section>
+        )}
+
         <section className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {progress.prefectures.map((prefecture) => (
             <PrefectureProgressCard
@@ -153,6 +175,59 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
 
       <BottomNav />
     </div>
+  );
+}
+
+function PrefectureManholeCard({ manhole }: { manhole: PublicPrefectureManhole }) {
+  const photoUrl = manhole.latestPublicPhotoId
+    ? `/api/photo/${encodeURIComponent(manhole.latestPublicPhotoId)}?size=small`
+    : null;
+  const pokemonLabel = manhole.pokemons.length > 0 ? manhole.pokemons.join('・') : 'ポケモン未設定';
+
+  return (
+    <Link
+      href={`/manhole/${manhole.id}`}
+      className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:border-[#DDA63A] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]/50"
+    >
+      <div className="aspect-[4/3] bg-[#E4D4B8]">
+        {photoUrl ? (
+          <img
+            src={photoUrl}
+            alt={`${manhole.title}の訪問写真`}
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-[#8C6A4A]">
+            <Camera className="h-8 w-8" />
+            <span className="text-xs font-extrabold">公開写真なし</span>
+          </div>
+        )}
+      </div>
+      <div className="p-4">
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <span
+            className={`inline-flex items-center gap-1 rounded-[7px] px-2.5 py-1 text-xs font-extrabold ${
+              manhole.visited
+                ? 'bg-[#E6F4DD] text-[#2C765E]'
+                : 'bg-[#F8D9C4] text-[#B5483C]'
+            }`}
+          >
+            {manhole.visited ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Compass className="h-3.5 w-3.5" />}
+            {manhole.visited ? '訪問済み' : '未訪問'}
+          </span>
+          <span className="font-pixel text-xs text-[#8C6A4A]">#{manhole.id}</span>
+        </div>
+        <h3 className="line-clamp-2 min-h-[3rem] text-base font-extrabold leading-6 text-[#4F3828]">
+          {manhole.title}
+        </h3>
+        <p className="mt-2 flex items-center gap-1 text-xs font-bold text-[#6A4D36]">
+          <MapPin className="h-3.5 w-3.5 shrink-0" />
+          <span className="truncate">{manhole.municipality || manhole.prefecture}</span>
+        </p>
+        <p className="mt-2 line-clamp-1 text-xs font-bold text-[#B5483C]">{pokemonLabel}</p>
+      </div>
+    </Link>
   );
 }
 
@@ -220,4 +295,3 @@ function PrefectureProgressCard({
     </article>
   );
 }
-

--- a/src/components/users/PrefectureProgressShareButton.tsx
+++ b/src/components/users/PrefectureProgressShareButton.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { Share2 } from 'lucide-react';
+import { SITE_NAME } from '@/lib/constants';
+import { openSharePanel, prefectureProgressShareText } from '@/lib/share';
+import { useAnalytics } from '@/lib/hooks/useAnalytics';
+
+type PrefectureProgressShareButtonProps = {
+  displayName: string;
+  completedPrefectureCount: number;
+  totalPrefectureCount: number;
+  shareUrl: string;
+};
+
+export default function PrefectureProgressShareButton({
+  displayName,
+  completedPrefectureCount,
+  totalPrefectureCount,
+  shareUrl,
+}: PrefectureProgressShareButtonProps) {
+  const sharePanelCleanupRef = useRef<(() => void) | null>(null);
+  const { trackShareClick, trackShareX, trackShareLine, trackCopyLink } = useAnalytics();
+
+  useEffect(() => {
+    return () => {
+      sharePanelCleanupRef.current?.();
+    };
+  }, []);
+
+  const handleShare = async () => {
+    const shareText = prefectureProgressShareText(
+      displayName,
+      completedPrefectureCount,
+      totalPrefectureCount
+    );
+
+    trackShareClick();
+
+    try {
+      if (navigator.share) {
+        await navigator.share({
+          title: SITE_NAME,
+          text: shareText,
+          url: shareUrl,
+        });
+        return;
+      }
+
+      sharePanelCleanupRef.current?.();
+      sharePanelCleanupRef.current = openSharePanel(shareText, shareUrl, {
+        onShareX: () => trackShareX(),
+        onShareLine: () => trackShareLine(),
+        onCopyLink: () => trackCopyLink(),
+      });
+    } catch (error) {
+      if (error instanceof Error && error.name !== 'AbortError') {
+        console.error('Prefecture progress share failed:', error);
+      }
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleShare}
+      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-[7px] bg-[#B5483C] px-4 py-3 text-sm font-extrabold text-white shadow-[0_6px_14px_rgba(181,72,60,0.22)] transition hover:bg-[#9F3D33] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+    >
+      <Share2 className="h-4 w-4" />
+      達成状況を共有
+    </button>
+  );
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -33,6 +33,14 @@ export function visitsShareText(): string {
   return 'ポケふた巡りのスタンプ帳を更新しました。\n訪問したポケふたを写真付きで記録しています。';
 }
 
+export function prefectureProgressShareText(
+  displayName: string,
+  completedPrefectureCount: number,
+  totalPrefectureCount: number
+): string {
+  return `${displayName}のポケふた都道府県達成状況です。\n${completedPrefectureCount}/${totalPrefectureCount}都道府県を制覇しました。`;
+}
+
 export interface SharePanelCallbacks {
   onShareX: () => void;
   onShareLine: () => void;

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -1,0 +1,157 @@
+import { supabaseAdmin } from '@/lib/supabase/client';
+
+export type PublicPrefectureProgress = {
+  name: string;
+  total: number;
+  visited: number;
+  remaining: number;
+  rate: number;
+  complete: boolean;
+};
+
+export type PublicUserPrefectureProgress = {
+  userId: string;
+  displayName: string;
+  prefectures: PublicPrefectureProgress[];
+  completedPrefectureCount: number;
+  totalPrefectureCount: number;
+  visitedManholeCount: number;
+  totalManholeCount: number;
+  completionRate: number;
+};
+
+type ManholeProgressRow = {
+  id: number;
+  prefecture: string | null;
+};
+
+type VisitProgressRow = {
+  manhole_id: number | null;
+  manhole?: {
+    prefecture: string | null;
+  } | Array<{
+    prefecture: string | null;
+  }> | null;
+};
+
+const FALLBACK_DISPLAY_NAME = 'トレーナー';
+
+const toRate = (visited: number, total: number) => (total > 0 ? (visited / total) * 100 : 0);
+
+export async function loadPublicUserPrefectureProgress(
+  userId: string
+): Promise<PublicUserPrefectureProgress | null> {
+  if (!supabaseAdmin) {
+    throw new Error('Supabase admin client is not configured');
+  }
+
+  const trimmedUserId = userId.trim();
+  if (!trimmedUserId) return null;
+
+  const [{ data: appUser, error: appUserError }, { data: manholes, error: manholesError }] =
+    await Promise.all([
+      supabaseAdmin
+        .from('app_user')
+        .select('auth_uid, display_name')
+        .eq('auth_uid', trimmedUserId)
+        .maybeSingle(),
+      supabaseAdmin
+        .from('manhole')
+        .select('id, prefecture')
+        .order('prefecture', { ascending: true }),
+    ]);
+
+  if (appUserError) {
+    throw new Error(appUserError.message);
+  }
+
+  if (!appUser) {
+    return null;
+  }
+
+  if (manholesError) {
+    throw new Error(manholesError.message);
+  }
+
+  const manholeRows = (manholes || []) as ManholeProgressRow[];
+  const totalIdsByPrefecture = new Map<string, Set<number>>();
+
+  manholeRows.forEach((manhole) => {
+    const prefecture = manhole.prefecture || '都道府県未設定';
+    const ids = totalIdsByPrefecture.get(prefecture) || new Set<number>();
+    ids.add(manhole.id);
+    totalIdsByPrefecture.set(prefecture, ids);
+  });
+
+  const { data: visits, error: visitsError } = await supabaseAdmin
+    .from('visit')
+    .select(`
+      manhole_id,
+      manhole:manhole_id (
+        prefecture
+      )
+    `)
+    .eq('user_id', trimmedUserId)
+    .eq('is_public', true)
+    .not('manhole_id', 'is', null);
+
+  if (visitsError) {
+    throw new Error(visitsError.message);
+  }
+
+  const visitedIdsByPrefecture = new Map<string, Set<number>>();
+
+  ((visits || []) as unknown as VisitProgressRow[]).forEach((visit) => {
+    if (typeof visit.manhole_id !== 'number') return;
+    const manhole = Array.isArray(visit.manhole) ? visit.manhole[0] : visit.manhole;
+    const prefecture = manhole?.prefecture || '都道府県未設定';
+    const ids = visitedIdsByPrefecture.get(prefecture) || new Set<number>();
+    ids.add(visit.manhole_id);
+    visitedIdsByPrefecture.set(prefecture, ids);
+  });
+
+  const prefectures = Array.from(totalIdsByPrefecture.entries())
+    .map(([name, totalIds]) => {
+      const total = totalIds.size;
+      const visited = Array.from(visitedIdsByPrefecture.get(name) || []).filter((id) =>
+        totalIds.has(id)
+      ).length;
+      const rate = toRate(visited, total);
+
+      return {
+        name,
+        total,
+        visited,
+        remaining: Math.max(total - visited, 0),
+        rate,
+        complete: total > 0 && visited >= total,
+      };
+    })
+    .sort((a, b) => {
+      if (Number(b.complete) !== Number(a.complete)) return Number(b.complete) - Number(a.complete);
+      if (b.rate !== a.rate) return b.rate - a.rate;
+      if (b.visited !== a.visited) return b.visited - a.visited;
+      return a.name.localeCompare(b.name, 'ja');
+    });
+
+  const completedPrefectureCount = prefectures.filter((prefecture) => prefecture.complete).length;
+  const totalManholeCount = manholeRows.length;
+  const allManholeIds = new Set(manholeRows.map((manhole) => manhole.id));
+  const visitedManholeIds = new Set(
+    Array.from(visitedIdsByPrefecture.values()).flatMap((ids) => Array.from(ids))
+  );
+  const validVisitedManholeCount = Array.from(visitedManholeIds).filter((id) =>
+    allManholeIds.has(id)
+  ).length;
+
+  return {
+    userId: trimmedUserId,
+    displayName: appUser.display_name || FALLBACK_DISPLAY_NAME,
+    prefectures,
+    completedPrefectureCount,
+    totalPrefectureCount: prefectures.filter((prefecture) => prefecture.total > 0).length,
+    visitedManholeCount: validVisitedManholeCount,
+    totalManholeCount,
+    completionRate: toRate(validVisitedManholeCount, totalManholeCount),
+  };
+}

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -1,4 +1,6 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabase/client';
+import type { Database } from '@/types/database';
 
 export type PublicPrefectureProgress = {
   name: string;
@@ -34,15 +36,43 @@ type VisitProgressRow = {
   }> | null;
 };
 
+type AppUserProgressRow = {
+  display_name: string | null;
+};
+
 const FALLBACK_DISPLAY_NAME = 'トレーナー';
 
 const toRate = (visited: number, total: number) => (total > 0 ? (visited / total) * 100 : 0);
 
+function createPublicReadClient(): SupabaseClient<Database> | null {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !anonKey) return null;
+
+  return createClient<Database>(supabaseUrl, anonKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+function getProgressClient(): SupabaseClient<Database> | null {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  const hasUsableServiceRoleKey =
+    serviceRoleKey.length > 100 && !serviceRoleKey.toLowerCase().includes('placeholder');
+
+  return hasUsableServiceRoleKey ? supabaseAdmin : createPublicReadClient();
+}
+
 export async function loadPublicUserPrefectureProgress(
   userId: string
 ): Promise<PublicUserPrefectureProgress | null> {
-  if (!supabaseAdmin) {
-    throw new Error('Supabase admin client is not configured');
+  const supabase = getProgressClient();
+
+  if (!supabase) {
+    throw new Error('Supabase client is not configured');
   }
 
   const trimmedUserId = userId.trim();
@@ -50,12 +80,12 @@ export async function loadPublicUserPrefectureProgress(
 
   const [{ data: appUser, error: appUserError }, { data: manholes, error: manholesError }] =
     await Promise.all([
-      supabaseAdmin
+      supabase
         .from('app_user')
         .select('auth_uid, display_name')
         .eq('auth_uid', trimmedUserId)
         .maybeSingle(),
-      supabaseAdmin
+      supabase
         .from('manhole')
         .select('id, prefecture')
         .order('prefecture', { ascending: true }),
@@ -68,6 +98,8 @@ export async function loadPublicUserPrefectureProgress(
   if (!appUser) {
     return null;
   }
+
+  const appUserRow = appUser as unknown as AppUserProgressRow;
 
   if (manholesError) {
     throw new Error(manholesError.message);
@@ -83,7 +115,7 @@ export async function loadPublicUserPrefectureProgress(
     totalIdsByPrefecture.set(prefecture, ids);
   });
 
-  const { data: visits, error: visitsError } = await supabaseAdmin
+  const { data: visits, error: visitsError } = await supabase
     .from('visit')
     .select(`
       manhole_id,
@@ -146,7 +178,7 @@ export async function loadPublicUserPrefectureProgress(
 
   return {
     userId: trimmedUserId,
-    displayName: appUser.display_name || FALLBACK_DISPLAY_NAME,
+    displayName: appUserRow.display_name || FALLBACK_DISPLAY_NAME,
     prefectures,
     completedPrefectureCount,
     totalPrefectureCount: prefectures.filter((prefecture) => prefecture.total > 0).length,

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -9,6 +9,17 @@ export type PublicPrefectureProgress = {
   remaining: number;
   rate: number;
   complete: boolean;
+  manholes: PublicPrefectureManhole[];
+};
+
+export type PublicPrefectureManhole = {
+  id: number;
+  title: string;
+  prefecture: string;
+  municipality: string | null;
+  pokemons: string[];
+  visited: boolean;
+  latestPublicPhotoId: string | null;
 };
 
 export type PublicUserPrefectureProgress = {
@@ -25,14 +36,23 @@ export type PublicUserPrefectureProgress = {
 type ManholeProgressRow = {
   id: number;
   prefecture: string | null;
+  title: string | null;
+  municipality: string | null;
+  pokemons: string[] | null;
 };
 
 type VisitProgressRow = {
   manhole_id: number | null;
+  shot_at: string | null;
+  created_at: string | null;
   manhole?: {
     prefecture: string | null;
   } | Array<{
     prefecture: string | null;
+  }> | null;
+  photos?: Array<{
+    id: string;
+    created_at: string | null;
   }> | null;
 };
 
@@ -43,6 +63,9 @@ type AppUserProgressRow = {
 const FALLBACK_DISPLAY_NAME = 'トレーナー';
 
 const toRate = (visited: number, total: number) => (total > 0 ? (visited / total) * 100 : 0);
+
+const getVisitSortTime = (visit: Pick<VisitProgressRow, 'shot_at' | 'created_at'>) =>
+  new Date(visit.shot_at || visit.created_at || 0).getTime();
 
 function createPublicReadClient(): SupabaseClient<Database> | null {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -87,8 +110,10 @@ export async function loadPublicUserPrefectureProgress(
         .maybeSingle(),
       supabase
         .from('manhole')
-        .select('id, prefecture')
-        .order('prefecture', { ascending: true }),
+        .select('id, title, prefecture, municipality, pokemons')
+        .order('prefecture', { ascending: true })
+        .order('municipality', { ascending: true })
+        .order('id', { ascending: true }),
     ]);
 
   if (appUserError) {
@@ -119,8 +144,14 @@ export async function loadPublicUserPrefectureProgress(
     .from('visit')
     .select(`
       manhole_id,
+      shot_at,
+      created_at,
       manhole:manhole_id (
         prefecture
+      ),
+      photos:photo (
+        id,
+        created_at
       )
     `)
     .eq('user_id', trimmedUserId)
@@ -132,6 +163,7 @@ export async function loadPublicUserPrefectureProgress(
   }
 
   const visitedIdsByPrefecture = new Map<string, Set<number>>();
+  const latestPublicPhotoIdByManhole = new Map<number, { photoId: string; sortTime: number }>();
 
   ((visits || []) as unknown as VisitProgressRow[]).forEach((visit) => {
     if (typeof visit.manhole_id !== 'number') return;
@@ -140,6 +172,29 @@ export async function loadPublicUserPrefectureProgress(
     const ids = visitedIdsByPrefecture.get(prefecture) || new Set<number>();
     ids.add(visit.manhole_id);
     visitedIdsByPrefecture.set(prefecture, ids);
+
+    const photos = Array.isArray(visit.photos) ? visit.photos : [];
+    const latestPhoto = photos
+      .filter((photo) => photo.id)
+      .sort((a, b) => {
+        const aTime = new Date(a.created_at || 0).getTime();
+        const bTime = new Date(b.created_at || 0).getTime();
+        return bTime - aTime;
+      })[0];
+
+    if (latestPhoto) {
+      const sortTime = Math.max(
+        getVisitSortTime(visit),
+        new Date(latestPhoto.created_at || 0).getTime()
+      );
+      const current = latestPublicPhotoIdByManhole.get(visit.manhole_id);
+      if (!current || sortTime > current.sortTime) {
+        latestPublicPhotoIdByManhole.set(visit.manhole_id, {
+          photoId: latestPhoto.id,
+          sortTime,
+        });
+      }
+    }
   });
 
   const prefectures = Array.from(totalIdsByPrefecture.entries())
@@ -157,6 +212,21 @@ export async function loadPublicUserPrefectureProgress(
         remaining: Math.max(total - visited, 0),
         rate,
         complete: total > 0 && visited >= total,
+        manholes: manholeRows
+          .filter((manhole) => (manhole.prefecture || '都道府県未設定') === name)
+          .map((manhole) => ({
+            id: manhole.id,
+            title: manhole.title || `${name}${manhole.municipality || ''}`,
+            prefecture: name,
+            municipality: manhole.municipality,
+            pokemons: Array.isArray(manhole.pokemons) ? manhole.pokemons : [],
+            visited: Array.from(visitedIdsByPrefecture.get(name) || []).includes(manhole.id),
+            latestPublicPhotoId: latestPublicPhotoIdByManhole.get(manhole.id)?.photoId || null,
+          }))
+          .sort((a, b) => {
+            if (Number(b.visited) !== Number(a.visited)) return Number(b.visited) - Number(a.visited);
+            return a.id - b.id;
+          }),
       };
     })
     .sort((a, b) => {

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -1,3 +1,4 @@
+import 'server-only';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabase/client';
 import type { Database } from '@/types/database';
@@ -57,6 +58,7 @@ type VisitProgressRow = {
 };
 
 type AppUserProgressRow = {
+  auth_uid: string;
   display_name: string | null;
 };
 
@@ -106,7 +108,7 @@ export async function loadPublicUserPrefectureProgress(
       supabase
         .from('app_user')
         .select('auth_uid, display_name')
-        .eq('auth_uid', trimmedUserId)
+        .eq('id', trimmedUserId)
         .maybeSingle(),
       supabase
         .from('manhole')
@@ -154,12 +156,16 @@ export async function loadPublicUserPrefectureProgress(
         created_at
       )
     `)
-    .eq('user_id', trimmedUserId)
+    .eq('user_id', appUserRow.auth_uid)
     .eq('is_public', true)
     .not('manhole_id', 'is', null);
 
   if (visitsError) {
     throw new Error(visitsError.message);
+  }
+
+  if (!visits || visits.length === 0) {
+    return null;
   }
 
   const visitedIdsByPrefecture = new Map<string, Set<number>>();

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -1,4 +1,5 @@
 import 'server-only';
+import { cache } from 'react';
 import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import { supabaseAdmin } from '@/lib/supabase/client';
 import type { Database } from '@/types/database';
@@ -63,6 +64,7 @@ type AppUserProgressRow = {
 };
 
 const FALLBACK_DISPLAY_NAME = 'トレーナー';
+const JAPAN_PREFECTURE_COUNT = 47;
 
 const toRate = (visited: number, total: number) => (total > 0 ? (visited / total) * 100 : 0);
 
@@ -91,7 +93,7 @@ function getProgressClient(): SupabaseClient<Database> | null {
   return hasUsableServiceRoleKey ? supabaseAdmin : createPublicReadClient();
 }
 
-export async function loadPublicUserPrefectureProgress(
+async function loadPublicUserPrefectureProgressImpl(
   userId: string
 ): Promise<PublicUserPrefectureProgress | null> {
   const supabase = getProgressClient();
@@ -134,13 +136,19 @@ export async function loadPublicUserPrefectureProgress(
 
   const manholeRows = (manholes || []) as ManholeProgressRow[];
   const totalIdsByPrefecture = new Map<string, Set<number>>();
+  const manholesByPrefecture = new Map<string, ManholeProgressRow[]>();
 
   manholeRows.forEach((manhole) => {
     const prefecture = manhole.prefecture || '都道府県未設定';
     const ids = totalIdsByPrefecture.get(prefecture) || new Set<number>();
     ids.add(manhole.id);
     totalIdsByPrefecture.set(prefecture, ids);
+    const list = manholesByPrefecture.get(prefecture) || [];
+    list.push(manhole);
+    manholesByPrefecture.set(prefecture, list);
   });
+
+  const displayName = appUserRow.display_name || FALLBACK_DISPLAY_NAME;
 
   const { data: visits, error: visitsError } = await supabase
     .from('visit')
@@ -165,7 +173,16 @@ export async function loadPublicUserPrefectureProgress(
   }
 
   if (!visits || visits.length === 0) {
-    return null;
+    return {
+      userId: trimmedUserId,
+      displayName,
+      prefectures: [],
+      completedPrefectureCount: 0,
+      totalPrefectureCount: JAPAN_PREFECTURE_COUNT,
+      visitedManholeCount: 0,
+      totalManholeCount: manholeRows.length,
+      completionRate: 0,
+    };
   }
 
   const visitedIdsByPrefecture = new Map<string, Set<number>>();
@@ -205,10 +222,14 @@ export async function loadPublicUserPrefectureProgress(
 
   const prefectures = Array.from(totalIdsByPrefecture.entries())
     .map(([name, totalIds]) => {
+      const visitedSet = visitedIdsByPrefecture.get(name);
+      let visited = 0;
+      if (visitedSet) {
+        for (const id of visitedSet) {
+          if (totalIds.has(id)) visited++;
+        }
+      }
       const total = totalIds.size;
-      const visited = Array.from(visitedIdsByPrefecture.get(name) || []).filter((id) =>
-        totalIds.has(id)
-      ).length;
       const rate = toRate(visited, total);
 
       return {
@@ -218,15 +239,14 @@ export async function loadPublicUserPrefectureProgress(
         remaining: Math.max(total - visited, 0),
         rate,
         complete: total > 0 && visited >= total,
-        manholes: manholeRows
-          .filter((manhole) => (manhole.prefecture || '都道府県未設定') === name)
+        manholes: (manholesByPrefecture.get(name) || [])
           .map((manhole) => ({
             id: manhole.id,
             title: manhole.title || `${name}${manhole.municipality || ''}`,
             prefecture: name,
             municipality: manhole.municipality,
             pokemons: Array.isArray(manhole.pokemons) ? manhole.pokemons : [],
-            visited: Array.from(visitedIdsByPrefecture.get(name) || []).includes(manhole.id),
+            visited: visitedSet?.has(manhole.id) ?? false,
             latestPublicPhotoId: latestPublicPhotoIdByManhole.get(manhole.id)?.photoId || null,
           }))
           .sort((a, b) => {
@@ -254,12 +274,14 @@ export async function loadPublicUserPrefectureProgress(
 
   return {
     userId: trimmedUserId,
-    displayName: appUserRow.display_name || FALLBACK_DISPLAY_NAME,
+    displayName,
     prefectures,
     completedPrefectureCount,
-    totalPrefectureCount: prefectures.filter((prefecture) => prefecture.total > 0).length,
+    totalPrefectureCount: JAPAN_PREFECTURE_COUNT,
     visitedManholeCount: validVisitedManholeCount,
     totalManholeCount,
     completionRate: toRate(validVisitedManholeCount, totalManholeCount),
   };
 }
+
+export const loadPublicUserPrefectureProgress = cache(loadPublicUserPrefectureProgressImpl);


### PR DESCRIPTION
## Summary
- Add a public user prefecture progress page at `/users/[userId]/prefectures` for SNS sharing.
- Add a public API that returns only display name and aggregate prefecture progress based on `is_public=true` visits.
- Link logged-in home prefecture cards to the new share page and add Web Share / X / LINE / copy sharing plus OGP image support.

## Verification
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Notes
- Build still logs existing dynamic server usage warnings for `/api/visits` and `/api/auth/session`, but completes successfully.
- Existing unrelated local changes were left untouched: `public/data/latest-manhole-photos.json`, `tools/export_latest_manhole_photos.py`, and `docs/`.