### PR TITLE
Fix prefecture progress page: clickable cards and secure anon DB access

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -15,6 +15,7 @@ Supabase SQL Editorで `database/migrations/` のSQLを番号順に実行しま�
 9. `011_add_public_user_info_fn.sql`
 10. `012_drop_email_from_app_user.sql`
 11. `013_add_app_user_self_select_policy.sql`
+12. `014_add_get_my_app_user_id_fn.sql`
 
 ## 注意
 

--- a/database/README.md
+++ b/database/README.md
@@ -14,6 +14,7 @@ Supabase SQL Editorで `database/migrations/` のSQLを番号順に実行しま�
 8. `010_add_manhole_share_metadata.sql`
 9. `011_add_public_user_info_fn.sql`
 10. `012_drop_email_from_app_user.sql`
+11. `013_add_app_user_self_select_policy.sql`
 
 ## 注意
 

--- a/database/README.md
+++ b/database/README.md
@@ -11,6 +11,9 @@ Supabase SQL Editorで `database/migrations/` のSQLを番号順に実行しま�
 5. `006_fix_orphan_visits.sql`
 6. `007_backfill_app_user_from_auth_users.sql`
 7. `008_extend_site_stats.sql`
+8. `010_add_manhole_share_metadata.sql`
+9. `011_add_public_user_info_fn.sql`
+10. `012_drop_email_from_app_user.sql`
 
 ## 注意
 

--- a/database/migrations/011_add_public_user_info_fn.sql
+++ b/database/migrations/011_add_public_user_info_fn.sql
@@ -1,0 +1,20 @@
+-- app_user テーブルには email 等のプライベートデータが含まれるため、
+-- anon ロールに直接 SELECT を許可せず、公開プロフィールページに必要な最小限の列のみを
+-- SECURITY DEFINER 関数で安全に公開する
+
+DROP FUNCTION IF EXISTS get_public_user_info(uuid);
+
+CREATE OR REPLACE FUNCTION get_public_user_info(p_user_id uuid)
+RETURNS TABLE (auth_uid uuid, display_name text)
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT au.auth_uid, au.display_name
+  FROM app_user au
+  WHERE au.id = p_user_id;
+$$;
+
+-- anon と authenticated ロールに実行権限を付与
+GRANT EXECUTE ON FUNCTION get_public_user_info(uuid) TO anon;
+GRANT EXECUTE ON FUNCTION get_public_user_info(uuid) TO authenticated;

--- a/database/migrations/011_add_public_user_info_fn.sql
+++ b/database/migrations/011_add_public_user_info_fn.sql
@@ -2,8 +2,6 @@
 -- anon ロールに直接 SELECT を許可せず、公開プロフィールページに必要な最小限の列のみを
 -- SECURITY DEFINER 関数で安全に公開する
 
-DROP FUNCTION IF EXISTS get_public_user_info(uuid);
-
 CREATE OR REPLACE FUNCTION get_public_user_info(p_user_id uuid)
 RETURNS TABLE (auth_uid uuid, display_name text)
 LANGUAGE sql

--- a/database/migrations/012_drop_email_from_app_user.sql
+++ b/database/migrations/012_drop_email_from_app_user.sql
@@ -1,0 +1,2 @@
+-- email は auth.users 側で管理するため app_user から削除
+ALTER TABLE app_user DROP COLUMN IF EXISTS email;

--- a/database/migrations/013_add_app_user_self_select_policy.sql
+++ b/database/migrations/013_add_app_user_self_select_policy.sql
@@ -1,0 +1,8 @@
+-- 認証済みユーザーが自分自身の app_user 行を読めるようにする
+-- （ホームページでの currentUserId 取得に必要）
+-- anon ロールは引き続き直接アクセス不可（公開情報は get_public_user_info() 経由）
+
+DROP POLICY IF EXISTS "users_select_own_app_user" ON app_user;
+CREATE POLICY "users_select_own_app_user"
+ON app_user FOR SELECT
+USING (auth.uid() = auth_uid);

--- a/database/migrations/014_add_get_my_app_user_id_fn.sql
+++ b/database/migrations/014_add_get_my_app_user_id_fn.sql
@@ -1,0 +1,14 @@
+-- ログイン中ユーザーが自分の app_user.id を取得するための関数
+-- ブラウザクライアントで app_user を直接 SELECT する代わりに使う
+-- （RLS や JWT ヘッダーの問題を回避しつつ、auth.uid() で本人確認）
+
+CREATE OR REPLACE FUNCTION get_my_app_user_id()
+RETURNS uuid
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT id FROM app_user WHERE auth_uid = auth.uid();
+$$;
+
+GRANT EXECUTE ON FUNCTION get_my_app_user_id() TO authenticated;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -194,12 +194,9 @@ export default function HomePage() {
           updateUserProperties({ registered_user: true });
           setLoading(false);
           loadJourney();
-          const { data: appUser } = await supabase
-            .from('app_user')
-            .select('id')
-            .eq('auth_uid', session.user.id)
-            .maybeSingle();
-          setCurrentUserId(appUser?.id ?? null);
+          const { data: myAppUserId } = await supabase
+            .rpc('get_my_app_user_id' as never);
+          setCurrentUserId((myAppUserId as string | null) ?? null);
         }
       } catch (error) {
         console.error('Session check error:', error);

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -154,7 +154,7 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
                 公開訪問 {selectedProgress.visited} / {selectedProgress.total}
               </p>
             </div>
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-4 gap-2 sm:grid-cols-5 lg:grid-cols-6">
               {selectedProgress.manholes.map((manhole) => (
                 <PrefectureManholeCard key={manhole.id} manhole={manhole} />
               ))}
@@ -188,24 +188,24 @@ function PrefectureManholeCard({ manhole }: { manhole: PublicPrefectureManhole }
   return (
     <Link
       href={`/manhole/${manhole.id}`}
-      className={`relative flex aspect-[4/5] flex-col justify-between rounded-lg border-2 p-3 shadow-sm transition-transform hover:-translate-y-0.5 ${
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-md border-2 p-1.5 shadow-sm transition-transform hover:-translate-y-0.5 ${
         manhole.visited
           ? 'border-[#B5483C]/45 bg-[#FFF7E5]'
           : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]/75'
       }`}
     >
       <div className="flex items-center justify-between">
-        <span className={`rounded-full px-2 py-1 font-pixelJp text-[10px] font-bold ${
+        <span className={`rounded-full px-1 py-0.5 font-pixelJp text-[8px] font-bold leading-none ${
           manhole.visited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
         }`}>
-          {manhole.visited ? '済' : '未訪問'}
+          {manhole.visited ? '済' : '未'}
         </span>
-        {photoUrl && <Camera className="h-4 w-4 text-[#B5483C]" />}
+        {photoUrl && <Camera className="h-3 w-3 text-[#B5483C]" />}
       </div>
 
       <div className="flex flex-1 items-center justify-center">
         {manhole.visited ? (
-          <div className="relative h-24 w-24 overflow-hidden rounded-full border-4 border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
+          <div className="relative aspect-square w-3/4 overflow-hidden rounded-full border-[3px] border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
             {photoUrl ? (
               <img
                 src={photoUrl}
@@ -215,27 +215,26 @@ function PrefectureManholeCard({ manhole }: { manhole: PublicPrefectureManhole }
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle,#6F6658_0_18%,#B9AA91_19%_29%,#6F6658_30%_33%,#D7C9AF_34%_48%,#8B7D67_49%_52%,#CFC0A5_53%)]">
-                <CircleDot className="h-8 w-8 text-[#4F3828]/70" />
+                <CircleDot className="h-4 w-4 text-[#4F3828]/70" />
               </div>
             )}
           </div>
         ) : (
-          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
+          <div className="flex aspect-square w-3/4 rotate-[-8deg] items-center justify-center rounded-full border-[3px] border-[#B8AB96] text-center text-[#A39580]">
             <div>
-              <Stamp className="mx-auto h-6 w-6" />
-              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+              <Stamp className="mx-auto h-4 w-4" />
+              <p className="font-pixel text-[7px] leading-none">NEXT</p>
             </div>
           </div>
         )}
       </div>
 
       <div>
-        <p className="line-clamp-2 font-pixelJp text-sm font-bold leading-tight text-[#4F3828]">
+        <p className="truncate font-pixelJp text-[9px] font-bold leading-tight text-[#4F3828]">
           {manhole.municipality || manhole.prefecture}
         </p>
-        <p className="mt-1 truncate font-pixelJp text-[11px] text-[#6A4D36]">{manhole.title}</p>
         {pokemonLabel && (
-          <p className="mt-1 truncate font-pixelJp text-[10px] text-[#B5483C]">{pokemonLabel}</p>
+          <p className="truncate font-pixelJp text-[8px] text-[#B5483C]">{pokemonLabel}</p>
         )}
       </div>
     </Link>

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, Camera, CheckCircle2, CircleDot, Compass, MapPin, Trophy } from 'lucide-react';
+import { ArrowLeft, Camera, CheckCircle2, CircleDot, Compass, Stamp, Trophy } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PrefectureProgressShareButton from '@/components/users/PrefectureProgressShareButton';
@@ -183,50 +183,60 @@ function PrefectureManholeCard({ manhole }: { manhole: PublicPrefectureManhole }
   const photoUrl = manhole.latestPublicPhotoId
     ? `/api/photo/${encodeURIComponent(manhole.latestPublicPhotoId)}?size=small`
     : null;
-  const pokemonLabel = manhole.pokemons.length > 0 ? manhole.pokemons.join('・') : 'ポケモン未設定';
+  const pokemonLabel = manhole.pokemons.length > 0 ? manhole.pokemons.join('・') : null;
 
   return (
     <Link
       href={`/manhole/${manhole.id}`}
-      className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:border-[#DDA63A] hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]/50"
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-lg border-2 p-3 shadow-sm transition-transform hover:-translate-y-0.5 ${
+        manhole.visited
+          ? 'border-[#B5483C]/45 bg-[#FFF7E5]'
+          : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]/75'
+      }`}
     >
-      <div className="aspect-[4/3] bg-[#E4D4B8]">
-        {photoUrl ? (
-          <img
-            src={photoUrl}
-            alt={`${manhole.title}の訪問写真`}
-            className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
-            loading="lazy"
-          />
+      <div className="flex items-center justify-between">
+        <span className={`rounded-full px-2 py-1 font-pixelJp text-[10px] font-bold ${
+          manhole.visited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
+        }`}>
+          {manhole.visited ? '済' : '未訪問'}
+        </span>
+        {photoUrl && <Camera className="h-4 w-4 text-[#B5483C]" />}
+      </div>
+
+      <div className="flex flex-1 items-center justify-center">
+        {manhole.visited ? (
+          <div className="relative h-24 w-24 overflow-hidden rounded-full border-4 border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
+            {photoUrl ? (
+              <img
+                src={photoUrl}
+                alt=""
+                className="h-full w-full object-cover"
+                loading="lazy"
+              />
+            ) : (
+              <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle,#6F6658_0_18%,#B9AA91_19%_29%,#6F6658_30%_33%,#D7C9AF_34%_48%,#8B7D67_49%_52%,#CFC0A5_53%)]">
+                <CircleDot className="h-8 w-8 text-[#4F3828]/70" />
+              </div>
+            )}
+          </div>
         ) : (
-          <div className="flex h-full w-full flex-col items-center justify-center gap-2 px-4 text-center text-[#8C6A4A]">
-            <Camera className="h-8 w-8" />
-            <span className="text-xs font-extrabold">公開写真なし</span>
+          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
+            <div>
+              <Stamp className="mx-auto h-6 w-6" />
+              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+            </div>
           </div>
         )}
       </div>
-      <div className="p-4">
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <span
-            className={`inline-flex items-center gap-1 rounded-[7px] px-2.5 py-1 text-xs font-extrabold ${
-              manhole.visited
-                ? 'bg-[#E6F4DD] text-[#2C765E]'
-                : 'bg-[#F8D9C4] text-[#B5483C]'
-            }`}
-          >
-            {manhole.visited ? <CheckCircle2 className="h-3.5 w-3.5" /> : <Compass className="h-3.5 w-3.5" />}
-            {manhole.visited ? '訪問済み' : '未訪問'}
-          </span>
-          <span className="font-pixel text-xs text-[#8C6A4A]">#{manhole.id}</span>
-        </div>
-        <h3 className="line-clamp-2 min-h-[3rem] text-base font-extrabold leading-6 text-[#4F3828]">
-          {manhole.title}
-        </h3>
-        <p className="mt-2 flex items-center gap-1 text-xs font-bold text-[#6A4D36]">
-          <MapPin className="h-3.5 w-3.5 shrink-0" />
-          <span className="truncate">{manhole.municipality || manhole.prefecture}</span>
+
+      <div>
+        <p className="line-clamp-2 font-pixelJp text-sm font-bold leading-tight text-[#4F3828]">
+          {manhole.municipality || manhole.prefecture}
         </p>
-        <p className="mt-2 line-clamp-1 text-xs font-bold text-[#B5483C]">{pokemonLabel}</p>
+        <p className="mt-1 truncate font-pixelJp text-[11px] text-[#6A4D36]">{manhole.title}</p>
+        {pokemonLabel && (
+          <p className="mt-1 truncate font-pixelJp text-[10px] text-[#B5483C]">{pokemonLabel}</p>
+        )}
       </div>
     </Link>
   );

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -130,7 +130,7 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
         </section>
 
         {selectedProgress && (
-          <section className="mt-5 rounded-[8px] border border-[#DDA63A]/35 bg-[#FFF8EB] p-4 shadow-sm">
+          <section id="prefecture-detail" className="mt-5 rounded-[8px] border border-[#DDA63A]/35 bg-[#FFF8EB] p-4 shadow-sm">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <p className="text-xs font-extrabold text-[#8C6A4A]">選択中の都道府県</p>
@@ -265,7 +265,7 @@ function PrefectureProgressCard({
 }) {
   const href = highlighted
     ? `/users/${encodeURIComponent(userId)}/prefectures`
-    : `?prefecture=${encodeURIComponent(prefecture.name)}`;
+    : `?prefecture=${encodeURIComponent(prefecture.name)}#prefecture-detail`;
 
   return (
     <Link

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -168,6 +168,7 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
               key={prefecture.name}
               prefecture={prefecture}
               highlighted={prefecture.name === selectedPrefecture}
+              userId={progress.userId}
             />
           ))}
         </section>
@@ -256,13 +257,20 @@ function ProgressPill({ prefecture }: { prefecture: PublicPrefectureProgress }) 
 function PrefectureProgressCard({
   prefecture,
   highlighted,
+  userId,
 }: {
   prefecture: PublicPrefectureProgress;
   highlighted: boolean;
+  userId: string;
 }) {
+  const href = highlighted
+    ? `/users/${encodeURIComponent(userId)}/prefectures`
+    : `?prefecture=${encodeURIComponent(prefecture.name)}`;
+
   return (
-    <article
-      className={`rounded-[8px] border bg-[#FFF7E5] p-4 shadow-sm ${
+    <Link
+      href={href}
+      className={`block rounded-[8px] border bg-[#FFF7E5] p-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]/50 ${
         highlighted
           ? 'border-[#DDA63A] ring-2 ring-[#DDA63A]/30'
           : 'border-[#8C6A4A]/15'
@@ -292,6 +300,6 @@ function PrefectureProgressCard({
         </span>
         <span>{formatRate(prefecture.rate, 0)}</span>
       </div>
-    </article>
+    </Link>
   );
 }

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -107,8 +107,7 @@ async function loadPublicUserPrefectureProgressImpl(
 
   const [userInfoResult, { data: manholes, error: manholesError }] =
     await Promise.all([
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (supabase as any).rpc('get_public_user_info', { p_user_id: trimmedUserId }),
+      supabase.rpc('get_public_user_info' as never, { p_user_id: trimmedUserId } as never),
       supabase
         .from('manhole')
         .select('id, title, prefecture, municipality, pokemons')

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -105,13 +105,10 @@ async function loadPublicUserPrefectureProgressImpl(
   const trimmedUserId = userId.trim();
   if (!trimmedUserId) return null;
 
-  const [{ data: appUser, error: appUserError }, { data: manholes, error: manholesError }] =
+  const [userInfoResult, { data: manholes, error: manholesError }] =
     await Promise.all([
-      supabase
-        .from('app_user')
-        .select('auth_uid, display_name')
-        .eq('id', trimmedUserId)
-        .maybeSingle(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (supabase as any).rpc('get_public_user_info', { p_user_id: trimmedUserId }),
       supabase
         .from('manhole')
         .select('id, title, prefecture, municipality, pokemons')
@@ -120,15 +117,14 @@ async function loadPublicUserPrefectureProgressImpl(
         .order('id', { ascending: true }),
     ]);
 
-  if (appUserError) {
-    throw new Error(appUserError.message);
+  if (userInfoResult.error) {
+    throw new Error(userInfoResult.error.message);
   }
 
-  if (!appUser) {
+  const appUserRow = (userInfoResult.data as AppUserProgressRow[] | null)?.[0] ?? null;
+  if (!appUserRow) {
     return null;
   }
-
-  const appUserRow = appUser as unknown as AppUserProgressRow;
 
   if (manholesError) {
     throw new Error(manholesError.message);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -448,14 +448,6 @@ export interface Database {
   };
 }
 
-export interface UserStats {
-  total_visits: number;
-  total_photos: number;
-  prefectures_visited: string[];
-  first_visit: string | null;
-  last_visit: string | null;
-}
-
 export interface Weather {
   condition: 'sunny' | 'cloudy' | 'rainy' | 'snowy' | 'foggy' | 'windy' | 'stormy';
   temperature?: number;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -17,8 +17,6 @@ export interface Database {
           avatar_url: string | null;
           created_at: string;
           updated_at: string;
-          settings: Record<string, any>;
-          stats: UserStats;
           all_prefectures_completed_at: string | null;
           all_prefectures_outdated_at: string | null;
         };
@@ -27,16 +25,12 @@ export interface Database {
           auth_uid: string;
           display_name?: string | null;
           avatar_url?: string | null;
-          settings?: Record<string, any>;
-          stats?: UserStats;
           all_prefectures_completed_at?: string | null;
           all_prefectures_outdated_at?: string | null;
         };
         Update: {
           display_name?: string | null;
           avatar_url?: string | null;
-          settings?: Record<string, any>;
-          stats?: UserStats;
           all_prefectures_completed_at?: string | null;
           all_prefectures_outdated_at?: string | null;
         };


### PR DESCRIPTION
## Summary

- 都道府県カードをクリック可能にした（`?prefecture=<name>` に遷移、選択中は再クリックで解除）
- `app_user` の直接 SELECT を廃止し、`SECURITY DEFINER` 関数経由で `display_name` と `auth_uid` だけを安全に公開（`email` 等のプライベート列を漏洩しない）
- `database.ts` の型定義を実際のスキーマに同期（設計段階のまま残っていた `settings`/`stats` を削除）

## DDL（デプロイ前に適用済み）

- **011**: `get_public_user_info(uuid)` 関数を作成（anon/authenticated に EXECUTE 権限付与）
- **012**: `app_user.email` カラムを削除（`auth.users` で管理）

## Test plan

- [ ] `/users/<userId>/prefectures` で都道府県カードをクリック → `?prefecture=<name>` に遷移してマンホール一覧が表示される
- [ ] 選択中のカードを再クリック → 選択が解除される
- [ ] ログアウト状態（anon）でページが正常に表示される
- [ ] OGP 画像 `/users/<userId>/prefectures/opengraph-image` が正常に返る

🤖 Generated with [Claude Code](https://claude.com/claude-code)