### PR TITLE
Add site_type=photo to all GA4 events

### DIFF
--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -17,6 +17,7 @@ export interface GAUserProperties {
 
 /** pokefuta.com 共通イベントパラメータ */
 export interface PokefutaEventParams extends GAEventParams {
+  site_type?: 'photo' | 'map';
   manhole_id?: string | number;
   prefecture?: string;
   pokemon_ids?: string;    // カンマ区切り文字列 (GA4は配列非対応)
@@ -72,6 +73,7 @@ export function trackEvent(
   }
 
   const enrichedParams: GAEventParams = {
+    site_type: 'photo',
     page_path: isClientSide() ? window.location.pathname : undefined,
     page_title: isClientSide() ? document.title : undefined,
     event_timestamp: new Date().toISOString(),


### PR DESCRIPTION
## Summary

- `trackEvent()` ラッパーの `enrichedParams` 先頭に `site_type: 'photo'` を追加
- `PokefutaEventParams` インターフェースに `site_type?: 'photo' | 'map'` を追加
- 全GA4イベント（22イベント）に自動付与される。個別イベント呼び出し箇所の変更不要

## 目的

data.pokefuta.com（写真館）と pokefuta.com（マップ）をGA4上で明確に区別する。
GA4探索レポートで以下のクロス分析が可能になる：

- 流入元 × site_type（google→photo / google→map など）
- site_type × ログイン状態（photo×true / photo×false）
- イベント数比較（site_type別の利用傾向）

## GA4設定

カスタムディメンション `site_type`（スコープ: イベント）は登録済み。

## Test plan

- [ ] `npm run dev` で起動し `?debug_mode=1` クエリ付きでGA4 DebugView確認
- [ ] 任意のイベント発火時に `site_type=photo` が付与されていることを確認
- [ ] `(not set)` が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)