### PR TITLE
Rewrite share texts to user achievement voice + add Pokémon names

### DIFF
--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { MapPin, ArrowLeft, Camera, Navigation, Clock, Trash2, User as UserIcon, Stamp, CircleDot, CheckCircle2, ChevronDown, Share2, Copy, MessageCircle, Building2, Sparkles } from 'lucide-react';
+import { MapPin, ArrowLeft, Camera, Navigation, Clock, Trash2, User as UserIcon, Stamp, CircleDot, CheckCircle2, ChevronDown, Share2, MessageCircle, Building2, Sparkles } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { format } from 'date-fns';
 import { ja } from 'date-fns/locale';
@@ -392,9 +392,10 @@ export default function ManholeDetailPage() {
     const shareablePhoto = photos.find(
       (photo) => currentUserId && photo.visit?.user_id === currentUserId && photo.visit?.is_public === true
     );
+    const pokemons = manhole.pokemons ?? [];
     const shareText = shareablePhoto
-      ? photoShareText(`${manhole.prefecture}${municipality}`, titleHashtags)
-      : manholeShareText(`${manhole.prefecture}${municipality}`);
+      ? photoShareText(`${manhole.prefecture}${municipality}`, titleHashtags, pokemons)
+      : manholeShareText(`${manhole.prefecture}${municipality}`, pokemons);
     const shareUrl = shareablePhoto
       ? `${SITE_URL}/p/${shareablePhoto.id}`
       : `${SITE_URL}/manhole/${manhole.id}`;
@@ -441,18 +442,6 @@ export default function ManholeDetailPage() {
     window.open(buildLineShareUrl(payload.shareUrl), '_blank', 'noopener,noreferrer');
   };
 
-  const handleCopyShareUrl = async () => {
-    const payload = buildSharePayload();
-    if (!payload) return;
-    try {
-      await navigator.clipboard.writeText(payload.shareUrl);
-      trackShareClick(payload.trackParams);
-      trackCopyLink(payload.trackParams);
-      alert('リンクをコピーしました');
-    } catch {
-      alert('コピーに失敗しました');
-    }
-  };
 
   if (loading) {
     return (
@@ -762,11 +751,11 @@ export default function ManholeDetailPage() {
                   LINE
                 </button>
                 <button
-                  onClick={handleCopyShareUrl}
+                  onClick={handleShare}
                   className="inline-flex items-center justify-center gap-1 rounded-[8px] border border-[#7B63A8]/25 bg-white px-3 py-2 text-xs font-extrabold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
                 >
-                  <Copy className="h-4 w-4" />
-                  コピー
+                  <Share2 className="h-4 w-4" />
+                  通常の共有
                 </button>
               </div>
             </div>

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -310,7 +310,7 @@ function PrefectureProgressCard({
         />
       </div>
 
-      <div className="mt-3 flex items-center justify-between gap-2 text-[11px] font-bold text-[#6A4D36]">
+      <div className="mt-3 flex items-center justify-between gap-2 pr-9 text-[11px] font-bold text-[#6A4D36]">
         <span className="inline-flex items-center gap-1">
           <CircleDot className="h-3.5 w-3.5" />
           公開訪問ベース

--- a/src/app/users/[userId]/prefectures/page.tsx
+++ b/src/app/users/[userId]/prefectures/page.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Camera, CheckCircle2, CircleDot, Compass, Stamp, Trophy } fr
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PrefectureProgressShareButton from '@/components/users/PrefectureProgressShareButton';
+import PrefectureCardShareButton from '@/components/users/PrefectureCardShareButton';
 import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import {
   PublicPrefectureManhole,
@@ -107,7 +108,6 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
                 </p>
               </div>
               <PrefectureProgressShareButton
-                displayName={progress.displayName}
                 completedPrefectureCount={progress.completedPrefectureCount}
                 totalPrefectureCount={progress.totalPrefectureCount}
                 shareUrl={shareUrl}
@@ -164,12 +164,20 @@ export default async function UserPrefecturesPage({ params, searchParams }: Page
 
         <section className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {progress.prefectures.map((prefecture) => (
-            <PrefectureProgressCard
-              key={prefecture.name}
-              prefecture={prefecture}
-              highlighted={prefecture.name === selectedPrefecture}
-              userId={progress.userId}
-            />
+            <div key={prefecture.name} className="relative">
+              <PrefectureProgressCard
+                prefecture={prefecture}
+                highlighted={prefecture.name === selectedPrefecture}
+                userId={progress.userId}
+              />
+              <PrefectureCardShareButton
+                prefectureName={prefecture.name}
+                visited={prefecture.visited}
+                total={prefecture.total}
+                complete={prefecture.complete}
+                shareUrl={`${SITE_URL}/users/${encodeURIComponent(progress.userId)}/prefectures?prefecture=${encodeURIComponent(prefecture.name)}`}
+              />
+            </div>
           ))}
         </section>
       </main>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -134,7 +134,7 @@ export default function VisitsPage() {
   }, []);
 
   const handleShare = async () => {
-    const shareText = visitsShareText();
+    const shareText = visitsShareText(visitedManholesCount);
     const shareUrl = 'https://pokefuta.com/visits';
     trackShareClick();
     try {

--- a/src/components/users/PrefectureCardShareButton.tsx
+++ b/src/components/users/PrefectureCardShareButton.tsx
@@ -3,20 +3,24 @@
 import { useEffect, useRef } from 'react';
 import { Share2 } from 'lucide-react';
 import { SITE_NAME } from '@/lib/constants';
-import { openSharePanel, prefectureProgressShareText } from '@/lib/share';
+import { openSharePanel, prefectureCardShareText } from '@/lib/share';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
-type PrefectureProgressShareButtonProps = {
-  completedPrefectureCount: number;
-  totalPrefectureCount: number;
+type PrefectureCardShareButtonProps = {
+  prefectureName: string;
+  visited: number;
+  total: number;
+  complete: boolean;
   shareUrl: string;
 };
 
-export default function PrefectureProgressShareButton({
-  completedPrefectureCount,
-  totalPrefectureCount,
+export default function PrefectureCardShareButton({
+  prefectureName,
+  visited,
+  total,
+  complete,
   shareUrl,
-}: PrefectureProgressShareButtonProps) {
+}: PrefectureCardShareButtonProps) {
   const sharePanelCleanupRef = useRef<(() => void) | null>(null);
   const { trackShareClick, trackShareX, trackShareLine, trackCopyLink } = useAnalytics();
 
@@ -26,11 +30,11 @@ export default function PrefectureProgressShareButton({
     };
   }, []);
 
-  const handleShare = async () => {
-    const shareText = prefectureProgressShareText(
-      completedPrefectureCount,
-      totalPrefectureCount
-    );
+  const handleShare = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const shareText = prefectureCardShareText(prefectureName, visited, total, complete);
 
     trackShareClick();
 
@@ -52,7 +56,7 @@ export default function PrefectureProgressShareButton({
       });
     } catch (error) {
       if (error instanceof Error && error.name !== 'AbortError') {
-        console.error('Prefecture progress share failed:', error);
+        console.error('Prefecture card share failed:', error);
       }
     }
   };
@@ -61,10 +65,10 @@ export default function PrefectureProgressShareButton({
     <button
       type="button"
       onClick={handleShare}
-      className="inline-flex min-h-[44px] items-center justify-center gap-2 rounded-[7px] bg-[#B5483C] px-4 py-3 text-sm font-extrabold text-white shadow-[0_6px_14px_rgba(181,72,60,0.22)] transition hover:bg-[#9F3D33] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+      aria-label={`${prefectureName}を共有`}
+      className="absolute bottom-3 right-3 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-white/80 text-[#6A4D36] shadow-sm transition hover:bg-white hover:text-[#4F3828] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]/50"
     >
-      <Share2 className="h-4 w-4" />
-      達成状況を共有
+      <Share2 className="h-3.5 w-3.5" />
     </button>
   );
 }

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -103,7 +103,7 @@ export function openSharePanel(
     window.open(buildLineShareUrl(shareUrl), '_blank', 'noopener,noreferrer');
   }));
 
-  panel.appendChild(makeBtn('通常の共有', async () => {
+  panel.appendChild(makeBtn('リンクをコピー', async () => {
     try {
       await navigator.clipboard.writeText(shareUrl);
       callbacks.onCopyLink();

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -16,29 +16,42 @@ export function buildLineShareUrl(pageUrl: string): string {
   return `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(pageUrl)}`;
 }
 
-export function manholeShareText(municipality: string): string {
-  return `${municipality}のポケふたを見つけました。\n訪問記録や写真を残せるポケふた用スタンプ帳です。`;
+export function manholeShareText(municipality: string, pokemons: string[] = []): string {
+  const pokemonStr = pokemons.slice(0, 3).join('・');
+  return pokemonStr
+    ? `${pokemonStr}のポケふたを${municipality}で見つけました！`
+    : `${municipality}のポケふたを見つけました！`;
 }
 
-export function photoShareText(municipality: string, hashtags: string[] = []): string {
+export function photoShareText(municipality: string, hashtags: string[] = [], pokemons: string[] = []): string {
+  const pokemonStr = pokemons.slice(0, 3).join('・');
   const titleTags = hashtags.slice(0, 2).join(' ');
-  return [
-    `${municipality}のポケふたを見つけました。`,
-    titleTags,
-    '訪問記録や写真を残せるポケふた用スタンプ帳です。',
-  ].filter(Boolean).join('\n');
+  const base = pokemonStr
+    ? `${pokemonStr}のポケふたを${municipality}で記録しました！`
+    : `${municipality}のポケふたを記録しました！`;
+  return [base, titleTags].filter(Boolean).join('\n');
 }
 
-export function visitsShareText(): string {
-  return 'ポケふた巡りのスタンプ帳を更新しました。\n訪問したポケふたを写真付きで記録しています。';
+export function visitsShareText(stampCount: number): string {
+  return `ポケふた旅を続けています！\n${stampCount}枚のポケふたを巡りました`;
 }
 
 export function prefectureProgressShareText(
-  displayName: string,
   completedPrefectureCount: number,
   totalPrefectureCount: number
 ): string {
-  return `${displayName}のポケふた都道府県達成状況です。\n${completedPrefectureCount}/${totalPrefectureCount}都道府県を制覇しました。`;
+  return `${completedPrefectureCount}/${totalPrefectureCount}都道府県のポケふたを制覇しました！`;
+}
+
+export function prefectureCardShareText(
+  prefectureName: string,
+  visited: number,
+  total: number,
+  complete: boolean
+): string {
+  return complete
+    ? `${prefectureName}のポケふたを全て制覇しました！`
+    : `${prefectureName}のポケふたを${visited}/${total}枚制覇中です！`;
 }
 
 export interface SharePanelCallbacks {
@@ -90,7 +103,7 @@ export function openSharePanel(
     window.open(buildLineShareUrl(shareUrl), '_blank', 'noopener,noreferrer');
   }));
 
-  panel.appendChild(makeBtn('リンクをコピー', async () => {
+  panel.appendChild(makeBtn('通常の共有', async () => {
     try {
       await navigator.clipboard.writeText(shareUrl);
       callbacks.onCopyLink();


### PR DESCRIPTION
## Summary
- **Share text rewrite**: 全シェアテキストをサイト告知口調 → ユーザー達成口調に変更
- **ポケモン名追加**: マンホール・写真シェアにポケモン名（最大3体、「・」区切り）を追加
- **スタンプ数追加**: 訪問パスポートのシェアに訪問枚数を追加
- **都道府県カード個別共有**: 各都道府県カードに小さなシェアボタンを追加（`PrefectureCardShareButton`）
- **UI統一**: コピーボタン・openSharePanelの3択を「通常の共有」に統一（navigator.share → クリップボードフォールバック）

## 変更前後テキスト比較

| ページ | 変更前 | 変更後 |
|--------|--------|--------|
| マンホール | `○○市のポケふたを見つけました。\n訪問記録や写真を残せる…` | `ピカチュウのポケふたを○○市で見つけました！` |
| 写真あり | 同上 + サイト紹介 | `ピカチュウのポケふたを○○市で記録しました！\n#タグ` |
| 訪問パスポート | `ポケふた巡りのスタンプ帳を更新しました。\n…` | `ポケふた旅を続けています！\n42枚のポケふたを巡りました` |
| 都道府県達成 | `○○のポケふた都道府県達成状況です。\n15/47…` | `15/47都道府県のポケふたを制覇しました！` |
| 都道府県カード（新規） | — | `東京都のポケふたを全て制覇しました！` |

## Test plan
- [ ] マンホール詳細ページで X シェア → テキストにポケモン名が含まれるか確認
- [ ] ポケモンのいないマンホール → ポケモン名なし形式にfallbackするか確認
- [ ] 訪問パスポートのシェアボタン → スタンプ数が含まれるか確認
- [ ] 都道府県達成ページで「達成状況を共有」→ displayName なし達成口調になっているか確認
- [ ] 都道府県カード右下のシェアボタン → 制覇済み/巡り中で文言が分岐するか確認
- [ ] openSharePanel（デスクトップ）のボタンラベルが「通常の共有」になっているか確認
- [ ] `npm run type-check` が通るか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)