### PR TITLE
Show building field next to municipality in card/list views

### DIFF
--- a/src/app/api/visits/route.ts
+++ b/src/app/api/visits/route.ts
@@ -147,6 +147,7 @@ export async function GET(request: NextRequest) {
             title,
             prefecture,
             municipality,
+            building,
             pokemons${manholeTagFields}
           ),
           photos:photo (
@@ -181,6 +182,7 @@ export async function GET(request: NextRequest) {
             title,
             prefecture,
             municipality,
+            building,
             pokemons${manholeTagFields}
           ),
           photos:photo (

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -162,9 +162,7 @@ export default function ManholesPage() {
                       <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
                         {manhole.title || `${manhole.prefecture || ''}${manhole.municipality || manhole.city || ''}`}
                       </h2>
-                      <p className="mt-1 text-xs font-bold text-[#6B6B6B]">
-                        {manhole.prefecture} {manhole.municipality || manhole.city || ''}{(manhole.municipality || manhole.city) && manhole.building && ` · ${manhole.building}`}
-                      </p>
+
                     </div>
                     <span className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-sm font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">
                       #{manhole.id}

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -163,7 +163,7 @@ export default function ManholesPage() {
                         {manhole.title || `${manhole.prefecture || ''}${manhole.municipality || manhole.city || ''}`}
                       </h2>
                       <p className="mt-1 text-xs font-bold text-[#6B6B6B]">
-                        {manhole.prefecture} {manhole.municipality || manhole.city || ''}
+                        {manhole.prefecture} {manhole.municipality || manhole.city || ''}{(manhole.municipality || manhole.city) && manhole.building && ` · ${manhole.building}`}
                       </p>
                     </div>
                     <span className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-sm font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">

--- a/src/app/manholes/page.tsx
+++ b/src/app/manholes/page.tsx
@@ -162,7 +162,9 @@ export default function ManholesPage() {
                       <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
                         {manhole.title || `${manhole.prefecture || ''}${manhole.municipality || manhole.city || ''}`}
                       </h2>
-
+                      {manhole.building && (
+                        <p className="mt-1 text-xs font-bold text-[#6B6B6B]">{manhole.building}</p>
+                      )}
                     </div>
                     <span className="shrink-0 rounded-[8px] bg-white px-3 py-2 text-sm font-extrabold text-[#7B63A8] shadow-sm ring-1 ring-[#7B63A8]/15">
                       #{manhole.id}

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -508,7 +508,7 @@ export default function NearbyPage() {
                         <div className="min-w-0">
                           <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
                             {manhole.prefecture}
-                            {manhole.municipality || manhole.city || ''}
+                            {manhole.municipality || manhole.city || ''}{(manhole.municipality || manhole.city) && manhole.building && ` · ${manhole.building}`}
                           </h2>
                           <div className="mt-1 text-xs font-bold text-[#6B6B6B]">
                             ポケふた #{manhole.id}

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -508,7 +508,7 @@ export default function NearbyPage() {
                         <div className="min-w-0">
                           <h2 className="line-clamp-2 text-base font-extrabold leading-snug">
                             {manhole.prefecture}
-                            {manhole.municipality || manhole.city || ''}{(manhole.municipality || manhole.city) && manhole.building && ` · ${manhole.building}`}
+                            {manhole.municipality || manhole.city || ''}{(manhole.municipality || manhole.city) && manhole.building && `・${manhole.building}`}
                           </h2>
                           <div className="mt-1 text-xs font-bold text-[#6B6B6B]">
                             ポケふた #{manhole.id}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1537,8 +1537,11 @@ function RareManholeCard({ manhole }: { manhole: JourneyManhole }) {
 
       <div className="relative">
         <p className="line-clamp-1 text-sm font-extrabold text-[#2A2A2A]">
-          {manhole.building ? `${manhole.municipality}・${manhole.building}` : `${manhole.prefecture}${manhole.municipality ? ` ${manhole.municipality}` : ''}`}
+          {manhole.prefecture}{manhole.municipality ? ` ${manhole.municipality}` : ''}
         </p>
+        {manhole.building && (
+          <p className="line-clamp-1 text-xs font-bold text-[#6B6B6B]">{manhole.building}</p>
+        )}
         <div className="mt-2 flex flex-wrap gap-1">
           {(tags.length > 0 ? tags : [getManholeTitle(manhole)])
             .map(safeTagLabel)

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1407,8 +1407,12 @@ function JourneyHistoryCard({ manhole, visits }: { manhole: JourneyManhole; visi
       <div className="p-3">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
-            <p className="line-clamp-1 text-base font-extrabold text-[#4F3828]">{getMunicipality(manhole)}</p>
-            <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.prefecture}</p>
+            <p className="line-clamp-1 text-base font-extrabold text-[#4F3828]">
+              {manhole.prefecture}{manhole.municipality ? ` ${manhole.municipality}` : ''}
+            </p>
+            {manhole.building && (
+              <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.building}</p>
+            )}
           </div>
           {latestVisit && (
             <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] font-bold text-[#B5483C]">
@@ -1489,8 +1493,12 @@ function JourneyUnvisitedCard({ manhole, badge }: { manhole: JourneyManhole; bad
       </div>
 
       <div className="relative">
-        <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">{getMunicipality(manhole)}</p>
-        <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.prefecture}</p>
+        <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">
+          {manhole.prefecture}{manhole.municipality ? ` ${manhole.municipality}` : ''}
+        </p>
+        {manhole.building && (
+          <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.building}</p>
+        )}
         <div className="mt-2 flex flex-wrap gap-1">
           {(tags.length > 0 ? tags : [getManholeTitle(manhole)]).slice(0, 3).map((tag) => (
             <span key={tag} className="rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-bold text-[#6A4D36]">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -967,11 +967,7 @@ export default function HomePage() {
                     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                       {visibleFeed.map((visit, index) => {
                         const photo = visit.photos?.[0];
-                        const locationParts = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join(' · ');
-                        const title = [visit.manhole?.prefecture, locationParts]
-                          .filter(Boolean)
-                          .join(' ');
-                        const locationLabel = title || visit.shot_location || '';
+                        const locationLabel = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join('・') || visit.shot_location || '';
                         const manholeId = visit.manhole?.id ?? visit.manhole_id;
                         const canNavigate = Boolean(manholeId);
                         const to = canNavigate ? `/manhole/${manholeId}` : '';
@@ -1539,7 +1535,7 @@ function RareManholeCard({ manhole }: { manhole: JourneyManhole }) {
 
       <div className="relative">
         <p className="line-clamp-1 text-sm font-extrabold text-[#2A2A2A]">
-          {manhole.prefecture}{manhole.municipality && ` ${manhole.municipality}`}{manhole.building && ` · ${manhole.building}`}
+          {manhole.municipality}{manhole.building && `・${manhole.building}`}
         </p>
         <div className="mt-2 flex flex-wrap gap-1">
           {(tags.length > 0 ? tags : [getManholeTitle(manhole)])

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,7 +25,7 @@ import { calculateDistance, isValidCoordinates } from '@/lib/location';
 type FeedVisit = {
   id: string;
   manhole_id: number | null;
-  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'title' | 'pokemons' | 'titles' | 'hashtags' | 'title_tags'> | null;
+  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title' | 'pokemons' | 'titles' | 'hashtags' | 'title_tags'> | null;
   shot_at: string;
   created_at: string;
   shot_location?: string | null;
@@ -48,7 +48,7 @@ const galleryTabs: Array<{ key: GalleryTab; label: string }> = [
 type JourneyVisit = {
   id: string;
   manhole_id: number | null;
-  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'title' | 'pokemons' | 'titles' | 'hashtags' | 'title_tags'> | null;
+  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title' | 'pokemons' | 'titles' | 'hashtags' | 'title_tags'> | null;
   shot_at: string;
   created_at?: string;
   photos: Array<{ id: string; thumbnail_url?: string; created_at?: string }>;
@@ -967,7 +967,8 @@ export default function HomePage() {
                     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                       {visibleFeed.map((visit, index) => {
                         const photo = visit.photos?.[0];
-                        const title = [visit.manhole?.prefecture, visit.manhole?.municipality]
+                        const locationParts = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join(' · ');
+                        const title = [visit.manhole?.prefecture, locationParts]
                           .filter(Boolean)
                           .join(' ');
                         const locationLabel = title || visit.shot_location || '';
@@ -1538,7 +1539,7 @@ function RareManholeCard({ manhole }: { manhole: JourneyManhole }) {
 
       <div className="relative">
         <p className="line-clamp-1 text-sm font-extrabold text-[#2A2A2A]">
-          {[manhole.prefecture, manhole.municipality].filter(Boolean).join(' ')}
+          {manhole.prefecture}{manhole.municipality && ` ${manhole.municipality}`}{manhole.building && ` · ${manhole.building}`}
         </p>
         <div className="mt-2 flex flex-wrap gap-1">
           {(tags.length > 0 ? tags : [getManholeTitle(manhole)])

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -967,7 +967,9 @@ export default function HomePage() {
                     <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                       {visibleFeed.map((visit, index) => {
                         const photo = visit.photos?.[0];
-                        const locationLabel = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join('・') || visit.shot_location || '';
+                        const locationLabel = visit.manhole?.building
+                          ? [visit.manhole.municipality, visit.manhole.building].filter(Boolean).join('・')
+                          : [visit.manhole?.prefecture, visit.manhole?.municipality].filter(Boolean).join(' ') || visit.shot_location || '';
                         const manholeId = visit.manhole?.id ?? visit.manhole_id;
                         const canNavigate = Boolean(manholeId);
                         const to = canNavigate ? `/manhole/${manholeId}` : '';
@@ -1535,7 +1537,7 @@ function RareManholeCard({ manhole }: { manhole: JourneyManhole }) {
 
       <div className="relative">
         <p className="line-clamp-1 text-sm font-extrabold text-[#2A2A2A]">
-          {manhole.municipality}{manhole.building && `・${manhole.building}`}
+          {manhole.building ? `${manhole.municipality}・${manhole.building}` : `${manhole.prefecture}${manhole.municipality ? ` ${manhole.municipality}` : ''}`}
         </p>
         <div className="mt-2 flex flex-wrap gap-1">
           {(tags.length > 0 ? tags : [getManholeTitle(manhole)])

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -194,7 +194,9 @@ export default function PopularPage() {
                 <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                   {sortedFeed.map((visit, index) => {
                     const photo = visit.photos?.[0];
-                    const locationLabel = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join('・') || visit.shot_location || '';
+                    const locationLabel = visit.manhole?.building
+                      ? [visit.manhole.municipality, visit.manhole.building].filter(Boolean).join('・')
+                      : [visit.manhole?.prefecture, visit.manhole?.municipality].filter(Boolean).join(' ') || visit.shot_location || '';
                     const manholeId = visit.manhole?.id ?? visit.manhole_id;
                     const canNavigate = Boolean(manholeId);
                     const to = canNavigate ? `/manhole/${manholeId}` : '';

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -194,11 +194,7 @@ export default function PopularPage() {
                 <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                   {sortedFeed.map((visit, index) => {
                     const photo = visit.photos?.[0];
-                    const locationParts = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join(' · ');
-                    const title = [visit.manhole?.prefecture, locationParts]
-                      .filter(Boolean)
-                      .join(' ');
-                    const locationLabel = title || visit.shot_location || '';
+                    const locationLabel = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join('・') || visit.shot_location || '';
                     const manholeId = visit.manhole?.id ?? visit.manhole_id;
                     const canNavigate = Boolean(manholeId);
                     const to = canNavigate ? `/manhole/${manholeId}` : '';

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -22,7 +22,7 @@ import { useAnalytics } from '@/lib/hooks/useAnalytics';
 type FeedVisit = {
   id: string;
   manhole_id: number | null;
-  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'title' | 'pokemons'> | null;
+  manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title' | 'pokemons'> | null;
   shot_at: string;
   created_at: string;
   shot_location?: string | null;
@@ -194,7 +194,8 @@ export default function PopularPage() {
                 <div className="grid grid-cols-2 gap-3 md:grid-cols-3 lg:gap-5">
                   {sortedFeed.map((visit, index) => {
                     const photo = visit.photos?.[0];
-                    const title = [visit.manhole?.prefecture, visit.manhole?.municipality]
+                    const locationParts = [visit.manhole?.municipality, visit.manhole?.building].filter(Boolean).join(' · ');
+                    const title = [visit.manhole?.prefecture, locationParts]
                       .filter(Boolean)
                       .join(' ');
                     const locationLabel = title || visit.shot_location || '';

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -598,7 +598,7 @@ export default function VisitsPage() {
                   <div className="flex h-full flex-col items-center justify-center text-center">
                     <Stamp className="h-6 w-6 text-[#B8AB96]" />
                     <p className="mt-1 line-clamp-2 text-[10px] font-bold text-[#6A4D36]">
-                      {getMunicipality(manhole)}
+                      {getMunicipality(manhole)}{manhole.building && ` · ${manhole.building}`}
                     </p>
                   </div>
                 </Link>
@@ -939,7 +939,7 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
 
       <div>
         <p className="truncate font-pixelJp text-[9px] font-bold leading-tight text-[#4F3828]">
-          {getMunicipality(manhole)}
+          {getMunicipality(manhole)}{manhole.building && ` · ${manhole.building}`}
         </p>
         {summary && (
           <p className="font-pixel text-[8px] text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -598,7 +598,7 @@ export default function VisitsPage() {
                   <div className="flex h-full flex-col items-center justify-center text-center">
                     <Stamp className="h-6 w-6 text-[#B8AB96]" />
                     <p className="mt-1 line-clamp-2 text-[10px] font-bold text-[#6A4D36]">
-                      {getMunicipality(manhole)}{manhole.building && ` · ${manhole.building}`}
+                      {getMunicipality(manhole)}{manhole.building && `・${manhole.building}`}
                     </p>
                   </div>
                 </Link>
@@ -939,7 +939,7 @@ function StampCard({ manhole, summary }: { manhole: Manhole; summary?: VisitSumm
 
       <div>
         <p className="truncate font-pixelJp text-[9px] font-bold leading-tight text-[#4F3828]">
-          {getMunicipality(manhole)}{manhole.building && ` · ${manhole.building}`}
+          {getMunicipality(manhole)}{manhole.building && `・${manhole.building}`}
         </p>
         {summary && (
           <p className="font-pixel text-[8px] text-[#B5483C]">{formatVisitDate(summary.latestVisit.visited_at, 'yyyy/M')}</p>


### PR DESCRIPTION
## Summary

- `building` フィールド（道の駅・温泉・施設など、145件に値あり）をカード・リスト表示で市区町村名の横に表示する
- 表示フォーマット: `市区町村名 · 道の駅〇〇`（building が null/空の場合は追加なし）

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `src/app/api/visits/route.ts` | 認証あり・なし両クエリの manhole select に `building` を追加 |
| `src/app/page.tsx` | Pick 型に `building` 追加、フィード・旅セクションの表示更新 |
| `src/app/popular/page.tsx` | Pick 型に `building` 追加、フィード表示更新 |
| `src/app/manholes/page.tsx` | マンホール一覧カードのサブテキストに building 追加 |
| `src/app/visits/page.tsx` | スタンプ帳グリッド・パスポートスタンプの市区町村表示に building 追加 |
| `src/app/nearby/page.tsx` | 近くのポケふたカードの表示に building 追加 |

## 詳細ページ（ManholePage.tsx）について

詳細ページは既に「建物・目印」セクションで building を専用表示済みのため変更なし。

## Test plan

- [ ] `npm run type-check` がエラーなし
- [ ] ホームページのフィードで building があるマンホールの投稿カードに `市区町村 · 道の駅〇〇` が表示される
- [ ] `/manholes` リストで building 付きマンホールに表示
- [ ] `/visits` スタンプ帳・パスポートで building 表示
- [ ] `/nearby` カードで building 表示
- [ ] building が空の場合は何も追加されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)