### PR TITLE
Compact stamp grid to 4 columns on visits page

### DIFF
--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -775,7 +775,7 @@ export default function VisitsPage() {
           ) : (
             <>
               {activeTab === 'stamps' && (
-                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <section className="grid grid-cols-4 gap-2 sm:grid-cols-5 lg:grid-cols-6">
                   {passportManholes.slice(0, 60).map((manhole) => (
                     <StampCard
                       key={manhole.id}
@@ -795,7 +795,7 @@ export default function VisitsPage() {
               )}
 
               {activeTab === 'unvisited' && (
-                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <section className="grid grid-cols-4 gap-2 sm:grid-cols-5 lg:grid-cols-6">
                   {unvisitedManholes.slice(0, 60).map((manhole) => (
                     <StampCard key={manhole.id} manhole={manhole} />
                   ))}
@@ -908,22 +908,22 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
   return (
     <Link
       href={`/manhole/${manhole.id}`}
-      className={`relative flex aspect-[4/5] flex-col justify-between rounded-lg border-2 p-3 shadow-sm transition-transform hover:-translate-y-0.5 ${
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-md border-2 p-1.5 shadow-sm transition-transform hover:-translate-y-0.5 ${
         isVisited
           ? 'border-[#B5483C]/45 bg-[#FFF7E5]'
           : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]/75'
       }`}
     >
       <div className="flex items-center justify-between">
-        <span className={`rounded-full px-2 py-1 font-pixelJp text-[10px] font-bold ${
+        <span className={`rounded-full px-1 py-0.5 font-pixelJp text-[8px] font-bold leading-none ${
           isVisited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
         }`}>
-          {isVisited ? '済' : '未訪問'}
+          {isVisited ? '済' : '未'}
         </span>
-        <div className="flex items-center gap-1">
-          {summary?.hasPhotos && <Camera className="h-4 w-4 text-[#B5483C]" />}
+        <div className="flex items-center gap-0.5">
+          {summary?.hasPhotos && <Camera className="h-3 w-3 text-[#B5483C]" />}
           {summary && summary.count > 1 && (
-            <span className="rounded-full bg-[#4F3828] px-1.5 py-0.5 font-pixel text-[10px] text-white">
+            <span className="rounded-full bg-[#4F3828] px-1 py-0.5 font-pixel text-[7px] leading-none text-white">
               x{summary.count}
             </span>
           )}
@@ -932,7 +932,7 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
 
       <div className="flex flex-1 items-center justify-center">
         {isVisited ? (
-          <div className="relative h-24 w-24 overflow-hidden rounded-full border-4 border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
+          <div className="relative aspect-square w-3/4 overflow-hidden rounded-full border-[3px] border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
             {summary?.latestVisit.photos[0]?.thumbnail_url ? (
               <img
                 src={summary.latestVisit.photos[0].thumbnail_url}
@@ -945,27 +945,26 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle,#6F6658_0_18%,#B9AA91_19%_29%,#6F6658_30%_33%,#D7C9AF_34%_48%,#8B7D67_49%_52%,#CFC0A5_53%)]">
-                <CircleDot className="h-8 w-8 text-[#4F3828]/70" />
+                <CircleDot className="h-4 w-4 text-[#4F3828]/70" />
               </div>
             )}
           </div>
         ) : (
-          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
+          <div className="flex aspect-square w-3/4 rotate-[-8deg] items-center justify-center rounded-full border-[3px] border-[#B8AB96] text-center text-[#A39580]">
             <div>
-              <Stamp className="mx-auto h-6 w-6" />
-              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+              <Stamp className="mx-auto h-4 w-4" />
+              <p className="font-pixel text-[7px] leading-none">NEXT</p>
             </div>
           </div>
         )}
       </div>
 
       <div>
-        <p className="line-clamp-2 font-pixelJp text-sm font-bold leading-tight text-[#4F3828]">
+        <p className="truncate font-pixelJp text-[9px] font-bold leading-tight text-[#4F3828]">
           {getMunicipality(manhole)}
         </p>
-        <p className="mt-1 truncate font-pixelJp text-[11px] text-[#6A4D36]">{manhole.prefecture}</p>
         {summary && (
-          <p className="mt-2 font-pixel text-xs text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>
+          <p className="font-pixel text-[8px] text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>
         )}
       </div>
     </Link>


### PR DESCRIPTION
## Summary

- スタンプ帳（stamps・unvisited タブ）のグリッドを `grid-cols-2 sm:grid-cols-3` → `grid-cols-4 sm:grid-cols-5 lg:grid-cols-6` に変更
- `StampCard` 内部を都道府県別達成ページの `PrefectureManholeCard` と同じコンパクトサイズに統一
  - カード padding: `p-3` → `p-1.5`、角丸: `rounded-lg` → `rounded-md`
  - バッジ: `text-[10px] px-2 py-1` → `text-[8px] px-1 py-0.5`、「未訪問」→「未」
  - 訪問円: `h-24 w-24 border-4` → `aspect-square w-3/4 border-[3px]`（レスポンシブ対応）
  - 未訪問円: `h-20 w-20 border-4` → `aspect-square w-3/4 border-[3px]`
  - テキスト: `text-sm line-clamp-2` → `text-[9px] truncate`、都道府県行を削除

## Test plan

- [ ] まいたびページ → スタンプ帳タブ：1行4枚で表示されること
- [ ] 未訪問タブ：同じく1行4枚で表示されること
- [ ] スマートフォンサイズで窮屈になっていないこと
- [ ] 訪問済み・未訪問それぞれのカードデザインが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)