### PR TITLE
Add iOS context image upload API with Bearer token auth

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -16,6 +16,7 @@ Supabase SQL Editorで `database/migrations/` のSQLを番号順に実行しま�
 10. `012_drop_email_from_app_user.sql`
 11. `013_add_app_user_self_select_policy.sql`
 12. `014_add_get_my_app_user_id_fn.sql`
+13. `015_add_photo_context_images.sql`
 
 ## 注意
 

--- a/database/migrations/015_add_photo_context_images.sql
+++ b/database/migrations/015_add_photo_context_images.sql
@@ -1,0 +1,147 @@
+-- Add optional context images attached to manholes.
+-- These images are uploaded by the iOS app and keep Shot Context Classifier output.
+-- They intentionally do not reference visit/photo records, so this migration does
+-- not affect existing post visibility, post deletion, or photo deletion behavior.
+--
+-- Before running this migration in production, take a Supabase database backup:
+-- 1. Open Supabase Dashboard > Project > Database > Backups.
+-- 2. Confirm the latest automatic backup is recent enough for rollback.
+-- 3. If Point-in-Time Recovery is enabled, note the current timestamp.
+-- 4. For an extra manual export, run:
+--    supabase db dump --db-url "$SUPABASE_DB_URL" -f backups/pre_015_photo_context_images.sql
+-- 5. Verify the dump file exists and is non-empty before applying this migration.
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'shot_context_label') THEN
+    CREATE TYPE public.shot_context_label AS ENUM (
+      'centered_clean',
+      'selfie_with_manhole',
+      'wide_context',
+      'signage_info',
+      'partial_occluded',
+      'not_relevant',
+      'low_quality'
+    );
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.photo_context_image (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  manhole_id INTEGER NOT NULL REFERENCES public.manhole(id) ON DELETE CASCADE,
+
+  storage_provider TEXT NOT NULL DEFAULT 'r2',
+  storage_key TEXT NOT NULL UNIQUE,
+
+  original_name TEXT,
+  content_type TEXT NOT NULL,
+  file_size INTEGER,
+  width INTEGER,
+  height INTEGER,
+  sha256 TEXT,
+  exif JSONB,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  shot_context_label public.shot_context_label,
+  shot_context_confidence DOUBLE PRECISION,
+  shot_context_confidences JSONB,
+
+  source_platform TEXT NOT NULL DEFAULT 'ios',
+  app_version TEXT,
+  device_model TEXT,
+
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  created_by UUID NOT NULL REFERENCES auth.users(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_ios_only'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_ios_only
+      CHECK (source_platform = 'ios');
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_content_type'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_content_type
+      CHECK (content_type IN ('image/jpeg', 'image/png', 'image/heic', 'image/heif', 'image/webp'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_file_size'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_file_size
+      CHECK (file_size IS NULL OR file_size <= 10485760);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_photo_context_image_manhole_id
+  ON public.photo_context_image(manhole_id, sort_order, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_photo_context_image_created_by
+  ON public.photo_context_image(created_by);
+
+DROP TRIGGER IF EXISTS update_photo_context_image_updated_at ON public.photo_context_image;
+CREATE TRIGGER update_photo_context_image_updated_at
+  BEFORE UPDATE ON public.photo_context_image
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+ALTER TABLE public.photo_context_image ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "users_select_own_photo_context_images" ON public.photo_context_image;
+CREATE POLICY "users_select_own_photo_context_images"
+ON public.photo_context_image FOR SELECT
+USING (created_by = auth.uid());
+
+DROP POLICY IF EXISTS "users_insert_own_ios_photo_context_images" ON public.photo_context_image;
+CREATE POLICY "users_insert_own_ios_photo_context_images"
+ON public.photo_context_image FOR INSERT
+WITH CHECK (
+  source_platform = 'ios'
+  AND created_by = auth.uid()
+  AND EXISTS (
+    SELECT 1
+    FROM public.manhole m
+    WHERE m.id = photo_context_image.manhole_id
+  )
+);
+
+DROP POLICY IF EXISTS "users_update_own_photo_context_images" ON public.photo_context_image;
+CREATE POLICY "users_update_own_photo_context_images"
+ON public.photo_context_image FOR UPDATE
+USING (created_by = auth.uid())
+WITH CHECK (
+  created_by = auth.uid()
+  AND source_platform = 'ios'
+);
+
+DROP POLICY IF EXISTS "users_delete_own_photo_context_images" ON public.photo_context_image;
+CREATE POLICY "users_delete_own_photo_context_images"
+ON public.photo_context_image FOR DELETE
+USING (created_by = auth.uid());

--- a/database/migrations/016_remove_context_image_file_size_constraint.sql
+++ b/database/migrations/016_remove_context_image_file_size_constraint.sql
@@ -1,0 +1,2 @@
+ALTER TABLE photo_context_image
+  DROP CONSTRAINT IF EXISTS photo_context_image_file_size;

--- a/src/app/api/manholes/[manholeId]/comments/route.ts
+++ b/src/app/api/manholes/[manholeId]/comments/route.ts
@@ -80,7 +80,7 @@ import { Database } from '@/types/database';
 // ==========================================
 export async function GET(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: { manholeId: string } }
 ) {
   try {
     const supabase = createRouteHandlerClient<Database>({ cookies });
@@ -89,7 +89,7 @@ export async function GET(
     const limit = parseInt(searchParams.get('limit') || '20');
     const offset = parseInt(searchParams.get('offset') || '0');
 
-    const manholeId = Number(params.id);
+    const manholeId = Number(params.manholeId);
     if (!Number.isFinite(manholeId)) {
       return NextResponse.json(
         { success: false, error: 'Invalid manhole id' },
@@ -179,7 +179,7 @@ export async function GET(
 // ==========================================
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string } }
+  { params }: { params: { manholeId: string } }
 ) {
   try {
     const supabase = createRouteHandlerClient<Database>({ cookies });
@@ -192,7 +192,7 @@ export async function POST(
       );
     }
 
-    const manholeId = Number(params.id);
+    const manholeId = Number(params.manholeId);
     if (!Number.isFinite(manholeId)) {
       return NextResponse.json(
         { success: false, error: 'Invalid manhole id' },

--- a/src/app/api/manholes/[manholeId]/context-images/route.ts
+++ b/src/app/api/manholes/[manholeId]/context-images/route.ts
@@ -4,8 +4,10 @@ import { createClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
 import { Database, ShotContextLabel } from '@/types/database';
 import { generateContextImageStorageKey, storage } from '@/lib/storage';
+import { SHOT_CONTEXT_LABELS } from '@/lib/shot-context-labels';
 
 const MAX_CONTEXT_IMAGES_PER_USER_MANHOLE = 5;
+const MAX_CONTEXT_IMAGE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB
 const IOS_PLATFORM_HEADER = 'x-pokefuta-client-platform';
 const IOS_TOKEN_HEADER = 'x-pokefuta-ios-api-key';
 
@@ -17,15 +19,12 @@ const ALLOWED_CONTENT_TYPES = new Set([
   'image/webp',
 ]);
 
-const SHOT_CONTEXT_LABELS = new Set<ShotContextLabel>([
-  'centered_clean',
-  'selfie_with_manhole',
-  'wide_context',
-  'signage_info',
-  'partial_occluded',
-  'not_relevant',
-  'low_quality',
-]);
+class ValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ValidationError';
+  }
+}
 
 function isIosContextRequest(request: NextRequest) {
   const platform = request.headers.get(IOS_PLATFORM_HEADER)?.toLowerCase();
@@ -46,20 +45,20 @@ function isIosContextRequest(request: NextRequest) {
 function parseJsonField(value: FormDataEntryValue | null, fieldName: string) {
   if (value == null || value === '') return null;
   if (typeof value !== 'string') {
-    throw new Error(`${fieldName} must be a JSON string`);
+    throw new ValidationError(`${fieldName} must be a JSON string`);
   }
 
   try {
     return JSON.parse(value);
   } catch {
-    throw new Error(`${fieldName} must be valid JSON`);
+    throw new ValidationError(`${fieldName} must be valid JSON`);
   }
 }
 
 function parseShotContextLabel(value: FormDataEntryValue | null): ShotContextLabel | null {
   if (typeof value !== 'string' || value.length === 0) return null;
   if (!SHOT_CONTEXT_LABELS.has(value as ShotContextLabel)) {
-    throw new Error('Invalid shot_context_label');
+    throw new ValidationError('Invalid shot_context_label');
   }
   return value as ShotContextLabel;
 }
@@ -68,7 +67,7 @@ function parseConfidence(value: FormDataEntryValue | null) {
   if (typeof value !== 'string' || value.length === 0) return null;
   const confidence = Number(value);
   if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
-    throw new Error('shot_context_confidence must be between 0 and 1');
+    throw new ValidationError('shot_context_confidence must be between 0 and 1');
   }
   return confidence;
 }
@@ -183,6 +182,13 @@ export async function POST(
       }, { status: 400 });
     }
 
+    if (file.size > MAX_CONTEXT_IMAGE_SIZE_BYTES) {
+      return NextResponse.json({
+        success: false,
+        error: `Context image is too large (max ${MAX_CONTEXT_IMAGE_SIZE_BYTES / 1024 / 1024}MB)`,
+      }, { status: 400 });
+    }
+
     const arrayBuffer = await file.arrayBuffer();
     const fileSize = arrayBuffer.byteLength;
 
@@ -275,18 +281,12 @@ export async function POST(
       }
     }
 
-    const message = error?.message || 'Unknown error';
-    const status = message.includes('Invalid')
-      || message.includes('must be')
-      || message.includes('valid JSON')
-      ? 400
-      : 500;
-
+    const isValidation = error instanceof ValidationError;
     console.error('Context image upload error:', error);
     return NextResponse.json({
       success: false,
-      error: status === 400 ? message : 'Failed to upload context image',
-      details: status === 400 ? undefined : message,
-    }, { status });
+      error: isValidation ? error.message : 'Failed to upload context image',
+      details: isValidation ? undefined : error?.message,
+    }, { status: isValidation ? 400 : 500 });
   }
 }

--- a/src/app/api/manholes/[manholeId]/context-images/route.ts
+++ b/src/app/api/manholes/[manholeId]/context-images/route.ts
@@ -1,0 +1,292 @@
+import { createHash } from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import sharp from 'sharp';
+import { Database, ShotContextLabel } from '@/types/database';
+import { generateContextImageStorageKey, storage } from '@/lib/storage';
+
+const MAX_CONTEXT_IMAGES_PER_USER_MANHOLE = 5;
+const IOS_PLATFORM_HEADER = 'x-pokefuta-client-platform';
+const IOS_TOKEN_HEADER = 'x-pokefuta-ios-api-key';
+
+const ALLOWED_CONTENT_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/heic',
+  'image/heif',
+  'image/webp',
+]);
+
+const SHOT_CONTEXT_LABELS = new Set<ShotContextLabel>([
+  'centered_clean',
+  'selfie_with_manhole',
+  'wide_context',
+  'signage_info',
+  'partial_occluded',
+  'not_relevant',
+  'low_quality',
+]);
+
+function isIosContextRequest(request: NextRequest) {
+  const platform = request.headers.get(IOS_PLATFORM_HEADER)?.toLowerCase();
+  if (platform !== 'ios') return false;
+
+  const configuredToken = process.env.IOS_CONTEXT_UPLOAD_TOKEN;
+  if (!configuredToken) return true;
+
+  const tokenHeader = request.headers.get(IOS_TOKEN_HEADER);
+  const authorization = request.headers.get('authorization');
+  const bearerToken = authorization?.startsWith('Bearer ')
+    ? authorization.slice('Bearer '.length)
+    : null;
+
+  return tokenHeader === configuredToken || bearerToken === configuredToken;
+}
+
+function parseJsonField(value: FormDataEntryValue | null, fieldName: string) {
+  if (value == null || value === '') return null;
+  if (typeof value !== 'string') {
+    throw new Error(`${fieldName} must be a JSON string`);
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    throw new Error(`${fieldName} must be valid JSON`);
+  }
+}
+
+function parseShotContextLabel(value: FormDataEntryValue | null): ShotContextLabel | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!SHOT_CONTEXT_LABELS.has(value as ShotContextLabel)) {
+    throw new Error('Invalid shot_context_label');
+  }
+  return value as ShotContextLabel;
+}
+
+function parseConfidence(value: FormDataEntryValue | null) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const confidence = Number(value);
+  if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error('shot_context_confidence must be between 0 and 1');
+  }
+  return confidence;
+}
+
+async function getImageDimensions(buffer: Buffer) {
+  try {
+    const metadata = await sharp(buffer).metadata();
+    return {
+      width: metadata.width ?? null,
+      height: metadata.height ?? null,
+    };
+  } catch {
+    return {
+      width: null,
+      height: null,
+    };
+  }
+}
+
+/**
+ * @swagger
+ * /api/manholes/{manholeId}/context-images:
+ *   post:
+ *     summary: iOSアプリからマンホール周辺画像をアップロード
+ *     tags: [photos]
+ *     security:
+ *       - cookieAuth: []
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: { manholeId: string } }
+) {
+  let uploadedStorageKey: string | null = null;
+
+  try {
+    if (!isIosContextRequest(request)) {
+      return NextResponse.json({
+        success: false,
+        error: 'iOS app authorization required',
+      }, { status: 403 });
+    }
+
+    const manholeId = Number(params.manholeId);
+    if (!Number.isInteger(manholeId) || manholeId <= 0) {
+      return NextResponse.json({
+        success: false,
+        error: 'Invalid manhole_id',
+      }, { status: 400 });
+    }
+
+    const token = request.headers.get('authorization')?.replace('Bearer ', '');
+    if (!token) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+    const supabase = createClient<Database>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+    const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !user) {
+      return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+    }
+
+    const { data: manhole, error: manholeError } = await supabase
+      .from('manhole')
+      .select('id')
+      .eq('id', manholeId)
+      .single();
+
+    if (manholeError || !manhole) {
+      return NextResponse.json({
+        success: false,
+        error: 'Manhole not found',
+      }, { status: 404 });
+    }
+
+    const { count, error: countError } = await supabase
+      .from('photo_context_image')
+      .select('id', { count: 'exact', head: true })
+      .eq('manhole_id', manholeId)
+      .eq('created_by', user.id);
+
+    if (countError) {
+      return NextResponse.json({
+        success: false,
+        error: 'Failed to count context images',
+        details: countError.message,
+      }, { status: 500 });
+    }
+
+    if ((count ?? 0) >= MAX_CONTEXT_IMAGES_PER_USER_MANHOLE) {
+      return NextResponse.json({
+        success: false,
+        error: `Context image limit reached (max ${MAX_CONTEXT_IMAGES_PER_USER_MANHOLE})`,
+      }, { status: 400 });
+    }
+
+    const formData = await request.formData();
+    const file = formData.get('file') as File | null;
+    if (!file) {
+      return NextResponse.json({
+        success: false,
+        error: 'No file provided',
+      }, { status: 400 });
+    }
+
+    if (!ALLOWED_CONTENT_TYPES.has(file.type)) {
+      return NextResponse.json({
+        success: false,
+        error: 'Unsupported image content type',
+      }, { status: 400 });
+    }
+
+    const arrayBuffer = await file.arrayBuffer();
+    const fileSize = arrayBuffer.byteLength;
+
+    const shotContextLabel = parseShotContextLabel(formData.get('shot_context_label'));
+    const shotContextConfidence = parseConfidence(formData.get('shot_context_confidence'));
+    const shotContextConfidences = parseJsonField(
+      formData.get('shot_context_confidences'),
+      'shot_context_confidences'
+    );
+    const metadata = parseJsonField(formData.get('metadata'), 'metadata') ?? {};
+    const exif = parseJsonField(formData.get('exif'), 'exif');
+    const appVersion = formData.get('app_version');
+    const deviceModel = formData.get('device_model');
+    const sortOrder = formData.get('sort_order');
+    const parsedSortOrder = typeof sortOrder === 'string' && sortOrder.length > 0
+      ? Number(sortOrder)
+      : count ?? 0;
+
+    if (!Number.isInteger(parsedSortOrder) || parsedSortOrder < 0) {
+      return NextResponse.json({
+        success: false,
+        error: 'sort_order must be a non-negative integer',
+      }, { status: 400 });
+    }
+
+    const buffer = Buffer.from(arrayBuffer);
+    const sha256 = createHash('sha256').update(buffer).digest('hex');
+    const dimensions = await getImageDimensions(buffer);
+    const storageKey = generateContextImageStorageKey(manholeId, file.type);
+    uploadedStorageKey = storageKey;
+
+    await storage.put(storageKey, buffer, {
+      contentType: file.type,
+      cacheControl: 'public, max-age=31536000, immutable',
+      metadata: {
+        'manhole-id': String(manholeId),
+        'created-by': user.id,
+        'source-platform': 'ios',
+        ...(shotContextLabel ? { 'shot-context-label': shotContextLabel } : {}),
+      },
+    });
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('photo_context_image')
+      .insert({
+        manhole_id: manholeId,
+        storage_provider: process.env.STORAGE_PROVIDER || 'r2',
+        storage_key: storageKey,
+        original_name: file.name || null,
+        content_type: file.type,
+        file_size: fileSize,
+        width: dimensions.width,
+        height: dimensions.height,
+        sha256,
+        exif,
+        metadata,
+        shot_context_label: shotContextLabel,
+        shot_context_confidence: shotContextConfidence,
+        shot_context_confidences: shotContextConfidences,
+        source_platform: 'ios',
+        app_version: typeof appVersion === 'string' && appVersion.length > 0 ? appVersion : null,
+        device_model: typeof deviceModel === 'string' && deviceModel.length > 0 ? deviceModel : null,
+        sort_order: parsedSortOrder,
+        created_by: user.id,
+      })
+      .select()
+      .single();
+
+    if (insertError || !inserted) {
+      throw new Error(insertError?.message || 'Failed to create context image record');
+    }
+
+    const signedUrl = await storage.getSignedUrl(storageKey, 3600);
+
+    return NextResponse.json({
+      success: true,
+      message: 'Context image uploaded successfully',
+      context_image: {
+        ...inserted,
+        url: signedUrl.url,
+        expires_at: signedUrl.expiresAt,
+      },
+    });
+  } catch (error: any) {
+    if (uploadedStorageKey && storage.delete) {
+      try {
+        await storage.delete(uploadedStorageKey);
+      } catch (storageError) {
+        console.error('Failed to cleanup context image after error:', storageError);
+      }
+    }
+
+    const message = error?.message || 'Unknown error';
+    const status = message.includes('Invalid')
+      || message.includes('must be')
+      || message.includes('valid JSON')
+      ? 400
+      : 500;
+
+    console.error('Context image upload error:', error);
+    return NextResponse.json({
+      success: false,
+      error: status === 400 ? message : 'Failed to upload context image',
+      details: status === 400 ? undefined : message,
+    }, { status });
+  }
+}

--- a/src/app/api/user/context-images/[imageId]/route.ts
+++ b/src/app/api/user/context-images/[imageId]/route.ts
@@ -1,7 +1,21 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
-import { Database } from '@/types/database';
+import { Database, ShotContextLabel } from '@/types/database';
 import { storage } from '@/lib/storage';
+import { SHOT_CONTEXT_LABELS } from '@/lib/shot-context-labels';
+
+async function getAuthedClient(request: NextRequest) {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '');
+  if (!token) return null;
+  const supabase = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+  const { data: { user }, error } = await supabase.auth.getUser(token);
+  if (error || !user) return null;
+  return { supabase, user };
+}
 
 /**
  * @swagger
@@ -65,24 +79,14 @@ export async function DELETE(
   request: NextRequest,
   { params }: { params: { imageId: string } }
 ) {
-  const token = request.headers.get('authorization')?.replace('Bearer ', '');
-  if (!token) {
+  const auth = await getAuthedClient(request);
+  if (!auth) {
     return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
   }
+  const { supabase, user } = auth;
 
-  const supabase = createClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { global: { headers: { Authorization: `Bearer ${token}` } } }
-  );
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
-  }
-
-  const imageId = parseInt(params.imageId);
-  if (!Number.isInteger(imageId) || imageId <= 0) {
+  const imageId = params.imageId;
+  if (!imageId) {
     return NextResponse.json({ success: false, error: 'Invalid image id' }, { status: 400 });
   }
 
@@ -100,6 +104,15 @@ export async function DELETE(
     return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
   }
 
+  if (storage.delete) {
+    try {
+      await storage.delete(image.storage_key);
+    } catch (e) {
+      console.error('R2 delete failed, aborting DB delete:', e);
+      return NextResponse.json({ success: false, error: 'Failed to delete image from storage' }, { status: 500 });
+    }
+  }
+
   const { error: deleteError } = await supabase
     .from('photo_context_image')
     .delete()
@@ -109,13 +122,131 @@ export async function DELETE(
     return NextResponse.json({ success: false, error: deleteError.message }, { status: 500 });
   }
 
-  if (storage.delete) {
-    try {
-      await storage.delete(image.storage_key);
-    } catch (e) {
-      console.error('R2 delete failed after DB delete:', e);
-    }
+  return NextResponse.json({ success: true });
+}
+
+/**
+ * @swagger
+ * /api/user/context-images/{imageId}:
+ *   patch:
+ *     summary: コンテキスト画像のラベルを更新
+ *     tags: [user]
+ *     description: 自分がアップロードしたコンテキスト画像の shot_context_label を更新します。
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: imageId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: コンテキスト画像ID（UUID）
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - shot_context_label
+ *             properties:
+ *               shot_context_label:
+ *                 type: string
+ *                 enum: [centered_clean, selfie_with_manhole, wide_context, signage_info, partial_occluded, not_relevant, low_quality]
+ *                 description: 新しいラベル
+ *     responses:
+ *       200:
+ *         description: 更新成功
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 context_image:
+ *                   type: object
+ *       400:
+ *         description: ラベルが不正
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: 認証が必要
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: 他ユーザーの画像は更新不可
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: 画像が見つからない
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: サーバーエラー
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: { imageId: string } }
+) {
+  const auth = await getAuthedClient(request);
+  if (!auth) {
+    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+  }
+  const { supabase, user } = auth;
+
+  const imageId = params.imageId;
+  if (!imageId) {
+    return NextResponse.json({ success: false, error: 'Invalid image id' }, { status: 400 });
   }
 
-  return NextResponse.json({ success: true });
+  const body = await request.json().catch(() => null);
+  const label = body?.shot_context_label;
+  if (!label || !SHOT_CONTEXT_LABELS.has(label)) {
+    return NextResponse.json({
+      success: false,
+      error: `shot_context_label must be one of: ${[...SHOT_CONTEXT_LABELS].join(', ')}`,
+    }, { status: 400 });
+  }
+
+  const { data: image, error: fetchError } = await supabase
+    .from('photo_context_image')
+    .select('id, created_by')
+    .eq('id', imageId)
+    .single();
+
+  if (fetchError || !image) {
+    return NextResponse.json({ success: false, error: 'Image not found' }, { status: 404 });
+  }
+
+  if (image.created_by !== user.id) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { data: updated, error: updateError } = await supabase
+    .from('photo_context_image')
+    .update({ shot_context_label: label as ShotContextLabel })
+    .eq('id', imageId)
+    .select()
+    .single();
+
+  if (updateError || !updated) {
+    return NextResponse.json({ success: false, error: updateError?.message || 'Update failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true, context_image: updated });
 }

--- a/src/app/api/user/context-images/[imageId]/route.ts
+++ b/src/app/api/user/context-images/[imageId]/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database';
+import { storage } from '@/lib/storage';
+
+/**
+ * @swagger
+ * /api/user/context-images/{imageId}:
+ *   delete:
+ *     summary: 自分のコンテキスト画像を削除
+ *     tags: [user]
+ *     description: 指定したコンテキスト画像のDBレコードとR2上の画像ファイルを削除します。他ユーザーの画像は削除できません。
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: imageId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: コンテキスト画像ID
+ *     responses:
+ *       200:
+ *         description: 削除成功
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *       400:
+ *         description: imageIdが不正
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       401:
+ *         description: 認証が必要
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       403:
+ *         description: 他ユーザーの画像は削除不可
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       404:
+ *         description: 画像が見つからない
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: サーバーエラー
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: { imageId: string } }
+) {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '');
+  if (!token) {
+    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+  }
+
+  const supabase = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+  }
+
+  const imageId = parseInt(params.imageId);
+  if (!Number.isInteger(imageId) || imageId <= 0) {
+    return NextResponse.json({ success: false, error: 'Invalid image id' }, { status: 400 });
+  }
+
+  const { data: image, error: fetchError } = await supabase
+    .from('photo_context_image')
+    .select('id, storage_key, created_by')
+    .eq('id', imageId)
+    .single();
+
+  if (fetchError || !image) {
+    return NextResponse.json({ success: false, error: 'Image not found' }, { status: 404 });
+  }
+
+  if (image.created_by !== user.id) {
+    return NextResponse.json({ success: false, error: 'Forbidden' }, { status: 403 });
+  }
+
+  const { error: deleteError } = await supabase
+    .from('photo_context_image')
+    .delete()
+    .eq('id', imageId);
+
+  if (deleteError) {
+    return NextResponse.json({ success: false, error: deleteError.message }, { status: 500 });
+  }
+
+  if (storage.delete) {
+    try {
+      await storage.delete(image.storage_key);
+    } catch (e) {
+      console.error('R2 delete failed after DB delete:', e);
+    }
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/user/context-images/route.ts
+++ b/src/app/api/user/context-images/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+import { Database } from '@/types/database';
+import { storage } from '@/lib/storage';
+
+/**
+ * @swagger
+ * /api/user/context-images:
+ *   get:
+ *     summary: 自分がアップロードしたコンテキスト画像一覧取得
+ *     tags: [user]
+ *     description: 認証ユーザーが全マンホールにわたってアップロードしたコンテキスト画像を取得します。各画像にはsigned URL（1時間有効）が付与されます。
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           default: 50
+ *           maximum: 100
+ *         description: 取得件数（最大100）
+ *       - in: query
+ *         name: offset
+ *         schema:
+ *           type: integer
+ *           default: 0
+ *         description: オフセット
+ *     responses:
+ *       200:
+ *         description: 取得成功
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: true
+ *                 context_images:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       id:
+ *                         type: integer
+ *                       manhole_id:
+ *                         type: integer
+ *                       storage_key:
+ *                         type: string
+ *                       content_type:
+ *                         type: string
+ *                       file_size:
+ *                         type: integer
+ *                         nullable: true
+ *                       width:
+ *                         type: integer
+ *                         nullable: true
+ *                       height:
+ *                         type: integer
+ *                         nullable: true
+ *                       shot_context_label:
+ *                         type: string
+ *                         nullable: true
+ *                       source_platform:
+ *                         type: string
+ *                         nullable: true
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *                       url:
+ *                         type: string
+ *                         nullable: true
+ *                         description: signed URL（1時間有効）
+ *                       expires_at:
+ *                         type: string
+ *                         nullable: true
+ *                 total:
+ *                   type: integer
+ *       401:
+ *         description: 認証が必要
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ *       500:
+ *         description: サーバーエラー
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Error'
+ */
+export async function GET(request: NextRequest) {
+  const token = request.headers.get('authorization')?.replace('Bearer ', '');
+  if (!token) {
+    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+  }
+
+  const supabase = createClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { global: { headers: { Authorization: `Bearer ${token}` } } }
+  );
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) {
+    return NextResponse.json({ success: false, error: 'Authentication required' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(request.url);
+  const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
+  const offset = parseInt(searchParams.get('offset') || '0');
+
+  const { data, error, count } = await supabase
+    .from('photo_context_image')
+    .select('*', { count: 'exact' })
+    .eq('created_by', user.id)
+    .order('created_at', { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  const enriched = await Promise.all(
+    (data ?? []).map(async (img) => {
+      try {
+        const signed = await storage.getSignedUrl(img.storage_key, 3600);
+        return { ...img, url: signed.url, expires_at: signed.expiresAt };
+      } catch {
+        return { ...img, url: null, expires_at: null };
+      }
+    })
+  );
+
+  return NextResponse.json({ success: true, context_images: enriched, total: count ?? 0 });
+}

--- a/src/app/api/user/context-images/route.ts
+++ b/src/app/api/user/context-images/route.ts
@@ -108,8 +108,8 @@ export async function GET(request: NextRequest) {
   }
 
   const { searchParams } = new URL(request.url);
-  const limit = Math.min(parseInt(searchParams.get('limit') || '50'), 100);
-  const offset = parseInt(searchParams.get('offset') || '0');
+  const limit = Math.min(Math.max(1, parseInt(searchParams.get('limit') || '50') || 50), 100);
+  const offset = Math.max(0, parseInt(searchParams.get('offset') || '0') || 0);
 
   const { data, error, count } = await supabase
     .from('photo_context_image')

--- a/src/lib/shot-context-labels.ts
+++ b/src/lib/shot-context-labels.ts
@@ -1,0 +1,11 @@
+import { ShotContextLabel } from '@/types/database';
+
+export const SHOT_CONTEXT_LABELS = new Set<ShotContextLabel>([
+  'centered_clean',
+  'selfie_with_manhole',
+  'wide_context',
+  'signage_info',
+  'partial_occluded',
+  'not_relevant',
+  'low_quality',
+]);

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -36,6 +36,32 @@ export function generateStorageKey(type: 'original' | 'thumb', size?: number): s
   return `photos/original/${year}/${month}/${uuid}.jpg`;
 }
 
+export function generateContextImageStorageKey(manholeId: number, contentType?: string): string {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const uuid = crypto.randomUUID();
+  const extension = contentTypeToExtension(contentType);
+
+  return `photos/context/original/${year}/${month}/manholes/${manholeId}/${uuid}.${extension}`;
+}
+
+function contentTypeToExtension(contentType?: string): string {
+  switch (contentType) {
+    case 'image/png':
+      return 'png';
+    case 'image/heic':
+      return 'heic';
+    case 'image/heif':
+      return 'heif';
+    case 'image/webp':
+      return 'webp';
+    case 'image/jpeg':
+    default:
+      return 'jpg';
+  }
+}
+
 export function parseStorageKey(key: string) {
   const parts = key.split('/');
   if (parts.length < 4) {

--- a/src/lib/swagger.ts
+++ b/src/lib/swagger.ts
@@ -25,6 +25,12 @@ const options: swaggerJsdoc.Options = {
           name: 'supabase-auth-token',
           description: 'Supabase認証Cookie',
         },
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+          description: 'Supabase Access Token (iOSアプリ等モバイルクライアント用)',
+        },
       },
       schemas: {
         Manhole: {
@@ -91,6 +97,7 @@ const options: swaggerJsdoc.Options = {
       { name: 'visits', description: '訪問記録' },
       { name: 'photos', description: '写真管理' },
       { name: 'auth', description: '認証' },
+      { name: 'user', description: '認証ユーザー自身のリソース' },
     ],
   },
   apis: ['./src/app/api/**/*.ts'],

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -6,6 +6,15 @@ export interface ManholeTitle {
   priority?: number;
 }
 
+export type ShotContextLabel =
+  | 'centered_clean'
+  | 'selfie_with_manhole'
+  | 'wide_context'
+  | 'signage_info'
+  | 'partial_occluded'
+  | 'not_relevant'
+  | 'low_quality';
+
 export interface Database {
   public: {
     Tables: {
@@ -239,6 +248,59 @@ export interface Database {
           thumbnail_small?: ArrayBuffer | null;
           thumbnail_medium?: ArrayBuffer | null;
           metadata?: Record<string, any> | null;
+        };
+      };
+      photo_context_image: {
+        Row: {
+          id: string;
+          manhole_id: number;
+          storage_provider: string;
+          storage_key: string;
+          original_name: string | null;
+          content_type: string;
+          file_size: number | null;
+          width: number | null;
+          height: number | null;
+          sha256: string | null;
+          exif: ExifData | null;
+          metadata: Record<string, any>;
+          shot_context_label: ShotContextLabel | null;
+          shot_context_confidence: number | null;
+          shot_context_confidences: Record<string, any> | null;
+          source_platform: string;
+          app_version: string | null;
+          device_model: string | null;
+          sort_order: number;
+          created_by: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          manhole_id: number;
+          storage_provider?: string;
+          storage_key: string;
+          original_name?: string | null;
+          content_type: string;
+          file_size?: number | null;
+          width?: number | null;
+          height?: number | null;
+          sha256?: string | null;
+          exif?: ExifData | null;
+          metadata?: Record<string, any>;
+          shot_context_label?: ShotContextLabel | null;
+          shot_context_confidence?: number | null;
+          shot_context_confidences?: Record<string, any> | null;
+          source_platform?: string;
+          app_version?: string | null;
+          device_model?: string | null;
+          sort_order?: number;
+          created_by: string;
+        };
+        Update: {
+          metadata?: Record<string, any>;
+          sort_order?: number;
+          updated_at?: string;
         };
       };
       shared_link: {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -299,6 +299,7 @@ export interface Database {
         };
         Update: {
           metadata?: Record<string, any>;
+          shot_context_label?: ShotContextLabel | null;
           sort_order?: number;
           updated_at?: string;
         };


### PR DESCRIPTION
## Summary
- `[id]` → `[manholeId]` にリネームしてルートスラグ競合を解消
- `POST /api/manholes/[manholeId]/context-images`: Cookie不要のBearer token認証に対応（`getSession()` → `getUser(token)` + `createClient` with Authorization header）
- アプリ側10MBサイズ制限を撤廃、DBのcheck constraintも migration 016 で削除
- `GET /api/user/context-images`: 自分がアップロードした全context_image一覧（signed URL付き）
- `DELETE /api/user/context-images/[imageId]`: DBレコード + R2ファイルを削除
- Swagger: `bearerAuth` セキュリティスキーム追加、新エンドポイントのドキュメント追加

## Migration
Supabase SQL Editorで以下を実行してください：
```sql
-- 016_remove_context_image_file_size_constraint.sql
ALTER TABLE photo_context_image
  DROP CONSTRAINT IF EXISTS photo_context_image_file_size;
```

## Test plan
- [ ] `POST /api/manholes/{manholeId}/context-images` — `Authorization: Bearer <token>` + `x-pokefuta-client-platform: ios` で 200
- [ ] 10MB超の画像がアップロードできる（migration 016 適用後）
- [ ] `GET /api/user/context-images` — Bearer token で自分の画像一覧が取得できる
- [ ] `DELETE /api/user/context-images/{imageId}` — 自分の画像を削除できる、他人の画像は 403
- [ ] `GET /api/swagger` でSwagger UIに新エンドポイントが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)