### PR TITLE
未ログイン導線リデザイン — 収集欲・達成欲を前面に

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,6 +17,7 @@ import {
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import StampBookMockup from '@/components/StampBookMockup';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { formatDateJa } from '@/lib/date';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
@@ -850,19 +851,6 @@ export default function HomePage() {
                           <MapPin className="h-4 w-4" />
                           近くのポケふたを見る
                         </Link>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setGalleryTab('latest');
-                            requestAnimationFrame(() =>
-                              document.getElementById('gallery')?.scrollIntoView({ behavior: 'smooth' })
-                            );
-                          }}
-                          className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white sm:py-2.5"
-                        >
-                          <Camera className="h-4 w-4" />
-                          みんなの写真を見る
-                        </button>
                       </div>
                     </div>
 
@@ -1102,141 +1090,6 @@ export default function HomePage() {
       )}
 
       <BottomNav />
-    </div>
-  );
-}
-
-const MOCKUP_STAMPS = [
-  { src: '/mockup/s1.jpeg', name: 'ルギア' },
-  { src: '/mockup/s2.jpeg', name: 'ホエルオー' },
-  { src: '/mockup/s3.jpeg', name: 'ロコン' },
-];
-
-const PREFECTURE_GRID: Array<{ short: string; state: 'complete' | 'partial' | 'empty'; title: string }> = [
-  { short: '北海', state: 'complete', title: '北海道 制覇済み' },
-  { short: '青森', state: 'complete', title: '青森県 制覇済み' },
-  { short: '岩手', state: 'partial', title: '岩手県 訪問済み' },
-  { short: '宮城', state: 'complete', title: '宮城県 制覇済み' },
-  { short: '秋田', state: 'partial', title: '秋田県 訪問済み' },
-  { short: '山形', state: 'empty', title: '山形県 未訪問' },
-  { short: '福島', state: 'partial', title: '福島県 訪問済み' },
-  { short: '茨城', state: 'partial', title: '茨城県 訪問済み' },
-  { short: '栃木', state: 'empty', title: '栃木県 未訪問' },
-  { short: '群馬', state: 'empty', title: '群馬県 未訪問' },
-  { short: '埼玉', state: 'complete', title: '埼玉県 制覇済み' },
-  { short: '千葉', state: 'complete', title: '千葉県 制覇済み' },
-  { short: '東京', state: 'complete', title: '東京都 制覇済み' },
-  { short: '神奈', state: 'complete', title: '神奈川県 制覇済み' },
-  { short: '新潟', state: 'partial', title: '新潟県 訪問済み' },
-  { short: '富山', state: 'empty', title: '富山県 未訪問' },
-  { short: '石川', state: 'partial', title: '石川県 訪問済み' },
-  { short: '福井', state: 'empty', title: '福井県 未訪問' },
-  { short: '山梨', state: 'empty', title: '山梨県 未訪問' },
-  { short: '長野', state: 'partial', title: '長野県 訪問済み' },
-  { short: '岐阜', state: 'partial', title: '岐阜県 訪問済み' },
-  { short: '静岡', state: 'complete', title: '静岡県 制覇済み' },
-  { short: '愛知', state: 'complete', title: '愛知県 制覇済み' },
-  { short: '三重', state: 'partial', title: '三重県 訪問済み' },
-  { short: '滋賀', state: 'empty', title: '滋賀県 未訪問' },
-  { short: '京都', state: 'complete', title: '京都府 制覇済み' },
-  { short: '大阪', state: 'complete', title: '大阪府 制覇済み' },
-  { short: '兵庫', state: 'complete', title: '兵庫県 制覇済み' },
-  { short: '奈良', state: 'partial', title: '奈良県 訪問済み' },
-  { short: '和歌', state: 'empty', title: '和歌山県 未訪問' },
-  { short: '鳥取', state: 'empty', title: '鳥取県 未訪問' },
-  { short: '島根', state: 'empty', title: '島根県 未訪問' },
-  { short: '岡山', state: 'partial', title: '岡山県 訪問済み' },
-  { short: '広島', state: 'complete', title: '広島県 制覇済み' },
-  { short: '山口', state: 'partial', title: '山口県 訪問済み' },
-  { short: '徳島', state: 'empty', title: '徳島県 未訪問' },
-  { short: '香川', state: 'partial', title: '香川県 訪問済み' },
-  { short: '愛媛', state: 'empty', title: '愛媛県 未訪問' },
-  { short: '高知', state: 'empty', title: '高知県 未訪問' },
-  { short: '福岡', state: 'complete', title: '福岡県 制覇済み' },
-  { short: '佐賀', state: 'partial', title: '佐賀県 訪問済み' },
-  { short: '長崎', state: 'partial', title: '長崎県 訪問済み' },
-  { short: '熊本', state: 'partial', title: '熊本県 訪問済み' },
-  { short: '大分', state: 'empty', title: '大分県 未訪問' },
-  { short: '宮崎', state: 'empty', title: '宮崎県 未訪問' },
-  { short: '鹿児', state: 'partial', title: '鹿児島県 訪問済み' },
-  { short: '沖縄', state: 'complete', title: '沖縄県 制覇済み' },
-];
-
-const PREFECTURE_STATE_CLASS = {
-  complete: 'bg-[#7B63A8] text-white',
-  partial: 'bg-[#DDD0F5] text-[#7B63A8]',
-  empty: 'bg-[#F0EEF5] text-[#C0B8D0]',
-} as const;
-
-function StampBookMockup() {
-  return (
-    <div className="overflow-hidden rounded-[10px] border-2 border-[#C9B8E8] bg-[#FFFDF7] text-xs">
-      {/* Passport header */}
-      <div className="flex items-center justify-between bg-[#7B63A8] px-3 py-1.5">
-        <div className="flex items-center gap-1.5 text-[10px] font-extrabold text-white">
-          <Stamp className="h-3.5 w-3.5" />
-          ポケふたパスポート
-        </div>
-        <div className="flex items-center gap-1 rounded-full bg-[#FFB347] px-2 py-0.5 text-[9px] font-extrabold text-white">
-          <Award className="h-2.5 w-2.5" />
-          355達成!
-        </div>
-      </div>
-
-      <div className="space-y-1.5 p-2.5">
-        {/* 全国 + 都道府県コンプ + ポケモンコンプ 横並び */}
-        <div className="flex gap-2 border-b border-dashed border-[#DDD0F5] pb-1.5">
-          <div className="flex-1">
-            <div className="text-[9px] font-bold text-[#9B9B9B]">全国</div>
-            <div className="text-xl font-extrabold leading-tight text-[#7B63A8]">
-              355<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/470</span>
-            </div>
-          </div>
-          <div className="flex-1">
-            <div className="text-[9px] font-bold text-[#9B9B9B]">都道府県</div>
-            <div className="text-xl font-extrabold leading-tight text-[#2C765E]">
-              15<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/47</span>
-            </div>
-          </div>
-          <div className="flex-1">
-            <div className="text-[9px] font-bold text-[#9B9B9B]">ポケモン</div>
-            <div className="text-xl font-extrabold leading-tight text-[#FFB347]">
-              42<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/151</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Recent 3 stamps with real photos */}
-        <div>
-          <div className="mb-0.5 text-[9px] font-extrabold text-[#6B6B6B]">最近集めたポケふた</div>
-          <div className="flex gap-1">
-            {MOCKUP_STAMPS.slice(0, 3).map(({ src, name }) => (
-              <div key={src} className="flex flex-1 flex-col items-center gap-0.5">
-                <div className="mx-auto h-[52px] w-[52px] overflow-hidden rounded-full border-2 border-[#7B63A8] shadow-sm">
-                  <img src={src} alt="" loading="lazy" decoding="async" className="h-full w-full object-cover" />
-                </div>
-                <span className="text-center text-[7px] font-bold leading-tight text-[#7B63A8]">{name}</span>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* 都道府県達成 Grid */}
-        <div className="border-t border-dashed border-[#DDD0F5] pt-2">
-          <div className="mb-1 text-[9px] font-extrabold text-[#6B6B6B]">都道府県達成</div>
-          <div className="flex flex-wrap gap-0.5">
-            {PREFECTURE_GRID.map(({ short, state, title }) => (
-              <div
-                key={short}
-                title={title}
-                className={`rounded-sm px-[3px] py-[1px] text-[7px] font-bold leading-tight ${PREFECTURE_STATE_CLASS[state]}`}
-              >
-                {short}
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
     </div>
   );
 }

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -10,11 +10,13 @@ import {
   MapPin,
   MessageCircle,
   Sparkles,
+  Stamp,
   TrendingUp,
 } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import StampBookMockup from '@/components/StampBookMockup';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { formatDateJa } from '@/lib/date';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
@@ -39,12 +41,16 @@ export default function PopularPage() {
   const [feed, setFeed] = useState<FeedVisit[]>([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPosts, setTotalPosts] = useState<number | null>(null);
+  const [totalManholes, setTotalManholes] = useState<number | null>(null);
+  const [manholesWithPhotos, setManholesWithPhotos] = useState<number | null>(null);
+  const [rareManholes, setRareManholes] = useState<Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title'>[]>([]);
+  const [rareLoading, setRareLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const feedPerPage = 24;
   const { trackView } = useAnalytics();
 
   useEffect(() => {
-    document.title = 'みんなのポケふた投稿 - ポケふた訪問記録';
+    document.title = '全国のポケふた写真館 - ポケふた訪問記録';
 
     (async () => {
       try {
@@ -54,15 +60,16 @@ export default function PopularPage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
-        trackView('/popular', 'みんなのポケふた投稿', 'popular', loggedIn);
+        trackView('/popular', '全国のポケふた写真館', 'popular', loggedIn);
       } catch (error) {
         console.error('Session check error:', error);
         setIsLoggedIn(false);
-        trackView('/popular', 'みんなのポケふた投稿', 'popular', false);
+        trackView('/popular', '全国のポケふた写真館', 'popular', false);
       }
     })();
 
     loadSiteStats();
+    loadRareManholes();
   }, []);
 
   useEffect(() => {
@@ -98,8 +105,25 @@ export default function PopularPage() {
       const data = await response.json();
       if (!data?.success) return;
       setTotalPosts(typeof data.posts === 'number' ? data.posts : null);
+      setTotalManholes(typeof data.manholes === 'number' ? data.manholes : null);
+      setManholesWithPhotos(typeof data.manholes_with_photos === 'number' ? data.manholes_with_photos : null);
     } catch {
       // ignore
+    }
+  };
+
+  const loadRareManholes = async () => {
+    try {
+      const response = await fetch('/api/manholes?no_photos=true&limit=12');
+      if (!response.ok) return;
+      const data = await response.json();
+      if (Array.isArray(data.manholes)) {
+        setRareManholes(data.manholes);
+      }
+    } catch {
+      // ignore
+    } finally {
+      setRareLoading(false);
     }
   };
 
@@ -113,7 +137,7 @@ export default function PopularPage() {
 
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
-      <Header title="みんなのポケふた投稿" />
+      <Header title="全国のポケふた写真館" />
 
       <main className="mx-auto max-w-6xl px-4 pb-6 pt-5 sm:pt-8">
         {/* Hero Section */}
@@ -122,14 +146,22 @@ export default function PopularPage() {
             <div className="relative max-w-3xl">
               <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
                 <Sparkles className="h-3.5 w-3.5" />
-                みんなのポケふた投稿
+                ポケふた写真館
               </div>
               <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
-                旅先で出会ったポケふた写真を眺めよう
+                全国のポケふたを写真で埋めよう
               </h1>
               <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
-                全国のユーザーが記録した写真から、次に行きたい場所を見つけられます。
-                ログインすると、あなたの旅の続きとして記録を保存できます。
+                {totalPosts != null && totalPosts > 0 ? (
+                  <>
+                    {totalPosts}枚の旅写真が集まっています。
+                    {totalManholes != null && manholesWithPhotos != null && totalManholes > manholesWithPhotos && (
+                      <>残り{totalManholes - manholesWithPhotos}枚以上はまだ募集中。</>
+                    )}
+                  </>
+                ) : (
+                  <>全国のポケふたを旅して写真を記録しよう。まだ写真がない場所がたくさんあります。</>
+                )}
               </p>
 
               {!isLoggedIn && (
@@ -152,11 +184,7 @@ export default function PopularPage() {
             </div>
 
             <div className="hidden rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block">
-              <img
-                src="/pokefuta_photo_gallery_mockup.svg"
-                alt=""
-                className="h-[210px] w-full rounded-[6px] object-cover object-left-top xl:h-[230px]"
-              />
+              <StampBookMockup />
             </div>
           </div>
         </section>
@@ -170,6 +198,39 @@ export default function PopularPage() {
               </div>
             </div>
           </div>
+        )}
+
+        {/* 写真がまだないポケふた */}
+        {!rareLoading && rareManholes.length > 0 && (
+          <section className="mt-6">
+            <div className="mb-4 flex items-center justify-between">
+              <h2 className="flex items-center gap-2 text-lg font-extrabold">
+                <Stamp className="h-5 w-5 text-[#7B63A8]" />
+                写真がまだないポケふた
+              </h2>
+              <span className="text-sm font-bold text-[#B5483C]">募集中</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+              {rareManholes.map((manhole) => {
+                const label = manhole.building
+                  ? [manhole.municipality, manhole.building].filter(Boolean).join('・')
+                  : [manhole.prefecture, manhole.municipality].filter(Boolean).join(' ') || manhole.title || 'ポケふた';
+                return (
+                  <Link
+                    key={manhole.id}
+                    href={isLoggedIn ? `/upload?manhole_id=${manhole.id}` : '/signup'}
+                    className="flex items-center gap-2 rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-3 py-2.5 text-sm font-bold text-[#4A4A4A] shadow-sm transition hover:border-[#7B63A8]/40 hover:bg-white"
+                  >
+                    <Camera className="h-4 w-4 shrink-0 text-[#7B63A8]" />
+                    <span className="line-clamp-2 text-xs leading-snug">{label}</span>
+                  </Link>
+                );
+              })}
+            </div>
+            <p className="mt-3 text-center text-xs font-medium text-[#6B6B6B]">
+              {isLoggedIn ? '写真を投稿して図鑑を埋めよう' : 'ログインして写真を投稿できます'}
+            </p>
+          </section>
         )}
 
         {/* Photo Gallery */}

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -21,6 +21,7 @@ import { ja } from 'date-fns/locale';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import StampBookMockup from '@/components/StampBookMockup';
 import DeletePhotoModal from '@/components/DeletePhotoModal';
 import ShareButtons from '@/components/ShareButtons';
 import { createBrowserClient } from '@/lib/supabase/client';
@@ -117,6 +118,7 @@ export default function VisitsPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [showUnvisitedPrefectures, setShowUnvisitedPrefectures] = useState(false);
+  const [sampleVisits, setSampleVisits] = useState<Array<{ id: string; thumbnail_url: string | null; location: string }>>([]);
   const { trackView, trackPassportOpen } = useAnalytics();
 
   const selectPassportTab = (tab: PassportTab) => {
@@ -167,9 +169,12 @@ export default function VisitsPage() {
 
   const loadManholesOnly = async () => {
     try {
-      const response = await fetch('/api/manholes?limit=1000');
-      if (response.ok) {
-        const data = await response.json();
+      const [manholesRes, visitsRes] = await Promise.all([
+        fetch('/api/manholes?limit=1000'),
+        fetch('/api/visits?with_photos=true&limit=6&order_by=created_at', { credentials: 'omit' }),
+      ]);
+      if (manholesRes.ok) {
+        const data = await manholesRes.json();
         const apiManholes: Manhole[] = Array.isArray(data.manholes)
           ? data.manholes.map((manhole: any) => ({
               ...manhole,
@@ -179,6 +184,20 @@ export default function VisitsPage() {
           : [];
         setManholes(apiManholes);
         setTotalManholes(typeof data.total === 'number' ? data.total : apiManholes.length || null);
+      }
+      if (visitsRes.ok) {
+        const data = await visitsRes.json();
+        if (data.success && Array.isArray(data.visits)) {
+          setSampleVisits(
+            data.visits.map((v: any) => ({
+              id: v.id,
+              thumbnail_url: v.photos?.[0]?.thumbnail_url ?? null,
+              location: v.manhole?.building
+                ? [v.manhole.municipality, v.manhole.building].filter(Boolean).join('・')
+                : [v.manhole?.prefecture, v.manhole?.municipality].filter(Boolean).join(' ') || 'ポケふた',
+            }))
+          );
+        }
       }
     } catch (error) {
       console.error('Failed to load manholes:', error);
@@ -560,157 +579,143 @@ export default function VisitsPage() {
 
   // Unauthenticated preview mode
   if (!isLoggedIn) {
+    const prefectureCount = manholes.length > 0
+      ? new Set(manholes.map((m) => m.prefecture).filter(Boolean)).size
+      : null;
+    const pokemonCount = manholes.length > 0
+      ? new Set(manholes.flatMap((m) => m.pokemons ?? [])).size
+      : null;
+
     return (
       <div className="min-h-screen safe-area-inset bg-[#F3E7CC] pb-nav-safe">
         <Header title="スタンプ帳" />
 
-        <div className="max-w-3xl mx-auto p-4 space-y-4">
-          {/* Preview Header */}
-          <section className="relative overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5] p-6 shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
-            <div className="absolute inset-0 opacity-[0.08] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
-            <div className="relative text-center">
-              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1.5 text-xs font-bold text-[#7B63A8]">
-                <Sparkles className="h-3.5 w-3.5" />
-                スタンプ帳機能のプレビュー
-              </div>
-              <h1 className="font-pixelJp text-2xl font-bold text-[#4F3828]">
-                ポケふた訪問パスポート
-              </h1>
-              <p className="mt-3 text-sm font-medium text-[#6A4D36]">
-                ログインすると、あなたの旅の続きとして全国{totalManholes || '470'}箇所以上のポケふたをコレクションできます
-              </p>
+        <main className="mx-auto max-w-6xl px-4 pb-6 pt-5 space-y-4 sm:pt-8">
+          {/* Hero — same grid layout as top page */}
+          <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-4 py-3 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-8 sm:py-7">
+            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start xl:grid-cols-[minmax(0,1fr)_320px]">
+              <div className="relative max-w-3xl">
+                <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+                  <Sparkles className="h-3.5 w-3.5" />
+                  ポケふたスタンプ帳
+                </div>
+                <h1 className="max-w-2xl text-2xl font-extrabold leading-tight tracking-normal sm:text-4xl">
+                  ポケふた訪問パスポート
+                </h1>
+                <p className="mt-2 text-sm font-medium leading-relaxed text-[#4A4A4A] sm:mt-3 sm:text-base">
+                  あなた専用のスタンプ帳を無料で作れます
+                </p>
 
-              {/* Sample Progress Bar */}
-              <div className="mt-6 max-w-md mx-auto">
-                <div className="mb-2 flex items-end justify-between">
+                {/* Stats row */}
+                <div className="mt-3 flex flex-wrap gap-4 sm:mt-4">
                   <div>
-                    <p className="font-pixel text-xl text-[#4F3828]">0 / {totalManholes ?? '470'}</p>
-                    <p className="font-pixelJp text-xs text-[#6A4D36]">訪問済みスタンプ</p>
+                    <span className="font-pixel text-2xl font-extrabold text-[#7B63A8]">{totalManholes ?? '470'}</span>
+                    <span className="ml-1 text-xs font-bold text-[#9B9B9B]">全国のポケふた</span>
                   </div>
-                  <p className="font-pixel text-lg text-[#B5483C]">0.0%</p>
-                </div>
-                <div className="h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/25 bg-[#E4D4B8]">
-                  <div className="h-full w-0 rounded-sm bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D]" />
-                </div>
-              </div>
-
-              {/* CTA Buttons */}
-              <div className="mt-6 flex flex-wrap justify-center gap-3">
-                <Link
-                  href="/signup"
-                  className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-6 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-                >
-                  <Stamp className="h-4 w-4" />
-                  無料でスタンプ帳をはじめる
-                </Link>
-                <Link
-                  href="/login?redirect=/visits"
-                  className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8] bg-white px-6 py-3 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
-                >
-                  旅の続きへ
-                </Link>
-              </div>
-            </div>
-          </section>
-
-          {/* Feature Showcase */}
-          <section className="space-y-3">
-            <h2 className="font-pixelJp text-lg font-bold text-[#4F3828]">スタンプ帳でできること</h2>
-
-            <div className="grid gap-3 sm:grid-cols-2">
-              <div className="rounded-lg border border-[#8C6A4A]/15 bg-white/70 p-4">
-                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-[#7B63A8]/10">
-                  <Stamp className="h-5 w-5 text-[#7B63A8]" />
-                </div>
-                <h3 className="font-pixelJp text-sm font-bold text-[#4F3828]">訪問記録を保存</h3>
-                <p className="mt-1 text-xs text-[#6A4D36]">
-                  見つけたポケふたを記録して、あなただけのコレクションを作れます
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-[#8C6A4A]/15 bg-white/70 p-4">
-                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-[#7B63A8]/10">
-                  <Camera className="h-5 w-5 text-[#7B63A8]" />
-                </div>
-                <h3 className="font-pixelJp text-sm font-bold text-[#4F3828]">写真を投稿</h3>
-                <p className="mt-1 text-xs text-[#6A4D36]">
-                  撮影した写真をアップロードして、旅の思い出を残せます
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-[#8C6A4A]/15 bg-white/70 p-4">
-                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-[#7B63A8]/10">
-                  <MapPin className="h-5 w-5 text-[#7B63A8]" />
-                </div>
-                <h3 className="font-pixelJp text-sm font-bold text-[#4F3828]">都道府県別の進捗</h3>
-                <p className="mt-1 text-xs text-[#6A4D36]">
-                  47都道府県の制覇状況を確認できます
-                </p>
-              </div>
-
-              <div className="rounded-lg border border-[#8C6A4A]/15 bg-white/70 p-4">
-                <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-[#7B63A8]/10">
-                  <CheckCircle2 className="h-5 w-5 text-[#7B63A8]" />
-                </div>
-                <h3 className="font-pixelJp text-sm font-bold text-[#4F3828]">全国制覇を目指す</h3>
-                <p className="mt-1 text-xs text-[#6A4D36]">
-                  達成率を見ながら、全国のポケふたを巡る旅を楽しめます
-                </p>
-              </div>
-            </div>
-          </section>
-
-          {/* Sample Preview Images */}
-          <section className="rounded-lg border border-[#8C6A4A]/15 bg-white/70 p-4">
-            <h3 className="mb-3 font-pixelJp text-sm font-bold text-[#4F3828]">全国{totalManholes || '470'}箇所以上のコレクション</h3>
-            <div className="grid grid-cols-3 gap-2">
-              {manholes.slice(0, 6).map((manhole) => (
-                <Link
-                  key={manhole.id}
-                  href={`/manhole/${manhole.id}`}
-                  className="group relative aspect-square overflow-hidden rounded-lg border-2 border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9] p-2 transition hover:border-[#7B63A8]"
-                >
-                  <div className="flex h-full flex-col items-center justify-center text-center">
-                    <Stamp className="h-6 w-6 text-[#B8AB96]" />
-                    <p className="mt-1 line-clamp-2 text-[10px] font-bold text-[#6A4D36]">
-                      {getMunicipality(manhole)}{manhole.building && `・${manhole.building}`}
-                    </p>
+                  <div>
+                    <span className="font-pixel text-2xl font-extrabold text-[#2C765E]">{prefectureCount ?? '47'}</span>
+                    <span className="ml-1 text-xs font-bold text-[#9B9B9B]">都道府県</span>
                   </div>
-                </Link>
-              ))}
+                  <div>
+                    <span className="font-pixel text-2xl font-extrabold text-[#FFB347]">{pokemonCount ?? '500+'}</span>
+                    <span className="ml-1 text-xs font-bold text-[#9B9B9B]">種類のポケモン</span>
+                  </div>
+                </div>
+
+                {/* CTA Buttons */}
+                <div className="mt-3 flex flex-wrap gap-2 sm:mt-4">
+                  <Link
+                    href="/signup"
+                    className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299] sm:py-2.5"
+                  >
+                    <Stamp className="h-4 w-4" />
+                    無料でスタンプ帳を作る
+                  </Link>
+                  <Link
+                    href="/nearby"
+                    className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white sm:py-2.5"
+                  >
+                    <MapPin className="h-4 w-4" />
+                    近くのポケふたを探す
+                  </Link>
+                </div>
+              </div>
+
+              <div className="hidden rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block">
+                <StampBookMockup />
+              </div>
             </div>
-            <p className="mt-3 text-center text-xs text-[#6A4D36]">
-              ログインして、あなたの旅の続きを記録しましょう
-            </p>
           </section>
 
-          {/* Bottom CTA */}
-          <section className="rounded-lg border border-[#FFB347]/30 bg-gradient-to-br from-[#FFF8EB] to-[#FFEDD5] p-6 text-center">
-            <Sparkles className="mx-auto mb-3 h-10 w-10 text-[#7B63A8]" />
-            <h3 className="font-pixelJp text-xl font-bold text-[#4F3828]">
-              旅の記録を保存しませんか？
-            </h3>
-            <p className="mt-2 text-sm font-medium text-[#6B6B6B]">
-              ログインすると、旅の続きとして訪問済みや行きたい場所を記録できます。<br />
-              全国制覇率や都道府県別の進捗も見られます。
-            </p>
-            <div className="mt-5 flex flex-wrap justify-center gap-3">
-              <Link
-                href="/signup"
-                className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-6 py-3 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-              >
-                <Camera className="h-4 w-4" />
-                無料で新規登録
-              </Link>
-              <Link
-                href="/login?redirect=/visits"
-                className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8] bg-white px-6 py-3 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-[#7B63A8]/5"
-              >
-                旅の続きへ
-              </Link>
+          {/* 旅を続けると… モックカード */}
+          <section className="rounded-[8px] border border-[#7B63A8]/15 bg-white/80 px-4 py-4 shadow-sm sm:px-6">
+            <p className="mb-3 text-xs font-extrabold uppercase tracking-widest text-[#9B9B9B]">旅を続けると…</p>
+            <div className="grid grid-cols-3 gap-3 sm:grid-cols-3">
+              <div className="rounded-lg bg-[#F5F0FF] px-3 py-3 text-center">
+                <p className="text-[10px] font-bold text-[#9B9B9B]">全国</p>
+                <p className="font-pixel text-xl font-extrabold text-[#7B63A8]">
+                  80<span className="text-[11px] font-bold text-[#C0B8D0]">/{totalManholes ?? '470'}</span>
+                </p>
+              </div>
+              <div className="rounded-lg bg-[#EDFAF5] px-3 py-3 text-center">
+                <p className="text-[10px] font-bold text-[#9B9B9B]">都道府県</p>
+                <p className="font-pixel text-xl font-extrabold text-[#2C765E]">
+                  10<span className="text-[11px] font-bold text-[#A8D5C4]">/{prefectureCount ?? '47'}</span>
+                </p>
+              </div>
+              <div className="rounded-lg bg-[#FFF8EB] px-3 py-3 text-center">
+                <p className="text-[10px] font-bold text-[#9B9B9B]">ポケモン</p>
+                <p className="font-pixel text-xl font-extrabold text-[#C87C2A]">
+                  104<span className="text-[11px] font-bold text-[#D4BC8A]">/{pokemonCount ?? '500+'}</span>
+                </p>
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <span className="inline-flex items-center gap-1 rounded-full bg-[#DDD0F5] px-2.5 py-1 text-xs font-bold text-[#7B63A8]">
+                <Stamp className="h-3 w-3" />
+                岐阜県 あと2枚で制覇
+              </span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-[#DDD0F5] px-2.5 py-1 text-xs font-bold text-[#7B63A8]">
+                <Stamp className="h-3 w-3" />
+                ニンフィア 4/6 収集中
+              </span>
             </div>
           </section>
-        </div>
+
+          {/* 旅写真プレビュー */}
+          {sampleVisits.length > 0 && (
+            <section className="rounded-[8px] border border-[#8C6A4A]/15 bg-white/70 p-4">
+              <h3 className="mb-3 font-pixelJp text-sm font-bold text-[#4F3828]">みんなの旅写真</h3>
+              <div className="grid grid-cols-3 gap-2 sm:grid-cols-6">
+                {sampleVisits.slice(0, 6).map((sv) => (
+                  <div
+                    key={sv.id}
+                    className="relative aspect-square overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#E9DEC9]"
+                  >
+                    {sv.thumbnail_url ? (
+                      <img
+                        src={sv.thumbnail_url}
+                        alt=""
+                        className="h-full w-full object-cover"
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center">
+                        <Stamp className="h-6 w-6 text-[#B8AB96]" />
+                      </div>
+                    )}
+                    <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/70 to-transparent p-1.5">
+                      <p className="line-clamp-1 text-[9px] font-bold text-white">{sv.location}</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="mt-3 text-center text-xs text-[#6A4D36]">
+                登録すると、あなたの旅写真もここに残せます
+              </p>
+            </section>
+          )}
+        </main>
 
         <BottomNav />
       </div>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -650,7 +650,7 @@ export default function VisitsPage() {
           {/* 旅を続けると… モックカード */}
           <section className="rounded-[8px] border border-[#7B63A8]/15 bg-white/80 px-4 py-4 shadow-sm sm:px-6">
             <p className="mb-3 text-xs font-extrabold uppercase tracking-widest text-[#9B9B9B]">旅を続けると…</p>
-            <div className="grid grid-cols-3 gap-3 sm:grid-cols-3">
+            <div className="grid grid-cols-3 gap-3">
               <div className="rounded-lg bg-[#F5F0FF] px-3 py-3 text-center">
                 <p className="text-[10px] font-bold text-[#9B9B9B]">全国</p>
                 <p className="font-pixel text-xl font-extrabold text-[#7B63A8]">

--- a/src/components/StampBookMockup.tsx
+++ b/src/components/StampBookMockup.tsx
@@ -1,0 +1,136 @@
+import { Award, Stamp } from 'lucide-react';
+
+const MOCKUP_STAMPS = [
+  { src: '/mockup/s1.jpeg', name: 'ルギア' },
+  { src: '/mockup/s2.jpeg', name: 'ホエルオー' },
+  { src: '/mockup/s3.jpeg', name: 'ロコン' },
+];
+
+const PREFECTURE_GRID: Array<{ short: string; state: 'complete' | 'partial' | 'empty'; title: string }> = [
+  { short: '北海', state: 'complete', title: '北海道 制覇済み' },
+  { short: '青森', state: 'complete', title: '青森県 制覇済み' },
+  { short: '岩手', state: 'partial', title: '岩手県 訪問済み' },
+  { short: '宮城', state: 'complete', title: '宮城県 制覇済み' },
+  { short: '秋田', state: 'partial', title: '秋田県 訪問済み' },
+  { short: '山形', state: 'empty', title: '山形県 未訪問' },
+  { short: '福島', state: 'partial', title: '福島県 訪問済み' },
+  { short: '茨城', state: 'partial', title: '茨城県 訪問済み' },
+  { short: '栃木', state: 'empty', title: '栃木県 未訪問' },
+  { short: '群馬', state: 'empty', title: '群馬県 未訪問' },
+  { short: '埼玉', state: 'complete', title: '埼玉県 制覇済み' },
+  { short: '千葉', state: 'complete', title: '千葉県 制覇済み' },
+  { short: '東京', state: 'complete', title: '東京都 制覇済み' },
+  { short: '神奈', state: 'complete', title: '神奈川県 制覇済み' },
+  { short: '新潟', state: 'partial', title: '新潟県 訪問済み' },
+  { short: '富山', state: 'empty', title: '富山県 未訪問' },
+  { short: '石川', state: 'partial', title: '石川県 訪問済み' },
+  { short: '福井', state: 'empty', title: '福井県 未訪問' },
+  { short: '山梨', state: 'empty', title: '山梨県 未訪問' },
+  { short: '長野', state: 'partial', title: '長野県 訪問済み' },
+  { short: '岐阜', state: 'partial', title: '岐阜県 訪問済み' },
+  { short: '静岡', state: 'complete', title: '静岡県 制覇済み' },
+  { short: '愛知', state: 'complete', title: '愛知県 制覇済み' },
+  { short: '三重', state: 'partial', title: '三重県 訪問済み' },
+  { short: '滋賀', state: 'empty', title: '滋賀県 未訪問' },
+  { short: '京都', state: 'complete', title: '京都府 制覇済み' },
+  { short: '大阪', state: 'complete', title: '大阪府 制覇済み' },
+  { short: '兵庫', state: 'complete', title: '兵庫県 制覇済み' },
+  { short: '奈良', state: 'partial', title: '奈良県 訪問済み' },
+  { short: '和歌', state: 'empty', title: '和歌山県 未訪問' },
+  { short: '鳥取', state: 'empty', title: '鳥取県 未訪問' },
+  { short: '島根', state: 'empty', title: '島根県 未訪問' },
+  { short: '岡山', state: 'partial', title: '岡山県 訪問済み' },
+  { short: '広島', state: 'complete', title: '広島県 制覇済み' },
+  { short: '山口', state: 'partial', title: '山口県 訪問済み' },
+  { short: '徳島', state: 'empty', title: '徳島県 未訪問' },
+  { short: '香川', state: 'partial', title: '香川県 訪問済み' },
+  { short: '愛媛', state: 'empty', title: '愛媛県 未訪問' },
+  { short: '高知', state: 'empty', title: '高知県 未訪問' },
+  { short: '福岡', state: 'complete', title: '福岡県 制覇済み' },
+  { short: '佐賀', state: 'partial', title: '佐賀県 訪問済み' },
+  { short: '長崎', state: 'partial', title: '長崎県 訪問済み' },
+  { short: '熊本', state: 'partial', title: '熊本県 訪問済み' },
+  { short: '大分', state: 'empty', title: '大分県 未訪問' },
+  { short: '宮崎', state: 'empty', title: '宮崎県 未訪問' },
+  { short: '鹿児', state: 'partial', title: '鹿児島県 訪問済み' },
+  { short: '沖縄', state: 'complete', title: '沖縄県 制覇済み' },
+];
+
+const PREFECTURE_STATE_CLASS = {
+  complete: 'bg-[#7B63A8] text-white',
+  partial: 'bg-[#DDD0F5] text-[#7B63A8]',
+  empty: 'bg-[#F0EEF5] text-[#C0B8D0]',
+} as const;
+
+export default function StampBookMockup() {
+  return (
+    <div className="overflow-hidden rounded-[10px] border-2 border-[#C9B8E8] bg-[#FFFDF7] text-xs">
+      {/* Passport header */}
+      <div className="flex items-center justify-between bg-[#7B63A8] px-3 py-1.5">
+        <div className="flex items-center gap-1.5 text-[10px] font-extrabold text-white">
+          <Stamp className="h-3.5 w-3.5" />
+          ポケふたパスポート
+        </div>
+        <div className="flex items-center gap-1 rounded-full bg-[#FFB347] px-2 py-0.5 text-[9px] font-extrabold text-white">
+          <Award className="h-2.5 w-2.5" />
+          355達成!
+        </div>
+      </div>
+
+      <div className="space-y-1.5 p-2.5">
+        {/* 全国 + 都道府県コンプ + ポケモンコンプ 横並び */}
+        <div className="flex gap-2 border-b border-dashed border-[#DDD0F5] pb-1.5">
+          <div className="flex-1">
+            <div className="text-[9px] font-bold text-[#9B9B9B]">全国</div>
+            <div className="text-xl font-extrabold leading-tight text-[#7B63A8]">
+              355<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/470</span>
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="text-[9px] font-bold text-[#9B9B9B]">都道府県</div>
+            <div className="text-xl font-extrabold leading-tight text-[#2C765E]">
+              15<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/47</span>
+            </div>
+          </div>
+          <div className="flex-1">
+            <div className="text-[9px] font-bold text-[#9B9B9B]">ポケモン</div>
+            <div className="text-xl font-extrabold leading-tight text-[#FFB347]">
+              42<span className="ml-0.5 text-[9px] font-bold text-[#9B9B9B]">/151</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Recent 3 stamps with real photos */}
+        <div>
+          <div className="mb-0.5 text-[9px] font-extrabold text-[#6B6B6B]">最近集めたポケふた</div>
+          <div className="flex gap-1">
+            {MOCKUP_STAMPS.slice(0, 3).map(({ src, name }) => (
+              <div key={src} className="flex flex-1 flex-col items-center gap-0.5">
+                <div className="mx-auto h-[52px] w-[52px] overflow-hidden rounded-full border-2 border-[#7B63A8] shadow-sm">
+                  <img src={src} alt="" loading="lazy" decoding="async" className="h-full w-full object-cover" />
+                </div>
+                <span className="text-center text-[7px] font-bold leading-tight text-[#7B63A8]">{name}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* 都道府県達成 Grid */}
+        <div className="border-t border-dashed border-[#DDD0F5] pt-2">
+          <div className="mb-1 text-[9px] font-extrabold text-[#6B6B6B]">都道府県達成</div>
+          <div className="flex flex-wrap gap-0.5">
+            {PREFECTURE_GRID.map(({ short, state, title }) => (
+              <div
+                key={short}
+                title={title}
+                className={`rounded-sm px-[3px] py-[1px] text-[7px] font-bold leading-tight ${PREFECTURE_STATE_CLASS[state]}`}
+              >
+                {short}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **popular**: 「全国のポケふた写真館」にリブランド。ヒーローに投稿数＋残り募集枚数を動的表示。「写真がまだないポケふた」セクションを最新投稿より上に配置。右画像を古いSVGからStampBookMockupに変更し、トップと世界観を統一
- **visits**: コンテナ幅をmax-w-6xlに拡大（旧max-w-3xlから）。3統計をインライン横並びで視認性改善。「旅を続けると…」モックカード（80/470, 10/47, 104/534 サンプル進捗 + 岐阜県あと2枚バッジ）を追加して登録後の達成感を訴求。CTAを「無料でスタンプ帳を作る」「近くのポケふたを探す」に変更、「旅の続きへ」（未ログインユーザーに意味不明）を削除
- **top**: ヒーローCTAを3ボタン→2ボタンに絞る（「みんなの写真を見る」削除）
- **StampBookMockup**: `src/components/StampBookMockup.tsx` に切り出し、top/popular/visits で共有

## Test plan

- [ ] 未ログイン状態で `/`, `/popular`, `/visits` を確認
- [ ] ログイン済み状態で `/visits` が正常動作することを確認（変更はunauthブロックのみ）
- [ ] デスクトップ幅で `/visits` のgridレイアウト（左:テキスト、右:パスポートモック）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)