### PR TITLE
Add ML classifier and annotation metadata to context images

### DIFF
--- a/database/migrations/017_add_context_image_ml_metadata.sql
+++ b/database/migrations/017_add_context_image_ml_metadata.sql
@@ -1,0 +1,55 @@
+-- Add ML classifier, detection, and annotation metadata to iOS context images.
+
+ALTER TABLE public.photo_context_image
+  ADD COLUMN IF NOT EXISTS manhole_classifier_label TEXT,
+  ADD COLUMN IF NOT EXISTS manhole_classifier_confidence DOUBLE PRECISION,
+  ADD COLUMN IF NOT EXISTS manhole_detection_result JSONB,
+  ADD COLUMN IF NOT EXISTS overlay_quality_grade TEXT,
+  ADD COLUMN IF NOT EXISTS annotation_manhole_label TEXT,
+  ADD COLUMN IF NOT EXISTS annotation_shot_context_label public.shot_context_label;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_manhole_classifier_label'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_manhole_classifier_label
+      CHECK (manhole_classifier_label IS NULL OR manhole_classifier_label IN ('manhole', 'not_manhole'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_manhole_classifier_confidence'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_manhole_classifier_confidence
+      CHECK (
+        manhole_classifier_confidence IS NULL
+        OR (manhole_classifier_confidence >= 0 AND manhole_classifier_confidence <= 1)
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_overlay_quality_grade'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_overlay_quality_grade
+      CHECK (overlay_quality_grade IS NULL OR overlay_quality_grade IN ('p', 'e', 'g', 'f', 'b'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'photo_context_image_annotation_manhole_label'
+  ) THEN
+    ALTER TABLE public.photo_context_image
+      ADD CONSTRAINT photo_context_image_annotation_manhole_label
+      CHECK (annotation_manhole_label IS NULL OR annotation_manhole_label IN ('manhole', 'not_manhole'));
+  END IF;
+END $$;

--- a/src/app/api/manholes/[manholeId]/context-images/route.ts
+++ b/src/app/api/manholes/[manholeId]/context-images/route.ts
@@ -2,7 +2,12 @@ import { createHash } from 'crypto';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 import sharp from 'sharp';
-import { Database, ShotContextLabel } from '@/types/database';
+import {
+  Database,
+  ManholeClassifierLabel,
+  OverlayQualityGrade,
+  ShotContextLabel,
+} from '@/types/database';
 import { generateContextImageStorageKey, storage } from '@/lib/storage';
 import { SHOT_CONTEXT_LABELS } from '@/lib/shot-context-labels';
 
@@ -18,6 +23,8 @@ const ALLOWED_CONTENT_TYPES = new Set([
   'image/heif',
   'image/webp',
 ]);
+const MANHOLE_LABELS = new Set<ManholeClassifierLabel>(['manhole', 'not_manhole']);
+const OVERLAY_QUALITY_GRADES = new Set<OverlayQualityGrade>(['p', 'e', 'g', 'f', 'b']);
 
 class ValidationError extends Error {
   constructor(message: string) {
@@ -55,6 +62,10 @@ function parseJsonField(value: FormDataEntryValue | null, fieldName: string) {
   }
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function parseShotContextLabel(value: FormDataEntryValue | null): ShotContextLabel | null {
   if (typeof value !== 'string' || value.length === 0) return null;
   if (!SHOT_CONTEXT_LABELS.has(value as ShotContextLabel)) {
@@ -63,13 +74,61 @@ function parseShotContextLabel(value: FormDataEntryValue | null): ShotContextLab
   return value as ShotContextLabel;
 }
 
-function parseConfidence(value: FormDataEntryValue | null) {
+function parseAnnotationShotContextLabel(value: FormDataEntryValue | null): ShotContextLabel | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!SHOT_CONTEXT_LABELS.has(value as ShotContextLabel)) {
+    throw new ValidationError('Invalid annotation_shot_context_label');
+  }
+  return value as ShotContextLabel;
+}
+
+function parseConfidence(value: FormDataEntryValue | null, fieldName: string) {
   if (typeof value !== 'string' || value.length === 0) return null;
   const confidence = Number(value);
   if (!Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
-    throw new ValidationError('shot_context_confidence must be between 0 and 1');
+    throw new ValidationError(`${fieldName} must be between 0 and 1`);
   }
   return confidence;
+}
+
+function parseOptionalManholeLabel(
+  value: FormDataEntryValue | null,
+  fieldName: string
+): ManholeClassifierLabel | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!MANHOLE_LABELS.has(value as ManholeClassifierLabel)) {
+    throw new ValidationError(`${fieldName} must be one of: manhole, not_manhole`);
+  }
+  return value as ManholeClassifierLabel;
+}
+
+function parseOptionalOverlayQualityGrade(value: FormDataEntryValue | null): OverlayQualityGrade | null {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  if (!OVERLAY_QUALITY_GRADES.has(value as OverlayQualityGrade)) {
+    throw new ValidationError('overlay_quality_grade must be one of: p, e, g, f, b');
+  }
+  return value as OverlayQualityGrade;
+}
+
+function metadataString(metadata: unknown, key: string) {
+  if (!isPlainObject(metadata)) return null;
+  const value = metadata[key];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+function metadataConfidence(metadata: unknown, key: string, fieldName: string) {
+  if (!isPlainObject(metadata)) return null;
+  const value = metadata[key];
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new ValidationError(`${fieldName} must be between 0 and 1`);
+    }
+    return value;
+  }
+  if (typeof value === 'string' && value.length > 0) {
+    return parseConfidence(value, fieldName);
+  }
+  return null;
 }
 
 async function getImageDimensions(buffer: Buffer) {
@@ -94,7 +153,61 @@ async function getImageDimensions(buffer: Buffer) {
  *     summary: iOSアプリからマンホール周辺画像をアップロード
  *     tags: [photos]
  *     security:
- *       - cookieAuth: []
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - file
+ *             properties:
+ *               file:
+ *                 type: string
+ *                 format: binary
+ *               shot_context_label:
+ *                 type: string
+ *                 enum: [centered_clean, selfie_with_manhole, wide_context, signage_info, partial_occluded, not_relevant, low_quality]
+ *               shot_context_confidence:
+ *                 type: number
+ *                 minimum: 0
+ *                 maximum: 1
+ *               shot_context_confidences:
+ *                 type: string
+ *                 description: JSON string containing all shot context label confidences.
+ *               manhole_classifier_label:
+ *                 type: string
+ *                 enum: [manhole, not_manhole]
+ *               manhole_classifier_confidence:
+ *                 type: number
+ *                 minimum: 0
+ *                 maximum: 1
+ *               manhole_detection_result:
+ *                 type: string
+ *                 description: JSON string containing detector status, confidence, bbox, raw_bbox, and model_name.
+ *               overlay_quality_grade:
+ *                 type: string
+ *                 enum: [p, e, g, f, b]
+ *               annotation_manhole_label:
+ *                 type: string
+ *                 enum: [manhole, not_manhole]
+ *               annotation_shot_context_label:
+ *                 type: string
+ *                 enum: [centered_clean, selfie_with_manhole, wide_context, signage_info, partial_occluded, not_relevant, low_quality]
+ *               metadata:
+ *                 type: string
+ *                 description: JSON string. Legacy metadata.manhole_classifier_* values are used as fallback when top-level classifier fields are absent.
+ *               exif:
+ *                 type: string
+ *                 description: JSON string.
+ *               app_version:
+ *                 type: string
+ *               device_model:
+ *                 type: string
+ *               sort_order:
+ *                 type: integer
+ *                 minimum: 0
  */
 export async function POST(
   request: NextRequest,
@@ -193,12 +306,44 @@ export async function POST(
     const fileSize = arrayBuffer.byteLength;
 
     const shotContextLabel = parseShotContextLabel(formData.get('shot_context_label'));
-    const shotContextConfidence = parseConfidence(formData.get('shot_context_confidence'));
+    const shotContextConfidence = parseConfidence(
+      formData.get('shot_context_confidence'),
+      'shot_context_confidence'
+    );
     const shotContextConfidences = parseJsonField(
       formData.get('shot_context_confidences'),
       'shot_context_confidences'
     );
     const metadata = parseJsonField(formData.get('metadata'), 'metadata') ?? {};
+    const topLevelManholeClassifierLabel = parseOptionalManholeLabel(
+      formData.get('manhole_classifier_label'),
+      'manhole_classifier_label'
+    );
+    const metadataManholeClassifierLabel = metadataString(metadata, 'manhole_classifier_label');
+    const manholeClassifierLabel = topLevelManholeClassifierLabel ?? parseOptionalManholeLabel(
+      metadataManholeClassifierLabel,
+      'metadata.manhole_classifier_label'
+    );
+    const manholeClassifierConfidence = parseConfidence(
+      formData.get('manhole_classifier_confidence'),
+      'manhole_classifier_confidence'
+    ) ?? metadataConfidence(
+      metadata,
+      'manhole_classifier_confidence',
+      'metadata.manhole_classifier_confidence'
+    );
+    const manholeDetectionResult = parseJsonField(
+      formData.get('manhole_detection_result'),
+      'manhole_detection_result'
+    );
+    const overlayQualityGrade = parseOptionalOverlayQualityGrade(formData.get('overlay_quality_grade'));
+    const annotationManholeLabel = parseOptionalManholeLabel(
+      formData.get('annotation_manhole_label'),
+      'annotation_manhole_label'
+    );
+    const annotationShotContextLabel = parseAnnotationShotContextLabel(
+      formData.get('annotation_shot_context_label')
+    );
     const exif = parseJsonField(formData.get('exif'), 'exif');
     const appVersion = formData.get('app_version');
     const deviceModel = formData.get('device_model');
@@ -248,6 +393,12 @@ export async function POST(
         shot_context_label: shotContextLabel,
         shot_context_confidence: shotContextConfidence,
         shot_context_confidences: shotContextConfidences,
+        manhole_classifier_label: manholeClassifierLabel,
+        manhole_classifier_confidence: manholeClassifierConfidence,
+        manhole_detection_result: manholeDetectionResult,
+        overlay_quality_grade: overlayQualityGrade,
+        annotation_manhole_label: annotationManholeLabel,
+        annotation_shot_context_label: annotationShotContextLabel,
         source_platform: 'ios',
         app_version: typeof appVersion === 'string' && appVersion.length > 0 ? appVersion : null,
         device_model: typeof deviceModel === 'string' && deviceModel.length > 0 ? deviceModel : null,

--- a/src/app/api/manholes/[manholeId]/context-images/route.ts
+++ b/src/app/api/manholes/[manholeId]/context-images/route.ts
@@ -154,6 +154,25 @@ async function getImageDimensions(buffer: Buffer) {
  *     tags: [photos]
  *     security:
  *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: manholeId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - in: header
+ *         name: x-pokefuta-client-platform
+ *         required: true
+ *         schema:
+ *           type: string
+ *           enum: [ios]
+ *         description: Must be "ios". Required for all requests to this endpoint.
+ *       - in: header
+ *         name: x-pokefuta-ios-api-key
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: iOS API key. Required when IOS_CONTEXT_UPLOAD_TOKEN is configured (alternative to Bearer token).
  *     requestBody:
  *       required: true
  *       content:
@@ -332,10 +351,17 @@ export async function POST(
       'manhole_classifier_confidence',
       'metadata.manhole_classifier_confidence'
     );
-    const manholeDetectionResult = parseJsonField(
+    const manholeDetectionResultRaw = parseJsonField(
       formData.get('manhole_detection_result'),
       'manhole_detection_result'
     );
+    if (manholeDetectionResultRaw !== null && !isPlainObject(manholeDetectionResultRaw)) {
+      return NextResponse.json({
+        success: false,
+        error: 'manhole_detection_result must be a JSON object',
+      }, { status: 400 });
+    }
+    const manholeDetectionResult = manholeDetectionResultRaw;
     const overlayQualityGrade = parseOptionalOverlayQualityGrade(formData.get('overlay_quality_grade'));
     const annotationManholeLabel = parseOptionalManholeLabel(
       formData.get('annotation_manhole_label'),

--- a/src/app/api/user/context-images/route.ts
+++ b/src/app/api/user/context-images/route.ts
@@ -62,6 +62,34 @@ import { storage } from '@/lib/storage';
  *                       shot_context_label:
  *                         type: string
  *                         nullable: true
+ *                       shot_context_confidence:
+ *                         type: number
+ *                         nullable: true
+ *                       shot_context_confidences:
+ *                         type: object
+ *                         nullable: true
+ *                       manhole_classifier_label:
+ *                         type: string
+ *                         enum: [manhole, not_manhole]
+ *                         nullable: true
+ *                       manhole_classifier_confidence:
+ *                         type: number
+ *                         nullable: true
+ *                       manhole_detection_result:
+ *                         type: object
+ *                         nullable: true
+ *                       overlay_quality_grade:
+ *                         type: string
+ *                         enum: [p, e, g, f, b]
+ *                         nullable: true
+ *                       annotation_manhole_label:
+ *                         type: string
+ *                         enum: [manhole, not_manhole]
+ *                         nullable: true
+ *                       annotation_shot_context_label:
+ *                         type: string
+ *                         enum: [centered_clean, selfie_with_manhole, wide_context, signage_info, partial_occluded, not_relevant, low_quality]
+ *                         nullable: true
  *                       source_platform:
  *                         type: string
  *                         nullable: true

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -15,6 +15,9 @@ export type ShotContextLabel =
   | 'not_relevant'
   | 'low_quality';
 
+export type ManholeClassifierLabel = 'manhole' | 'not_manhole';
+export type OverlayQualityGrade = 'p' | 'e' | 'g' | 'f' | 'b';
+
 export interface Database {
   public: {
     Tables: {
@@ -274,6 +277,12 @@ export interface Database {
           shot_context_label: ShotContextLabel | null;
           shot_context_confidence: number | null;
           shot_context_confidences: Record<string, any> | null;
+          manhole_classifier_label: ManholeClassifierLabel | null;
+          manhole_classifier_confidence: number | null;
+          manhole_detection_result: Record<string, any> | null;
+          overlay_quality_grade: OverlayQualityGrade | null;
+          annotation_manhole_label: ManholeClassifierLabel | null;
+          annotation_shot_context_label: ShotContextLabel | null;
           source_platform: string;
           app_version: string | null;
           device_model: string | null;
@@ -298,6 +307,12 @@ export interface Database {
           shot_context_label?: ShotContextLabel | null;
           shot_context_confidence?: number | null;
           shot_context_confidences?: Record<string, any> | null;
+          manhole_classifier_label?: ManholeClassifierLabel | null;
+          manhole_classifier_confidence?: number | null;
+          manhole_detection_result?: Record<string, any> | null;
+          overlay_quality_grade?: OverlayQualityGrade | null;
+          annotation_manhole_label?: ManholeClassifierLabel | null;
+          annotation_shot_context_label?: ShotContextLabel | null;
           source_platform?: string;
           app_version?: string | null;
           device_model?: string | null;


### PR DESCRIPTION
## Summary

- **Migration 017**: `photo_context_image` テーブルに ML 分類・アノテーション用カラムを追加
  - `manhole_classifier_label` / `manhole_classifier_confidence`: マンホール検出 ML の出力
  - `manhole_detection_result`: 検出結果 JSON (bounding box 等)
  - `overlay_quality_grade`: オーバーレイ品質グレード (`p/e/g/f/b`)
  - `annotation_manhole_label` / `annotation_shot_context_label`: 人間アノテーション用
- **TypeScript 型**: `ManholeClassifierLabel`、`OverlayQualityGrade` を追加
- **API**: iOS upload エンドポイントで新フィールドを受け取り・バリデーション・保存
- **OpenAPI docs**: GET `/api/user/context-images` のレスポンス定義を更新

## Test plan

- [ ] migration 017 を Supabase SQL Editor で実行
- [ ] iOS アプリから `manhole_classifier_label` 等を含む multipart POST が成功すること
- [ ] 無効な label 値 (`manhole_classifier_label=unknown`) を送ると 400 が返ること
- [ ] confidence が範囲外 (`1.5`) を送ると 400 が返ること
- [ ] 新フィールドなしの既存リクエストが引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)