### PR TITLE
Compact guest and nearby mobile layouts

### DIFF
--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -305,17 +305,17 @@ export default function NearbyPage() {
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
       <Header title="ポケふたを探す" />
 
-      <main className="relative mx-auto max-w-6xl px-4 pb-6 pt-5 sm:pt-8">
-        <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-7 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-10">
+      <main className="relative mx-auto max-w-6xl px-3 pb-5 pt-3 sm:px-4 sm:pb-6 sm:pt-8">
+        <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-4 py-4 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-10">
           <div className="relative max-w-3xl">
-            <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+            <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-2.5 py-1 text-[11px] font-bold text-[#7B63A8] sm:mb-4 sm:px-3 sm:text-xs">
               <Compass className="h-3.5 w-3.5" />
               旅先で探す
             </div>
-            <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
+            <h1 className="max-w-2xl text-2xl font-extrabold leading-tight tracking-normal sm:text-5xl">
               ポケふたを探す
             </h1>
-            <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
+            <p className="mt-2 max-w-2xl text-sm font-medium leading-snug sm:mt-4 sm:text-lg sm:leading-relaxed">
               現在地の近くから、全国一覧まで。次に会いに行くポケふたをここで見つけよう。
             </p>
           </div>
@@ -334,41 +334,41 @@ export default function NearbyPage() {
         )}
 
         {userLocation && (
-          <section id="nearby-controls" className="mt-5 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-4 shadow-sm sm:p-5">
-            <div className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-center">
-              <div className="grid grid-cols-3 gap-3">
-                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-                  <div className="text-xl font-extrabold leading-none text-[#7B63A8]">{nearbyManholes.length}</div>
-                  <div className="mt-1 text-xs font-bold text-[#6B6B6B]">発見</div>
+          <section id="nearby-controls" className="mt-3 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-3 shadow-sm sm:mt-5 sm:p-5">
+            <div className="grid gap-3">
+              <div className="grid grid-cols-3 gap-2 sm:gap-3">
+                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-2.5 sm:p-3">
+                  <div className="text-lg font-extrabold leading-none text-[#7B63A8] sm:text-xl">{nearbyManholes.length}</div>
+                  <div className="mt-0.5 text-[11px] font-bold text-[#6B6B6B] sm:mt-1 sm:text-xs">発見</div>
                 </div>
-                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-                  <div className="text-xl font-extrabold leading-none text-[#FF8F1F]">{radius}km</div>
-                  <div className="mt-1 text-xs font-bold text-[#6B6B6B]">範囲</div>
+                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-2.5 sm:p-3">
+                  <div className="text-lg font-extrabold leading-none text-[#FF8F1F] sm:text-xl">{radius}km</div>
+                  <div className="mt-0.5 text-[11px] font-bold text-[#6B6B6B] sm:mt-1 sm:text-xs">範囲</div>
                 </div>
-                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-3">
-                  <div className="text-xl font-extrabold leading-none text-[#2D846C]">
+                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-white/70 p-2.5 sm:p-3">
+                  <div className="text-lg font-extrabold leading-none text-[#2D846C] sm:text-xl">
                     {nearbyManholes.length > 0 ? formatDistance(nearbyManholes[0].distance) : '-'}
                   </div>
-                  <div className="mt-1 text-xs font-bold text-[#6B6B6B]">最寄り</div>
+                  <div className="mt-0.5 text-[11px] font-bold text-[#6B6B6B] sm:mt-1 sm:text-xs">最寄り</div>
                 </div>
-              </div>
-
-              <div className="flex gap-2">
-                <button
-                  onClick={getCurrentLocationAndLoadManholes}
-                  className="inline-flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-lg bg-white px-4 text-sm font-bold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15 transition hover:bg-[#FFB347]/20 lg:flex-none"
-                  title="現在地を更新"
-                >
-                  <RefreshCw className="h-4 w-4" />
-                  現在地を更新
-                </button>
               </div>
             </div>
 
-            <div className="mt-5">
-              <div className="mb-2 flex items-center justify-between text-xs font-bold text-[#6B6B6B]">
-                <span>検索範囲</span>
-                <span>1km - 100km</span>
+            <div className="mt-3">
+              <div className="mb-2 flex items-center justify-between gap-3">
+                <div className="min-w-0 text-xs font-bold text-[#6B6B6B]">
+                  <span>検索範囲</span>
+                  <span className="ml-2 text-[#9B8D78]">1km - 100km</span>
+                </div>
+                <button
+                  onClick={getCurrentLocationAndLoadManholes}
+                  className="inline-flex min-h-[44px] shrink-0 items-center justify-center gap-1.5 rounded-lg bg-white px-3 text-xs font-bold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15 transition hover:bg-[#FFB347]/20 sm:gap-2 sm:px-4 sm:text-sm"
+                  title="現在地を更新"
+                >
+                  <RefreshCw className="h-4 w-4" />
+                  <span className="sm:hidden">更新</span>
+                  <span className="hidden sm:inline">現在地を更新</span>
+                </button>
               </div>
               <input
                 type="range"
@@ -385,9 +385,9 @@ export default function NearbyPage() {
           </section>
         )}
 
-        <section className="mt-5">
-          <div className="-mx-4 overflow-x-auto px-4 pb-1">
-            <div className="flex min-w-max gap-2 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB]/80 p-1 shadow-sm sm:min-w-0">
+        <section className="mt-3 sm:mt-5">
+          <div className="-mx-3 overflow-x-auto px-3 pb-1 sm:-mx-4 sm:px-4">
+            <div className="flex min-w-max gap-1.5 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB]/80 p-0.5 shadow-sm sm:min-w-0 sm:gap-2 sm:p-1">
               {visibleSearchTabs.map((tab) => {
                 const isActive = activeTab === tab.key;
                 return (
@@ -395,7 +395,7 @@ export default function NearbyPage() {
                     key={tab.key}
                     type="button"
                     onClick={() => handleTabChange(tab.key)}
-                    className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
+                    className={`min-h-[44px] rounded-[7px] px-4 text-sm font-bold transition sm:px-5 ${
                       isActive
                         ? 'bg-[#7B63A8] text-white shadow-sm'
                         : 'text-[#2A2A2A] hover:bg-white'
@@ -410,7 +410,7 @@ export default function NearbyPage() {
         </section>
 
         {activeTab === 'all' && (
-          <section className="mt-5 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-4 shadow-sm sm:p-5">
+          <section className="mt-3 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] p-3 shadow-sm sm:mt-5 sm:p-5">
             <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
               <label className="relative block">
                 <Search className="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7B63A8]" />
@@ -437,7 +437,7 @@ export default function NearbyPage() {
         )}
 
         {(((activeTab === 'nearby' || activeTab === 'unvisited') && loading) || (activeTab === 'all' && allLoading)) && (
-          <div className="flex items-center justify-center py-10">
+          <div className="flex items-center justify-center py-7 sm:py-10">
             <div className="text-center">
               <div className="font-bold text-[#7B63A8]">
                 {activeTab === 'all' ? '全ポケふたを読み込み中' : '検索中'}<span className="rpg-loading"></span>
@@ -447,7 +447,7 @@ export default function NearbyPage() {
         )}
 
         {!(((activeTab === 'nearby' || activeTab === 'unvisited') && loading) || (activeTab === 'all' && allLoading)) && (
-          <section className="mt-5">
+          <section className="mt-3 sm:mt-5">
             {(() => {
               const displayManholes =
                 activeTab === 'all' ? filteredAllManholes :
@@ -455,8 +455,8 @@ export default function NearbyPage() {
                 nearbyManholes;
 
               return displayManholes.length === 0 ? (
-                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-10 text-center shadow-sm">
-                  <MapPin className="mx-auto mb-3 h-10 w-10 text-[#7B63A8]/60" />
+                <div className="rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-4 py-7 text-center shadow-sm sm:px-5 sm:py-10">
+                  <MapPin className="mx-auto mb-2 h-9 w-9 text-[#7B63A8]/60 sm:mb-3 sm:h-10 sm:w-10" />
                   <p className="text-sm font-bold text-[#2A2A2A]">
                     {activeTab === 'unvisited'
                       ? '近くに未訪問のポケふたが見つかりませんでした'
@@ -469,7 +469,7 @@ export default function NearbyPage() {
                   </p>
                 </div>
               ) : (
-                <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                <div className="grid gap-2.5 sm:gap-3 md:grid-cols-2 xl:grid-cols-3">
                   {displayManholes.map((manhole) => (
                   <article
                     key={manhole.id}
@@ -494,17 +494,17 @@ export default function NearbyPage() {
                           ))}
                         </div>
                       ) : (
-                        <div className="flex aspect-[3/1] items-center justify-center rounded-[6px] bg-[#E9DEC9]">
+                        <div className="flex aspect-[4/1] items-center justify-center rounded-[6px] bg-[#E9DEC9] sm:aspect-[3/1]">
                           <div className="flex flex-col items-center text-[#B8AB96]">
-                            <CircleDot className="h-8 w-8" />
+                            <CircleDot className="h-6 w-6 sm:h-8 sm:w-8" />
                             <p className="mt-1 font-pixel text-[9px] leading-none">POKEFUTA</p>
                           </div>
                         </div>
                       )}
                     </div>
 
-                    <div className="p-4">
-                      <div className="mb-3 flex items-start justify-between gap-3">
+                    <div className="p-3 sm:p-4">
+                      <div className="mb-2 flex items-start justify-between gap-2 sm:mb-3 sm:gap-3">
                         <div className="min-w-0">
                           <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
                             {manhole.prefecture}
@@ -515,8 +515,8 @@ export default function NearbyPage() {
                           </div>
                         </div>
                         {activeTab !== 'all' && (
-                          <div className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-right shadow-sm ring-1 ring-[#7B63A8]/15">
-                            <div className="text-base font-extrabold leading-none text-[#7B63A8]">
+                          <div className="shrink-0 rounded-[8px] bg-white px-2.5 py-1.5 text-right shadow-sm ring-1 ring-[#7B63A8]/15 sm:px-3 sm:py-2">
+                            <div className="text-sm font-extrabold leading-none text-[#7B63A8] sm:text-base">
                               {manhole.distance !== undefined ? formatDistance(manhole.distance) : '-'}
                             </div>
                             <div className="mt-1 text-[10px] font-bold text-[#6B6B6B]">現在地から</div>
@@ -525,14 +525,14 @@ export default function NearbyPage() {
                       </div>
 
                       {manhole.visit && (
-                        <div className="mb-3 inline-flex items-center gap-2 rounded-full bg-[#2D846C]/10 px-3 py-1 text-xs font-bold text-[#2D846C]">
+                        <div className="mb-2 inline-flex items-center gap-2 rounded-full bg-[#2D846C]/10 px-3 py-1 text-xs font-bold text-[#2D846C] sm:mb-3">
                           <Camera className="h-3.5 w-3.5" />
                           訪問済み {formatDate(manhole.visit.shot_at)}
                         </div>
                       )}
 
                       {manhole.pokemons && manhole.pokemons.length > 0 && (
-                        <div className="mb-4 flex flex-wrap gap-1.5">
+                        <div className="mb-3 flex flex-wrap gap-1.5 sm:mb-4">
                           {manhole.pokemons.slice(0, 3).map((pokemon, index) => (
                             <span
                               key={index}
@@ -551,7 +551,7 @@ export default function NearbyPage() {
 
                       <button
                         onClick={(e) => openInMaps(manhole, e)}
-                        className="inline-flex min-h-[42px] w-full items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-4 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
+                        className="inline-flex min-h-[44px] w-full items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-4 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
                         title="Google Mapsで経路を表示"
                       >
                         <Navigation className="h-4 w-4" />
@@ -576,9 +576,9 @@ export default function NearbyPage() {
 
       <Link
         href={uploadHref}
-        className="fixed bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] right-4 z-40 inline-flex items-center gap-2 rounded-full bg-[#7B63A8] px-5 py-4 text-sm font-extrabold text-white shadow-[0_8px_18px_rgba(123,99,168,0.30)] transition hover:bg-[#6A5299] sm:bottom-6 sm:right-6"
+        className="fixed bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] right-3 z-40 inline-flex min-h-[44px] items-center gap-1.5 rounded-full bg-[#7B63A8] px-4 py-3 text-xs font-extrabold text-white shadow-[0_8px_18px_rgba(123,99,168,0.30)] transition hover:bg-[#6A5299] sm:bottom-6 sm:right-6 sm:gap-2 sm:px-5 sm:py-4 sm:text-sm"
       >
-        <Camera className="h-5 w-5" />
+        <Camera className="h-4 w-4 sm:h-5 sm:w-5" />
         写真を投稿
       </Link>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -373,7 +373,7 @@ export default function HomePage() {
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
 
-  const listedCountLabel = totalPosts && totalPosts > 0 ? `${totalPosts}枚以上` : '集計中';
+  const listedCountLabel = totalPosts && totalPosts > 0 ? `${totalPosts}枚以上掲載` : '掲載数を集計中';
   const totalFeedCount = totalPosts && totalPosts > 0 ? totalPosts : null;
   const totalPages = totalFeedCount ? Math.max(1, Math.ceil(totalFeedCount / feedPerPage)) : null;
   const canGoNext = totalPages ? currentPage < totalPages : feed.length === feedPerPage;
@@ -814,67 +814,66 @@ export default function HomePage() {
               </>
             ) : (
               <>
-                <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-8 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-12">
-                  <div className="absolute right-6 top-7 hidden w-[300px] rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block xl:w-[360px]">
-                    <img
-                      src="/pokefuta_photo_gallery_mockup.svg"
-                      alt=""
-                      className="h-[220px] w-full rounded-[6px] object-cover object-left-top xl:h-[250px]"
-                    />
-                  </div>
-                  <div className="relative max-w-3xl lg:max-w-[680px]">
-                    <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
-                      <Sparkles className="h-3.5 w-3.5" />
-                      ポケふた旅日記
+                <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-6 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-8 sm:py-8">
+                  <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start xl:grid-cols-[minmax(0,1fr)_380px]">
+                    <div className="relative max-w-3xl">
+                      <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+                        <Sparkles className="h-3.5 w-3.5" />
+                        ポケふた旅日記
+                      </div>
+                      <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
+                        全国に広がるポケふた。
+                      </h1>
+                      <div className="mt-4 max-w-2xl space-y-3 text-base font-medium leading-relaxed sm:text-lg">
+                        <p>
+                          海沿いの町、温泉地、離島、雪国の駅前。
+                          旅先でしか出会えない
+                          <span className="font-extrabold text-[#7B63A8]"> "レアなポケふた"</span> がたくさんあります。
+                        </p>
+                        <p>
+                          地図を片手に探し回ったり、偶然見つけたり。
+                          その土地の景色と一緒に、ポケふたを記録してみませんか？
+                        </p>
+                      </div>
+
+                      <p className="mt-4 text-xs font-bold text-[#9B9B9B]">全国387自治体 · {listedCountLabel}</p>
+
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        <Link
+                          href="/nearby?tab=all"
+                          className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
+                        >
+                          <Compass className="h-4 w-4" />
+                          ポケふたを地図で探す
+                        </Link>
+                        <Link
+                          href="/nearby"
+                          className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
+                        >
+                          <MapPin className="h-4 w-4" />
+                          近くのポケふたを見る
+                        </Link>
+                        <Link
+                          href={uploadHref}
+                          className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
+                        >
+                          <Camera className="h-4 w-4" />
+                          旅の記録を残す
+                        </Link>
+                      </div>
                     </div>
-                    <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
-                      全国に広がるポケふた。
-                    </h1>
-                    <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
-                      海沿いの町、<br />
-                      温泉地、<br />
-                      離島、<br />
-                      雪国の駅前。<br />
-                      <br />
-                      旅先でしか出会えない<br />
-                      <span className="font-extrabold text-[#7B63A8]">"レアなポケふた"</span> がたくさんあります。<br />
-                      <br />
-                      地図を片手に探し回ったり、<br />
-                      偶然見つけたり。<br />
-                      <br />
-                      その土地の景色と一緒に、<br />
-                      ポケふたを記録してみませんか？
-                    </p>
 
-                    <p className="mt-5 text-xs font-bold text-[#9B9B9B]">全国387自治体 · {listedCountLabel}枚以上掲載</p>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <Link
-                        href="/nearby?tab=all"
-                        className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-                      >
-                        <Compass className="h-4 w-4" />
-                        ポケふたを地図で探す
-                      </Link>
-                      <Link
-                        href="/nearby"
-                        className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
-                      >
-                        <MapPin className="h-4 w-4" />
-                        近くのポケふたを見る
-                      </Link>
-                      <Link
-                        href={uploadHref}
-                        className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
-                      >
-                        <Camera className="h-4 w-4" />
-                        旅の記録を残す
-                      </Link>
+                    <div className="hidden rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block">
+                      <img
+                        src="/pokefuta_photo_gallery_mockup.svg"
+                        alt=""
+                        className="h-[210px] w-full rounded-[6px] object-cover object-left-top xl:h-[230px]"
+                      />
                     </div>
                   </div>
                 </section>
 
-                <section className="mt-6">
+                <section className="mt-4 sm:mt-5">
                   <div className="-mx-4 overflow-x-auto px-4 pb-1">
                     <div role="tablist" className="flex min-w-max gap-2 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB]/80 p-1 shadow-sm sm:min-w-0">
                       {galleryTabs.map((tab) => {


### PR DESCRIPTION
## Summary
- Compact the logged-out home hero by tightening spacing, grouping the copy into shorter paragraphs, and placing the mockup in the grid flow.
- Compact the `/nearby` mobile UI so results appear sooner while preserving tap targets.
- Address review feedback by making the listed-count fallback read `掲載数を集計中` instead of appending `掲載` blindly.

## Verification
- `npm run type-check`
- `npm run build`
- `git diff --check`

## Notes
- `npm run build` still logs the existing Next.js dynamic route warnings for cookie/request-url API routes, but completes successfully.