### PR TITLE
Compact stamp grid (4 cols) + update manhole photos export

### DIFF
--- a/docs/claude-commands.md
+++ b/docs/claude-commands.md
@@ -1,0 +1,50 @@
+# Claude Code スラッシュコマンド
+
+このプロジェクトで使える Claude Code のカスタムスラッシュコマンド一覧です。
+コマンド定義は `.claude/commands/` に置かれています。
+
+---
+
+## `/export-photos`
+
+**定義ファイル:** `.claude/commands/export-photos.md`
+
+Supabase の `photo` テーブルからマンホールIDごとの最新公開写真を取得し、
+`public/data/latest-manhole-photos.json` を生成します。
+
+### 何をするか
+
+1. `.env.local` から環境変数を読み込む
+2. `tools/export_latest_manhole_photos.py` を実行する
+3. 取得件数とファイルパスを表示する
+4. 生成された JSON の先頭数行（`generated_at`・`count`）を表示して確認する
+
+### 前提条件
+
+`.env.local` に以下が設定されていること。
+
+| 変数 | 必須 | 備考 |
+|------|------|------|
+| `NEXT_PUBLIC_SUPABASE_URL` | 必須 | Supabase プロジェクト URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | 推奨 | 公開写真のみ取得するため anon key で足りる |
+| `SUPABASE_SERVICE_ROLE_KEY` | 任意 | 設定されていれば優先使用。`placeholder_*` の場合は無視される |
+| `R2_PUBLIC_URL` | 必須 | 画像 URL のベース（例: `https://xxxxx.r2.cloudflarestorage.com`） |
+| `R2_BUCKET` | 必須 | R2 バケット名（例: `image`） |
+
+### 出力
+
+```
+public/data/latest-manhole-photos.json
+```
+
+スキーマの詳細は [`tools/README.md`](../tools/README.md) を参照してください。
+
+### 使い方
+
+Claude Code のチャット欄で入力するだけです。
+
+```
+/export-photos
+```
+
+生成した JSON は `pokefuta-tracker` リポジトリに手動でコピーして使用します。

--- a/public/data/latest-manhole-photos.json
+++ b/public/data/latest-manhole-photos.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-05-12T22:51:45.302901Z",
+  "generated_at": "2026-05-24T14:41:01.585804Z",
   "source": "pokefuta photo table",
   "image": {
     "r2_public_base_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image"
   },
-  "count": 114,
+  "count": 116,
   "photos": {
     "23": {
       "manhole_id": 23,
@@ -291,6 +291,21 @@
       "comment": "出光カルチャーパーク内にあります。",
       "display_name": "tako"
     },
+    "141": {
+      "manhole_id": 141,
+      "photo_id": "866ab293-855c-4810-a0f3-cf6237f120b9",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/63295206-f77c-4ab2-a7d1-79faadbded8c.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/63295206-f77c-4ab2-a7d1-79faadbded8c.jpg",
+      "storage_key": "photos/original/2026/05/63295206-f77c-4ab2-a7d1-79faadbded8c.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1334922,
+      "created_at": "2026-05-24T14:30:56.930694+00:00",
+      "shot_at": "2026-03-17T01:10:59+00:00",
+      "comment": "三笠市立博物館にあります。博物館内にアンモナイトの化石がいっぱいありました",
+      "display_name": "tako"
+    },
     "142": {
       "manhole_id": 142,
       "photo_id": "060a15a9-f063-4b9c-82c8-2bc547207c32",
@@ -439,6 +454,21 @@
       "created_at": "2026-03-17T23:01:50.37032+00:00",
       "shot_at": "2026-03-17T08:05:45+00:00",
       "comment": "小樽のサンモール一番街というモールの入口",
+      "display_name": "tako"
+    },
+    "190": {
+      "manhole_id": 190,
+      "photo_id": "66931efd-cb8e-47ca-b0bb-b9f1bc944deb",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/755f79ac-3dcd-4d02-9932-46d49ce35665.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/755f79ac-3dcd-4d02-9932-46d49ce35665.jpg",
+      "storage_key": "photos/original/2026/05/755f79ac-3dcd-4d02-9932-46d49ce35665.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1602886,
+      "created_at": "2026-05-24T14:35:01.187701+00:00",
+      "shot_at": "2026-03-20T05:01:09+00:00",
+      "comment": "登別市観光交流センター（愛称：ヌプㇽ）にあります。\r\n以前は登別ピーチパークにあったようです。",
       "display_name": "tako"
     },
     "192": {
@@ -713,18 +743,18 @@
     },
     "272": {
       "manhole_id": 272,
-      "photo_id": "d816643f-63df-48a8-a7a0-4142ae6c3a32",
-      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/01/061e4c0b-9f4a-4da5-a6d4-dc2eabf37baf.jpg",
-      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/01/061e4c0b-9f4a-4da5-a6d4-dc2eabf37baf.jpg",
-      "storage_key": "photos/original/2026/01/061e4c0b-9f4a-4da5-a6d4-dc2eabf37baf.jpg",
+      "photo_id": "f0406523-b2aa-4efe-9ba9-a072039e823b",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/02167329-16b6-410e-a14f-e7d13e8219fd.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/05/02167329-16b6-410e-a14f-e7d13e8219fd.jpg",
+      "storage_key": "photos/original/2026/05/02167329-16b6-410e-a14f-e7d13e8219fd.jpg",
       "content_type": "image/jpeg",
       "width": null,
       "height": null,
-      "file_size": 1561371,
-      "created_at": "2026-01-11T13:19:55.118975+00:00",
-      "shot_at": "2025-12-21T07:57:30+00:00",
-      "comment": null,
-      "display_name": "hirochinn0519"
+      "file_size": 1693798,
+      "created_at": "2026-05-24T00:46:17.867307+00:00",
+      "shot_at": "2026-05-24T00:43:10+00:00",
+      "comment": "豊橋鉄道渥美線の新豊橋駅前にありました。豊橋駅の新幹線口公共駐車場が30分無料でした",
+      "display_name": "tako"
     },
     "273": {
       "manhole_id": 273,
@@ -1718,6 +1748,16 @@
     }
   },
   "manhole_comments": {
+    "71": [
+      {
+        "id": "1b92a24d-8f06-4d57-99c2-366030cf7844",
+        "manhole_id": 71,
+        "content": "rわr",
+        "created_at": "2026-05-15T11:55:00.013485+00:00",
+        "updated_at": "2026-05-15T11:55:00.013485+00:00",
+        "display_name": "tako"
+      }
+    ],
     "240": [
       {
         "id": "e3ca6398-8850-4e92-a0ea-4ec790654398",

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -775,7 +775,7 @@ export default function VisitsPage() {
           ) : (
             <>
               {activeTab === 'stamps' && (
-                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <section className="grid grid-cols-4 gap-2 sm:grid-cols-5 lg:grid-cols-6">
                   {passportManholes.slice(0, 60).map((manhole) => (
                     <StampCard
                       key={manhole.id}
@@ -795,7 +795,7 @@ export default function VisitsPage() {
               )}
 
               {activeTab === 'unvisited' && (
-                <section className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                <section className="grid grid-cols-4 gap-2 sm:grid-cols-5 lg:grid-cols-6">
                   {unvisitedManholes.slice(0, 60).map((manhole) => (
                     <StampCard key={manhole.id} manhole={manhole} />
                   ))}
@@ -908,22 +908,22 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
   return (
     <Link
       href={`/manhole/${manhole.id}`}
-      className={`relative flex aspect-[4/5] flex-col justify-between rounded-lg border-2 p-3 shadow-sm transition-transform hover:-translate-y-0.5 ${
+      className={`relative flex aspect-[4/5] flex-col justify-between rounded-md border-2 p-1.5 shadow-sm transition-transform hover:-translate-y-0.5 ${
         isVisited
           ? 'border-[#B5483C]/45 bg-[#FFF7E5]'
           : 'border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9]/75'
       }`}
     >
       <div className="flex items-center justify-between">
-        <span className={`rounded-full px-2 py-1 font-pixelJp text-[10px] font-bold ${
+        <span className={`rounded-full px-1 py-0.5 font-pixelJp text-[8px] font-bold leading-none ${
           isVisited ? 'bg-[#D94D3F] text-white' : 'bg-[#D5C8B3] text-[#7D715F]'
         }`}>
-          {isVisited ? '済' : '未訪問'}
+          {isVisited ? '済' : '未'}
         </span>
-        <div className="flex items-center gap-1">
-          {summary?.hasPhotos && <Camera className="h-4 w-4 text-[#B5483C]" />}
+        <div className="flex items-center gap-0.5">
+          {summary?.hasPhotos && <Camera className="h-3 w-3 text-[#B5483C]" />}
           {summary && summary.count > 1 && (
-            <span className="rounded-full bg-[#4F3828] px-1.5 py-0.5 font-pixel text-[10px] text-white">
+            <span className="rounded-full bg-[#4F3828] px-1 py-0.5 font-pixel text-[7px] leading-none text-white">
               x{summary.count}
             </span>
           )}
@@ -932,7 +932,7 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
 
       <div className="flex flex-1 items-center justify-center">
         {isVisited ? (
-          <div className="relative h-24 w-24 overflow-hidden rounded-full border-4 border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
+          <div className="relative aspect-square w-3/4 overflow-hidden rounded-full border-[3px] border-[#D94D3F] bg-[#E9DEC9] shadow-[inset_0_2px_8px_rgba(181,72,60,0.18)]">
             {summary?.latestVisit.photos[0]?.thumbnail_url ? (
               <img
                 src={summary.latestVisit.photos[0].thumbnail_url}
@@ -945,27 +945,26 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
               />
             ) : (
               <div className="flex h-full w-full items-center justify-center bg-[radial-gradient(circle,#6F6658_0_18%,#B9AA91_19%_29%,#6F6658_30%_33%,#D7C9AF_34%_48%,#8B7D67_49%_52%,#CFC0A5_53%)]">
-                <CircleDot className="h-8 w-8 text-[#4F3828]/70" />
+                <CircleDot className="h-4 w-4 text-[#4F3828]/70" />
               </div>
             )}
           </div>
         ) : (
-          <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
+          <div className="flex aspect-square w-3/4 rotate-[-8deg] items-center justify-center rounded-full border-[3px] border-[#B8AB96] text-center text-[#A39580]">
             <div>
-              <Stamp className="mx-auto h-6 w-6" />
-              <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
+              <Stamp className="mx-auto h-4 w-4" />
+              <p className="font-pixel text-[7px] leading-none">NEXT</p>
             </div>
           </div>
         )}
       </div>
 
       <div>
-        <p className="line-clamp-2 font-pixelJp text-sm font-bold leading-tight text-[#4F3828]">
+        <p className="truncate font-pixelJp text-[9px] font-bold leading-tight text-[#4F3828]">
           {getMunicipality(manhole)}
         </p>
-        <p className="mt-1 truncate font-pixelJp text-[11px] text-[#6A4D36]">{manhole.prefecture}</p>
         {summary && (
-          <p className="mt-2 font-pixel text-xs text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>
+          <p className="font-pixel text-[8px] text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>
         )}
       </div>
     </Link>

--- a/tools/export_latest_manhole_photos.py
+++ b/tools/export_latest_manhole_photos.py
@@ -46,6 +46,16 @@ def encode_storage_key(storage_key: str) -> str:
     return "/".join(urllib.parse.quote(part) for part in storage_key.split("/"))
 
 
+def get_supabase_key() -> str:
+    service_role_key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY", "")
+    if service_role_key and not service_role_key.lower().startswith("placeholder"):
+        return service_role_key
+    anon_key = os.environ.get("NEXT_PUBLIC_SUPABASE_ANON_KEY")
+    if anon_key:
+        return anon_key
+    raise RuntimeError("SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY is required")
+
+
 def get_r2_public_base_url() -> str:
     value = os.environ.get("R2_PUBLIC_BASE_URL") or os.environ.get("R2_PUBLIC_URL")
     if not value:
@@ -133,7 +143,7 @@ def supabase_get(
     timeout: int,
 ) -> list[dict[str, Any]]:
     supabase_url = strip_trailing_slash(require_env("NEXT_PUBLIC_SUPABASE_URL"))
-    service_role_key = require_env("SUPABASE_SERVICE_ROLE_KEY")
+    service_role_key = get_supabase_key()
 
     params = dict(query)
     params["limit"] = str(batch_size)


### PR DESCRIPTION
## Summary

- **スタンプグリッドをコンパクト化**: visits ページでスタンプを4列表示に変更
- **マンホール写真データ更新**: manhole 141（三笠市立博物館）・190（登別市観光交流センター）の写真を追加、272を新写真に更新（114→116件）
- **エクスポートスクリプト改善**: `SUPABASE_SERVICE_ROLE_KEY` が未設定・placeholder の場合に `NEXT_PUBLIC_SUPABASE_ANON_KEY` へフォールバック
- **ドキュメント追加**: `docs/claude-commands.md` に `/export-photos` スラッシュコマンドの使い方を追加

## Test plan

- [ ] visits ページでスタンプが4列で表示されること
- [ ] `/export-photos` コマンドが anon key のみでも動作すること
- [ ] latest-manhole-photos.json の count が 116 になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)