### PR TITLE
Fix users OGP image returning HTTP 500

### DIFF
--- a/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
+++ b/src/app/users/[userId]/prefectures/opengraph-image/route.tsx
@@ -26,6 +26,7 @@ async function loadNotoSansCjk(): Promise<ArrayBuffer | null> {
 }
 
 export async function GET(_request: Request, { params }: RouteContext) {
+  try {
   const [progress, fontData] = await Promise.all([
     loadPublicUserPrefectureProgress(params.userId),
     loadNotoSansCjk(),
@@ -57,16 +58,15 @@ export async function GET(_request: Request, { params }: RouteContext) {
         <div
           style={{
             position: 'absolute',
-            inset: 0,
-            backgroundImage:
-              'linear-gradient(90deg, rgba(140,106,74,0.10) 1px, transparent 1px), linear-gradient(rgba(140,106,74,0.10) 1px, transparent 1px)',
+            top: 0, right: 0, bottom: 0, left: 0,
+            backgroundImage: 'linear-gradient(#8C6A4A1A 1px, transparent 1px)',
             backgroundSize: '32px 32px',
           }}
         />
         <div
           style={{
             position: 'absolute',
-            inset: 32,
+            top: 32, right: 32, bottom: 32, left: 32,
             border: '4px solid rgba(140,106,74,0.18)',
             borderRadius: 20,
           }}
@@ -115,6 +115,13 @@ export async function GET(_request: Request, { params }: RouteContext) {
       },
     }
   );
+  } catch (err) {
+    console.error('[OGP] users prefectures render failed:', err);
+    return new Response('Internal Server Error', {
+      status: 500,
+      headers: { 'Cache-Control': 'public, max-age=60' },
+    });
+  }
 }
 
 function OgpStat({ label, value }: { label: string; value: string }) {


### PR DESCRIPTION
## Summary

- Fix `GET /users/[userId]/prefectures/opengraph-image` returning HTTP 500

## Root Cause

Satori (`@vercel/og` 0.6.3, bundled in Next.js 14.2.32) misparses `rgba()` inside `linear-gradient` color stops. Its gradient parser splits on **all** commas, including those inside `rgba(...)`, so:

```
linear-gradient(90deg, rgba(140,106,74,0.10) 1px, transparent 1px), linear-gradient(...)
```

…throws `gba(140,106,74,0.10) 1px, transparent 1px): Missing comma before color stops` — an unhandled exception → HTTP 500.

Multiple gradients in a single `backgroundImage` are also unsupported by Satori.

## Changes

| | Before | After |
|---|---|---|
| Grid overlay | Double `rgba()`-based gradient | Single horizontal-stripe gradient, hex+alpha `#8C6A4A1A` |
| Border overlay | `inset: 32` shorthand | Explicit `top/right/bottom/left: 32` |
| Error handling | Unhandled → crash → 500 | `try/catch` with logged error and short-lived 500 cache |

## Verification

Open this URL after deploy — should return a `200 image/png`:

```
https://pokefuta.com/users/08c2bb09-8aa0-44f7-8287-7b332a589f33/prefectures/opengraph-image?v=20260522-ogp-layout
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)