### PR TITLE
GA4: gallery_index page_type と全ページの is_logged_in 追加

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -76,9 +76,13 @@ export default function AboutPage() {
   useEffect(() => {
     document.title = 'このアプリについて - ポケふた訪問記録';
     (async () => {
-      const supabase = createBrowserClient();
-      const { data: { session } } = await supabase.auth.getSession();
-      trackView('/about', 'このアプリについて', 'about', Boolean(session?.user));
+      try {
+        const supabase = createBrowserClient();
+        const { data: { session } } = await supabase.auth.getSession();
+        trackView('/about', 'このアプリについて', 'about', Boolean(session?.user));
+      } catch {
+        trackView('/about', 'このアプリについて', 'about', false);
+      }
     })();
   }, []);
 

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 const journeySteps = [
@@ -74,7 +75,11 @@ export default function AboutPage() {
 
   useEffect(() => {
     document.title = 'このアプリについて - ポケふた訪問記録';
-    trackView('/about', 'このアプリについて', 'about');
+    (async () => {
+      const supabase = createBrowserClient();
+      const { data: { session } } = await supabase.auth.getSession();
+      trackView('/about', 'このアプリについて', 'about', Boolean(session?.user));
+    })();
   }, []);
 
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -190,7 +190,6 @@ export default function HomePage() {
 
   useEffect(() => {
     document.title = 'ポケふた写真館 - ポケふた訪問記録';
-    trackView('/', 'ホーム', 'home');
 
     (async () => {
       try {
@@ -200,6 +199,7 @@ export default function HomePage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
+        trackView('/', 'ポケふた写真館', 'gallery_index', loggedIn);
         trackCollectionOpen({ is_logged_in: loggedIn });
         if (loggedIn && session?.user?.id) {
           setUserName(getDisplayName(session));

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -213,6 +213,7 @@ export default function HomePage() {
       } catch (error) {
         console.error('Session check error:', error);
         setIsLoggedIn(false);
+        trackView('/', 'ポケふた写真館', 'gallery_index', false);
         // エラー時もloadingをfalseに
         setLoading(false);
       }

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -45,7 +45,6 @@ export default function PopularPage() {
 
   useEffect(() => {
     document.title = 'みんなのポケふた投稿 - ポケふた訪問記録';
-    trackView('/popular', 'みんなのポケふた投稿', 'popular');
 
     (async () => {
       try {
@@ -53,10 +52,13 @@ export default function PopularPage() {
         const {
           data: { session },
         } = await supabase.auth.getSession();
-        setIsLoggedIn(Boolean(session?.user));
+        const loggedIn = Boolean(session?.user);
+        setIsLoggedIn(loggedIn);
+        trackView('/popular', 'みんなのポケふた投稿', 'popular', loggedIn);
       } catch (error) {
         console.error('Session check error:', error);
         setIsLoggedIn(false);
+        trackView('/popular', 'みんなのポケふた投稿', 'popular', false);
       }
     })();
 

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -91,7 +91,7 @@ export default function UploadPage() {
     document.title = '写真登録 - ポケふた訪問記録';
 
     // ✅ GA: ページビュー追跡
-    trackView('/upload', '写真登録', 'upload');
+    trackView('/upload', '写真登録', 'upload', true);
 
     loadManholes();
     // Cookieから公開設定を読み込み

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -10,6 +10,7 @@ import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import { calculateDistance, isValidCoordinates, MAX_DISTANCE_KM } from '@/lib/location';
+import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 interface PhotoMetadata {
@@ -91,7 +92,15 @@ export default function UploadPage() {
     document.title = '写真登録 - ポケふた訪問記録';
 
     // ✅ GA: ページビュー追跡
-    trackView('/upload', '写真登録', 'upload', true);
+    (async () => {
+      try {
+        const supabase = createBrowserClient();
+        const { data: { session } } = await supabase.auth.getSession();
+        trackView('/upload', '写真登録', 'upload', Boolean(session?.user));
+      } catch {
+        trackView('/upload', '写真登録', 'upload', true); // middleware が認証を保証
+      }
+    })();
 
     loadManholes();
     // Cookieから公開設定を読み込み

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -114,7 +114,6 @@ export default function VisitsPage() {
 
   useEffect(() => {
     document.title = 'ポケふた訪問パスポート - ポケふた訪問記録';
-    trackView('/visits', 'ポケふた訪問パスポート', 'visits');
     trackPassportOpen();
     checkAuth();
   }, []);
@@ -138,6 +137,7 @@ export default function VisitsPage() {
       } = await supabase.auth.getSession();
       const loggedIn = Boolean(session?.user);
       setIsLoggedIn(loggedIn);
+      trackView('/visits', 'ポケふた訪問パスポート', 'visits', loggedIn);
 
       if (loggedIn) {
         loadPassport();
@@ -148,6 +148,7 @@ export default function VisitsPage() {
     } catch (error) {
       console.error('Auth check error:', error);
       setIsLoggedIn(false);
+      trackView('/visits', 'ポケふた訪問パスポート', 'visits', false);
       loadManholesOnly();
     }
   };

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -102,12 +102,14 @@ export function trackEvent(
 export function trackPageView(
   pagePath: string,
   pageTitle: string,
-  pageType?: string
+  pageType?: string,
+  isLoggedIn?: boolean
 ): void {
   trackEvent('p_page_view', {
     page_path: pagePath,
     page_title: pageTitle,
     page_type: pageType,
+    is_logged_in: isLoggedIn,
   });
 }
 

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -103,7 +103,7 @@ export function trackPageView(
   pagePath: string,
   pageTitle: string,
   pageType?: string,
-  isLoggedIn?: boolean
+  isLoggedIn: boolean = false
 ): void {
   trackEvent('p_page_view', {
     page_path: pagePath,

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -32,7 +32,7 @@ export function useAnalytics() {
   );
 
   const trackView = useCallback(
-    (pagePath: string, pageTitle: string, pageType?: string, isLoggedIn?: boolean) =>
+    (pagePath: string, pageTitle: string, pageType?: string, isLoggedIn: boolean = false) =>
       trackPageView(pagePath, pageTitle, pageType, isLoggedIn),
     []
   );

--- a/src/lib/hooks/useAnalytics.ts
+++ b/src/lib/hooks/useAnalytics.ts
@@ -32,8 +32,8 @@ export function useAnalytics() {
   );
 
   const trackView = useCallback(
-    (pagePath: string, pageTitle: string, pageType?: string) =>
-      trackPageView(pagePath, pageTitle, pageType),
+    (pagePath: string, pageTitle: string, pageType?: string, isLoggedIn?: boolean) =>
+      trackPageView(pagePath, pageTitle, pageType, isLoggedIn),
     []
   );
 


### PR DESCRIPTION
## Summary

- ホームページ（写真館トップ）の `page_type` を `'home'` → `'gallery_index'` に変更し、流入元別のページタイプ分析を可能にする
- `trackPageView()` / `trackView()` に `isLoggedIn?: boolean` を追加し、全 `p_page_view` イベントに `is_logged_in` を付与
- `trackView` の呼び出しを async 認証チェック完了後に移動し、`is_logged_in` が常に正確な値になるよう修正
- `/about` ページには認証チェックがなかったため最小限の `getSession()` 呼び出しを追加

## Changes

| ファイル | 変更内容 |
|---------|--------|
| `src/lib/analytics/gtag.ts` | `trackPageView()` に `isLoggedIn?` 追加 |
| `src/lib/hooks/useAnalytics.ts` | `trackView()` ラッパーに `isLoggedIn?` 追加 |
| `src/app/page.tsx` | `'home'` → `'gallery_index'`、認証後に trackView 発火 |
| `src/app/visits/page.tsx` | `checkAuth()` 内で `is_logged_in` 付与 |
| `src/app/about/page.tsx` | auth チェック追加 + `is_logged_in` 付与 |
| `src/app/popular/page.tsx` | 認証後に trackView 発火 |
| `src/app/upload/page.tsx` | `is_logged_in: true` 固定（middleware 保証） |

## Test plan

- [ ] `npm run dev` 起動後、未ログイン状態でホームにアクセス → DevTools コンソールで `[GA Event] p_page_view` に `page_type: 'gallery_index'`, `is_logged_in: false` を確認
- [ ] ログイン状態でホームにアクセス → `is_logged_in: true` を確認
- [ ] `/visits`, `/about`, `/popular`, `/upload` でも `is_logged_in` が含まれることを確認
- [ ] GA4探索で `page_type × is_logged_in` のクロス集計が可能なことを確認（`(not set)` が出ない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)