### PR TITLE
GA4全イベントにis_logged_inを自動付与 (#139)

### DIFF
--- a/src/components/ApiErrorAnalytics.tsx
+++ b/src/components/ApiErrorAnalytics.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
-import { errorEvents } from '@/lib/analytics/gtag';
+import { useEffect, useRef } from 'react';
+import { createBrowserClient } from '@/lib/supabase/client';
+import { errorEvents, setAnalyticsAuthState } from '@/lib/analytics/gtag';
 
 const API_ERROR_ANALYTICS_PATCHED = Symbol.for('pokefuta.apiErrorAnalyticsPatched');
 
@@ -38,7 +39,41 @@ function getMethod(input: RequestInfo | URL, init?: RequestInit): string {
   return 'GET';
 }
 
+function derivePageType(pathname: string): string {
+  if (/^\/manhole\//.test(pathname)) return 'manhole_detail';
+  if (pathname === '/') return 'gallery_index';
+  if (pathname === '/visits') return 'visits';
+  if (pathname === '/popular') return 'popular';
+  if (pathname === '/upload') return 'upload';
+  if (pathname === '/login') return 'login';
+  if (pathname === '/signup') return 'signup';
+  if (/^\/prefecture\//.test(pathname)) return 'prefecture';
+  if (/^\/user\//.test(pathname)) return 'user_profile';
+  if (pathname === '/nearby') return 'nearby';
+  return 'other';
+}
+
 export default function ApiErrorAnalytics() {
+  const isLoggedInRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      const v = Boolean(session?.user);
+      isLoggedInRef.current = v;
+      setAnalyticsAuthState(v);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      const v = Boolean(session?.user);
+      isLoggedInRef.current = v;
+      setAnalyticsAuthState(v);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
   useEffect(() => {
     const patchedWindow = window as PatchedWindow;
 
@@ -55,7 +90,11 @@ export default function ApiErrorAnalytics() {
         const response = await originalFetch(input, init);
 
         if (apiPath && !response.ok) {
-          errorEvents.api(apiPath, response.status, method, response.statusText);
+          errorEvents.api(apiPath, response.status, method, response.statusText, {
+            is_logged_in: isLoggedInRef.current === null ? 'unknown' : isLoggedInRef.current,
+            page_type: derivePageType(window.location.pathname),
+            component: 'ApiErrorAnalytics',
+          });
         }
 
         return response;
@@ -65,7 +104,12 @@ export default function ApiErrorAnalytics() {
             apiPath,
             0,
             method,
-            error instanceof Error ? error.message : 'Network request failed'
+            error instanceof Error ? error.message : 'Network request failed',
+            {
+              is_logged_in: isLoggedInRef.current === null ? 'unknown' : isLoggedInRef.current,
+              page_type: derivePageType(window.location.pathname),
+              component: 'ApiErrorAnalytics',
+            }
           );
         }
 

--- a/src/components/ApiErrorAnalytics.tsx
+++ b/src/components/ApiErrorAnalytics.tsx
@@ -48,7 +48,7 @@ function derivePageType(pathname: string): string {
   if (pathname === '/login') return 'login';
   if (pathname === '/signup') return 'signup';
   if (/^\/prefecture\//.test(pathname)) return 'prefecture';
-  if (/^\/user\//.test(pathname)) return 'user_profile';
+  if (/^\/users\//.test(pathname)) return 'user_profile';
   if (pathname === '/nearby') return 'nearby';
   return 'other';
 }
@@ -57,21 +57,27 @@ export default function ApiErrorAnalytics() {
   const isLoggedInRef = useRef<boolean | null>(null);
 
   useEffect(() => {
-    const supabase = createBrowserClient();
+    try {
+      const supabase = createBrowserClient();
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      const v = Boolean(session?.user);
-      isLoggedInRef.current = v;
-      setAnalyticsAuthState(v);
-    });
+      supabase.auth.getSession()
+        .then(({ data: { session } }) => {
+          const v = Boolean(session?.user);
+          isLoggedInRef.current = v;
+          setAnalyticsAuthState(v);
+        })
+        .catch(() => {});
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      const v = Boolean(session?.user);
-      isLoggedInRef.current = v;
-      setAnalyticsAuthState(v);
-    });
+      const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+        const v = Boolean(session?.user);
+        isLoggedInRef.current = v;
+        setAnalyticsAuthState(v);
+      });
 
-    return () => subscription.unsubscribe();
+      return () => subscription.unsubscribe();
+    } catch {
+      // analytics auth tracking is non-fatal
+    }
   }, []);
 
   useEffect(() => {

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -31,6 +31,9 @@ export interface ApiErrorEventParams extends GAEventParams {
   status_code: number;
   method: string;
   error_message?: string;
+  is_logged_in?: boolean | 'unknown';
+  page_type?: string;
+  component?: string;
 }
 
 // ==========================================
@@ -57,6 +60,17 @@ function isGtagAvailable(): boolean {
 }
 
 // ==========================================
+// auth 状態（全イベント自動付与用）
+// ==========================================
+
+let _analyticsIsLoggedIn: boolean | null = null;
+
+/** ApiErrorAnalytics や認証フローから呼ぶ。全イベントに is_logged_in が自動付与される。 */
+export function setAnalyticsAuthState(isLoggedIn: boolean): void {
+  _analyticsIsLoggedIn = isLoggedIn;
+}
+
+// ==========================================
 // コア関数: イベント送信
 // ==========================================
 
@@ -78,6 +92,7 @@ export function trackEvent(
     page_title: isClientSide() ? document.title : undefined,
     event_timestamp: new Date().toISOString(),
     user_locale: navigator.language || 'ja-JP',
+    is_logged_in: _analyticsIsLoggedIn !== null ? _analyticsIsLoggedIn : undefined,
     ...context,
     ...eventParams,
   };
@@ -228,7 +243,8 @@ export const errorEvents = {
     endpoint: string,
     statusCode: number,
     method: string = 'GET',
-    errorMessage?: string
+    errorMessage?: string,
+    additionalParams?: Partial<ApiErrorEventParams>
   ) =>
     trackEvent('error_event', {
       error_type: 'api_error',
@@ -237,6 +253,7 @@ export const errorEvents = {
       status_code: statusCode,
       method,
       error_message: errorMessage?.slice(0, 100),
+      ...additionalParams,
     } satisfies ApiErrorEventParams),
 
   auth: (errorCode: string) =>

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -244,7 +244,7 @@ export const errorEvents = {
     statusCode: number,
     method: string = 'GET',
     errorMessage?: string,
-    additionalParams?: Partial<ApiErrorEventParams>
+    additionalParams?: Pick<ApiErrorEventParams, 'is_logged_in' | 'page_type' | 'component'>
   ) =>
     trackEvent('error_event', {
       error_type: 'api_error',


### PR DESCRIPTION
## Summary

- `trackEvent()` の自動エンリッチに `is_logged_in` を追加。`ApiErrorAnalytics` が管理するモジュールレベルの auth 状態変数から全イベントに自動付与される
- `ApiErrorAnalytics.tsx` に Supabase auth リスナーを追加。`getSession()` で初期状態取得、`onAuthStateChange` でログイン/ログアウトを追跡
- `error_event` に `is_logged_in` / `page_type` / `component` を追加。GA4 探索でログイン状態別・ページ別のエラー分析が可能になる
- `errorEvents.api()` に `additionalParams` を追加し、エラーイベント固有のパラメータを渡せるよう拡張

## 変更ファイル

- `src/lib/analytics/gtag.ts` — `setAnalyticsAuthState()` 追加、`trackEvent` エンリッチに `is_logged_in` 追加、`ApiErrorEventParams` 型拡張
- `src/components/ApiErrorAnalytics.tsx` — auth リスナー追加、`derivePageType()` 追加、`error_event` に3パラメータ付与

## Test plan

- [ ] GA4 DebugView（`?gtag_debug=1`）で任意のイベントに `is_logged_in` が付与されていることを確認
- [ ] 未ログイン状態で `is_logged_in: false`、ログイン後に `is_logged_in: true` に変化することを確認
- [ ] 開発環境の `[GA Event]` ログで `error_event` に `page_type` / `component` が出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)