### PR TITLE
ログイン後UX統一 — パスポートカード簡素化・月別旅履歴・ボトムCTAバー

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,8 @@ import {
   CircleDot,
   Compass,
   MapPin,
+  Navigation,
+  PlusCircle,
   Sparkles,
   Stamp,
 } from 'lucide-react';
@@ -512,6 +514,17 @@ export default function HomePage() {
         return a.name.localeCompare(b.name, 'ja');
       });
 
+    const visitedPrefectureCount = prefectureProgress.filter((p) => p.visited > 0).length;
+    const allPokemonSpecies = new Set<string>(allJourneyManholes.flatMap((m) => m.pokemons ?? []));
+    journeyVisits.forEach((v) => (v.manhole?.pokemons ?? []).forEach((p) => allPokemonSpecies.add(p)));
+    const visitedPokemonSpeciesSet = new Set<string>(journeyVisits.flatMap((v) => v.manhole?.pokemons ?? []));
+    const nextAchievement = prefectureProgress
+      .filter((p) => p.visited > 0 && p.remaining > 0)
+      .reduce<PrefectureProgress | null>(
+        (best, p) => (!best || p.remaining < best.remaining) ? p : best,
+        null
+      );
+
     const nearbyIds = new Set<number>();
     const nearbyCandidates = nearbyUnvisited
       .filter((manhole) => !visitsByManholeId.has(manhole.id))
@@ -601,6 +614,10 @@ export default function HomePage() {
     return {
       visitsByManholeId,
       visitedCount: visitsByManholeId.size,
+      visitedPrefectureCount,
+      visitedPokemonSpecies: visitedPokemonSpeciesSet.size,
+      totalPokemonSpecies: allPokemonSpecies.size,
+      nextAchievement,
       visitedManholes,
       completedPrefectures,
       continuingPrefecture,
@@ -614,21 +631,41 @@ export default function HomePage() {
   const {
     visitsByManholeId,
     visitedCount,
+    visitedPrefectureCount,
+    visitedPokemonSpecies,
+    totalPokemonSpecies,
+    nextAchievement,
+    visitedManholes,
     completedPrefectures,
     continuingPrefecture,
     nextPrefectureCandidates,
-    visitedManholes,
     nearbyCandidates,
     recentCandidates,
     journeyContinuationCandidates,
   } = journeyData;
   const completionRate = knownTotalManholes ? (visitedCount / knownTotalManholes) * 100 : null;
 
+  const visitsByMonth = useMemo(() => {
+    const groups = new Map<string, JourneyVisit[]>();
+    const sorted = [...journeyVisits].sort(
+      (a, b) => new Date(b.shot_at).getTime() - new Date(a.shot_at).getTime()
+    );
+    for (const visit of sorted) {
+      const date = new Date(visit.shot_at);
+      if (isNaN(date.getTime())) continue;
+      const key = `${date.getFullYear()}年${date.getMonth() + 1}月`;
+      const group = groups.get(key);
+      if (group) group.push(visit);
+      else groups.set(key, [visit]);
+    }
+    return Array.from(groups.entries()).map(([label, visits]) => ({ label, visits }));
+  }, [journeyVisits]);
+
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
       <Header title="ポケふた写真館" />
 
-      <main className="mx-auto max-w-6xl px-4 pb-6 pt-5 sm:pt-8">
+      <main className={`mx-auto max-w-6xl px-4 pt-5 sm:pt-8 ${isLoggedIn ? 'pb-[10rem]' : 'pb-6'}`}>
         {/* Loading State */}
         {loading && (
           <div className="flex items-center justify-center py-12">
@@ -644,78 +681,68 @@ export default function HomePage() {
           <>
             {isLoggedIn ? (
               <>
-                <section className="relative overflow-hidden rounded-[8px] border border-[#8C6A4A]/20 bg-[#FFF7E5] px-5 py-6 shadow-[0_10px_26px_rgba(95,68,42,0.12)] sm:px-8 sm:py-8">
-                  <div className="absolute inset-0 opacity-[0.07] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+                <section className="relative overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5] p-3 shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
+                  <div className="absolute inset-0 opacity-[0.08] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
                   <div className="relative">
-                    <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#B5483C]/25 bg-[#F8D9C4] px-3 py-1 text-xs font-bold text-[#B5483C]">
-                      <Stamp className="h-3.5 w-3.5" />
-                      まいたび
+                    <p className="font-pixelJp text-[11px] font-bold text-[#9B5C2E]">POKEFUTA PASSPORT</p>
+                    <h1 className="font-pixelJp text-base font-bold text-[#4F3828]">{userName}のポケふた旅</h1>
+
+                    <div className="mt-3 h-3 overflow-hidden rounded-sm border border-[#8C6A4A]/25 bg-[#E4D4B8]">
+                      <div
+                        className="h-full rounded-sm bg-gradient-to-r from-[#D94D3F] via-[#F1B642] to-[#3F9D7D] transition-all"
+                        style={{ width: `${Math.min(completionRate ?? 0, 100)}%` }}
+                      />
                     </div>
-                    <h1 className="text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
-                      {userName}のポケふた旅
-                    </h1>
 
-                    <div className="mt-5 rounded-[8px] border border-[#8C6A4A]/15 bg-white/70 p-4 shadow-[inset_0_0_0_1px_rgba(255,255,255,0.45)] sm:p-5">
-                      <div className="grid gap-5 lg:grid-cols-[1.05fr_0.95fr] lg:items-start">
-                        <div>
-                          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                            <div>
-                              <p className="font-pixel text-3xl leading-none text-[#4F3828] sm:text-4xl">
-                                {visitedCount} / {knownTotalManholes ?? '集計中'}
-                              </p>
-                              <p className="mt-2 text-xs font-extrabold text-[#6A4D36]">STAMPS</p>
-                            </div>
-                            <div className="rounded-[7px] border border-[#B5483C]/20 bg-[#FFF7E5] px-3 py-2">
-                              <p className="text-[11px] font-extrabold text-[#6A4D36]">全国達成率</p>
-                              <p className="mt-1 font-pixel text-2xl leading-none text-[#B5483C]">
-                                {completionRate === null ? '--%' : `${completionRate.toFixed(1)}%`}
-                              </p>
-                            </div>
-                          </div>
-                          <div className="mt-4 h-4 overflow-hidden rounded-sm border border-[#8C6A4A]/20 bg-[#E4D4B8]">
-                            <div
-                              className="h-full bg-gradient-to-r from-[#8C6A4A] via-[#DDA63A] to-[#2C765E]"
-                              style={{ width: `${Math.min(completionRate ?? 0, 100)}%` }}
-                            />
-                          </div>
-                          <JourneyPrefectureOverview
-                            completedPrefectures={completedPrefectures}
-                            continuingPrefecture={continuingPrefecture}
-                            userId={currentUserId}
-                          />
+                    <div className="mt-3 overflow-hidden rounded-lg border border-[#8C6A4A]/15 bg-white/55">
+                      <div className="grid grid-cols-3 divide-x divide-[#8C6A4A]/15">
+                        <div className="px-3 py-2 text-center">
+                          <p className="font-pixelJp text-[10px] font-bold text-[#8C6A4A]">全国</p>
+                          <p className="mt-0.5 font-pixel text-sm font-bold text-[#4F3828]">{visitedCount}<span className="text-[#8C6A4A]">/{knownTotalManholes ?? '-'}</span></p>
                         </div>
-
-                        <div>
-                          <div className="mb-3 flex items-center justify-between gap-3">
-                            <div>
-                              <p className="text-xs font-extrabold text-[#6A4D36]">次に狙いたい県</p>
-                              <p className="mt-1 text-[11px] font-bold text-[#8C6A4A]">旅の続きにしやすい候補</p>
-                            </div>
-                            <Compass className="h-5 w-5 text-[#B5483C]" />
-                          </div>
-                          {nextPrefectureCandidates.length > 0 ? (
-                            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
-                              {nextPrefectureCandidates.map((prefecture) => (
-                                <JourneyPrefectureStat
-                                  key={prefecture.name}
-                                  prefecture={prefecture}
-                                  label={prefecture.label}
-                                  userId={currentUserId}
-                                />
-                              ))}
-                            </div>
-                          ) : (
-                            <JourneyCandidateNotice text="最初の訪問を記録すると、次の旅先候補がここに育っていきます。" />
-                          )}
-                          <Link
-                            href="/nearby?tab=unvisited"
-                            className="mt-4 inline-flex min-h-[48px] w-full items-center justify-center gap-2 rounded-[7px] bg-[#B5483C] px-5 py-3 text-sm font-extrabold text-white shadow-[0_6px_14px_rgba(181,72,60,0.22)] transition hover:bg-[#9F3D33] focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-                          >
-                            <MapPin className="h-5 w-5" />
-                            次のポケふたを探す
-                          </Link>
+                        <div className="px-3 py-2 text-center">
+                          <p className="font-pixelJp text-[10px] font-bold text-[#8C6A4A]">都道府県</p>
+                          <p className="mt-0.5 font-pixel text-sm font-bold text-[#4F3828]">{visitedPrefectureCount}<span className="text-[#8C6A4A]">/47</span></p>
+                        </div>
+                        <div className="px-3 py-2 text-center">
+                          <p className="font-pixelJp text-[10px] font-bold text-[#8C6A4A]">ポケモン</p>
+                          <p className="mt-0.5 font-pixel text-sm font-bold text-[#4F3828]">{visitedPokemonSpecies}<span className="text-[#8C6A4A]">/{totalPokemonSpecies}</span></p>
                         </div>
                       </div>
+                      {nextAchievement && (
+                        <div className="flex items-center justify-between gap-3 border-t border-[#8C6A4A]/15 px-3 py-2">
+                          <p className="font-pixelJp text-[10px] font-bold text-[#9B5C2E]">🎯 次の達成</p>
+                          <div className="flex items-center gap-2">
+                            <p className="font-pixelJp text-xs font-bold text-[#4F3828]">{nextAchievement.name}</p>
+                            <p className="font-pixel text-xs text-[#6A4D36]">{nextAchievement.visited}/{nextAchievement.total}</p>
+                            <span className="rounded bg-[#F8D9C4] px-1.5 py-0.5 font-pixelJp text-[10px] font-bold text-[#B5483C]">あと{nextAchievement.remaining}枚</span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="mt-4 grid grid-cols-3 gap-2">
+                      <Link
+                        href="/upload"
+                        className="flex min-h-[44px] items-center justify-center gap-1.5 rounded-md bg-[#B5483C] px-2 font-pixelJp text-xs font-bold text-white"
+                      >
+                        <PlusCircle className="h-3.5 w-3.5 shrink-0" />
+                        訪問を記録
+                      </Link>
+                      <Link
+                        href="/visits"
+                        className="flex min-h-[44px] items-center justify-center gap-1.5 rounded-md border border-[#8C6A4A]/25 bg-white px-2 font-pixelJp text-xs font-bold text-[#4F3828]"
+                      >
+                        <Stamp className="h-3.5 w-3.5 shrink-0" />
+                        スタンプ帳
+                      </Link>
+                      <Link
+                        href="/nearby"
+                        className="flex min-h-[44px] items-center justify-center gap-1.5 rounded-md border border-[#8C6A4A]/25 bg-white px-2 font-pixelJp text-xs font-bold text-[#4F3828]"
+                      >
+                        <Navigation className="h-3.5 w-3.5 shrink-0" />
+                        近くを探す
+                      </Link>
                     </div>
                   </div>
                 </section>
@@ -746,22 +773,18 @@ export default function HomePage() {
 
                 {journeyTab === 'history' ? (
                   <section className="mt-6">
-                    {visitedManholes.length > 0 ? (
-                      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 lg:gap-5">
-                        {visitedManholes.map((manhole) => (
-                          <JourneyHistoryCard
-                            key={manhole.id}
-                            manhole={manhole}
-                            visits={visitsByManholeId.get(manhole.id)}
-                          />
-                        ))}
-                      </div>
-                    ) : (
+                    {visitsByMonth.length === 0 ? (
                       <JourneyEmptyState
                         title="まだ訪問履歴がありません"
                         description="最初の訪問を記録すると、ここに写真つきの旅のアルバムが育っていきます。"
                         uploadHref={uploadHref}
                       />
+                    ) : (
+                      <div className="space-y-8">
+                        {visitsByMonth.map(({ label, visits }) => (
+                          <VisitMonthGroup key={label} label={label} visits={visits} />
+                        ))}
+                      </div>
                     )}
                   </section>
                 ) : (
@@ -1080,13 +1103,18 @@ export default function HomePage() {
       </main>
 
       {isLoggedIn && (
-        <Link
-          href={uploadHref}
-          className="fixed bottom-[calc(env(safe-area-inset-bottom)+5.75rem)] right-4 z-40 inline-flex items-center gap-2 rounded-full bg-[#B5483C] px-5 py-4 text-sm font-extrabold text-white shadow-[0_8px_18px_rgba(123,99,168,0.30)] transition hover:bg-[#9F3D33] sm:bottom-6 sm:right-6"
-        >
-          <Camera className="h-5 w-5" />
-          訪問を記録
-        </Link>
+        <div className="fixed inset-x-0 bottom-[4.6rem] z-30 px-4">
+          <div className="mx-auto flex max-w-6xl gap-2 rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5]/95 p-2 shadow-lg backdrop-blur">
+            <Link href="/upload" className="flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-md bg-[#B5483C] px-3 font-pixelJp text-xs font-bold text-white">
+              <PlusCircle className="h-4 w-4" />
+              訪問を記録
+            </Link>
+            <Link href="/visits" className="flex min-h-[44px] flex-1 items-center justify-center gap-2 rounded-md border border-[#8C6A4A]/25 bg-white px-3 font-pixelJp text-xs font-bold text-[#4F3828]">
+              <Stamp className="h-4 w-4" />
+              スタンプ帳
+            </Link>
+          </div>
+        </div>
       )}
 
       <BottomNav />
@@ -1440,5 +1468,105 @@ function JourneyEmptyState({
         訪問を記録
       </Link>
     </div>
+  );
+}
+
+function VisitMonthGroup({ label, visits }: { label: string; visits: JourneyVisit[] }) {
+  const photoVisits = visits.filter((v) => v.photos.length > 0);
+  const noPhotoVisits = visits.filter((v) => v.photos.length === 0);
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <p className="text-sm font-extrabold text-[#4F3828]">{label}</p>
+        <span className="rounded-full bg-[#E9DEC9] px-2 py-0.5 text-xs font-bold text-[#6A4D36]">{visits.length}件</span>
+      </div>
+      {photoVisits.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+          {photoVisits.map((visit) => (
+            <VisitHistoryCard key={visit.id} visit={visit} hasPhoto />
+          ))}
+        </div>
+      )}
+      {noPhotoVisits.length > 0 && (
+        <div className={`${photoVisits.length > 0 ? 'mt-3' : ''} space-y-2`}>
+          {noPhotoVisits.map((visit) => (
+            <VisitHistoryCard key={visit.id} visit={visit} hasPhoto={false} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VisitHistoryCard({ visit, hasPhoto }: { visit: JourneyVisit; hasPhoto: boolean }) {
+  const photo = visit.photos[0];
+  const manhole = visit.manhole;
+  const manholeId = manhole?.id ?? visit.manhole_id;
+  const location = manhole?.building
+    ? [manhole.municipality, manhole.building].filter(Boolean).join('・')
+    : [manhole?.prefecture, manhole?.municipality].filter(Boolean).join(' ') || 'ポケふた';
+  const tags = getManholeTags(manhole, 3).map(safeTagLabel).filter(Boolean) as string[];
+  const href = manholeId ? `/manhole/${manholeId}` : '#';
+
+  if (!hasPhoto) {
+    return (
+      <Link
+        href={href}
+        className="flex items-center gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-3 py-2 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+      >
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 border-[#B8AB96] bg-[#E9DEC9]">
+          <Stamp className="h-4 w-4 text-[#A39580]" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">{location}</p>
+          <p className="text-xs font-bold text-[#B5483C]">{formatDateJa(visit.shot_at)}</p>
+          {tags.length > 0 && (
+            <div className="mt-1 flex flex-wrap gap-1">
+              {tags.slice(0, 2).map((tag) => (
+                <span key={tag} className="rounded-full border border-[#8C6A4A]/15 bg-white/80 px-1.5 py-0.5 text-[10px] font-bold text-[#6A4D36]">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+    >
+      <div className="relative aspect-square overflow-hidden bg-[#E9DEC9]">
+        {photo?.thumbnail_url ? (
+          <img
+            src={photo.thumbnail_url}
+            alt=""
+            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center">
+            <CircleDot className="h-8 w-8 text-[#B8AB96]" />
+          </div>
+        )}
+        <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/75 to-transparent p-2 pt-8">
+          <p className="line-clamp-1 text-xs font-extrabold text-white">{location}</p>
+          <p className="text-[10px] font-bold text-white/80">{formatDateJa(visit.shot_at)}</p>
+        </div>
+      </div>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-1 p-2">
+          {tags.map((tag) => (
+            <span key={tag} className="rounded-full border border-[#8C6A4A]/15 bg-white/80 px-2 py-0.5 text-[10px] font-bold text-[#6A4D36]">
+              {tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </Link>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -360,7 +360,6 @@ export default function HomePage() {
   }, [journeyVisits, journeyManholes]);
 
   const {
-    visitsByManholeId,
     visitedCount,
     visitedPrefectureCount,
     visitedPokemonSpecies,
@@ -881,14 +880,10 @@ function VisitHistoryCard({ visit, hasPhoto }: { visit: JourneyVisit; hasPhoto: 
     ? [manhole.municipality, manhole.building].filter(Boolean).join('・')
     : [manhole?.prefecture, manhole?.municipality].filter(Boolean).join(' ') || 'ポケふた';
   const tags = getManholeTags(manhole, 3).map(safeTagLabel).filter(Boolean) as string[];
-  const href = manholeId ? `/manhole/${manholeId}` : '#';
 
   if (!hasPhoto) {
-    return (
-      <Link
-        href={href}
-        className="flex items-center gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-3 py-2 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-      >
+    const compactContent = (
+      <>
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border-2 border-[#B8AB96] bg-[#E9DEC9]">
           <Stamp className="h-4 w-4 text-[#A39580]" />
         </div>
@@ -905,15 +900,27 @@ function VisitHistoryCard({ visit, hasPhoto }: { visit: JourneyVisit; hasPhoto: 
             </div>
           )}
         </div>
-      </Link>
+      </>
+    );
+    if (manholeId) {
+      return (
+        <Link
+          href={`/manhole/${manholeId}`}
+          className="flex items-center gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-3 py-2 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+        >
+          {compactContent}
+        </Link>
+      );
+    }
+    return (
+      <div className="flex items-center gap-3 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-3 py-2 shadow-sm">
+        {compactContent}
+      </div>
     );
   }
 
-  return (
-    <Link
-      href={href}
-      className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-    >
+  const photoCardContent = (
+    <>
       <div className="relative aspect-square overflow-hidden bg-[#E9DEC9]">
         {photo?.thumbnail_url ? (
           <img
@@ -941,6 +948,22 @@ function VisitHistoryCard({ visit, hasPhoto }: { visit: JourneyVisit; hasPhoto: 
           ))}
         </div>
       )}
-    </Link>
+    </>
+  );
+
+  if (manholeId) {
+    return (
+      <Link
+        href={`/manhole/${manholeId}`}
+        className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
+      >
+        {photoCardContent}
+      </Link>
+    );
+  }
+  return (
+    <div className="overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm">
+      {photoCardContent}
+    </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,12 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import type { ReactNode } from 'react';
 import Link from 'next/link';
 import {
-  Award,
   Camera,
   ChevronLeft,
   ChevronRight,
   CircleDot,
-  Compass,
   MapPin,
   Navigation,
   PlusCircle,
@@ -23,7 +20,6 @@ import StampBookMockup from '@/components/StampBookMockup';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { formatDateJa } from '@/lib/date';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
-import { calculateDistance, isValidCoordinates } from '@/lib/location';
 
 type FeedVisit = {
   id: string;
@@ -41,7 +37,6 @@ type FeedVisit = {
 };
 
 type GalleryTab = 'latest' | 'rare';
-type JourneyTab = 'history' | 'unvisited';
 
 const galleryTabs: Array<{ key: GalleryTab; label: string }> = [
   { key: 'latest', label: 'みんなの投稿写真' },
@@ -66,42 +61,6 @@ type JourneyManhole = Manhole & {
   photo_count?: number;
 };
 
-type PrefectureProgress = {
-  name: string;
-  total: number;
-  visited: number;
-  remaining: number;
-  rate: number;
-  unvisitedLatitude?: number;
-  unvisitedLongitude?: number;
-  distanceFromLatestKm?: number;
-};
-
-type PrefectureCandidate = PrefectureProgress & {
-  label: '制覇済み' | '制覇目前' | '旅の続き' | '近くで行けそう';
-};
-
-const journeyTabs: Array<{ key: JourneyTab; label: string }> = [
-  { key: 'history', label: '訪問履歴' },
-  { key: 'unvisited', label: '未訪問' },
-];
-
-const getJourneyTabFromUrl = (): JourneyTab => {
-  if (typeof window === 'undefined') return 'history';
-  return new URLSearchParams(window.location.search).get('tab') === 'unvisited' ? 'unvisited' : 'history';
-};
-
-const updateJourneyTabUrl = (tab: JourneyTab, hash?: string) => {
-  const url = new URL(window.location.href);
-  if (tab === 'history') {
-    url.searchParams.delete('tab');
-  } else {
-    url.searchParams.set('tab', tab);
-  }
-  url.hash = hash ? `#${hash}` : '';
-  window.history.pushState({}, '', `${url.pathname}${url.search}${url.hash}`);
-};
-
 const getDisplayName = (session: any) => {
   const metadataName = session?.user?.user_metadata?.display_name;
   const emailName = session?.user?.email?.split('@')[0];
@@ -113,18 +72,6 @@ const getMunicipality = (manhole?: Pick<Manhole, 'municipality'> & { city?: stri
 
 const getManholeTitle = (manhole?: Pick<Manhole, 'title' | 'municipality'> & { name?: string; city?: string }) =>
   manhole?.name || manhole?.title || getMunicipality(manhole);
-
-const getLatestVisit = (visits?: JourneyVisit[]) => visits?.[0];
-
-const getLatestPhoto = (visits?: JourneyVisit[]) =>
-  visits
-    ?.flatMap((visit) =>
-      visit.photos.map((photo) => ({
-        ...photo,
-        sortAt: photo.created_at || visit.shot_at,
-      }))
-    )
-    .sort((a, b) => new Date(b.sortAt).getTime() - new Date(a.sortAt).getTime())[0];
 
 const getManholeTags = (
   manhole?: Pick<Manhole, 'titles' | 'hashtags' | 'title_tags' | 'pokemons'> | null,
@@ -145,9 +92,6 @@ const getManholeTags = (
 
   return tags.slice(0, max);
 };
-
-const hasCoordinates = (manhole?: Pick<JourneyManhole, 'latitude' | 'longitude'> | null) =>
-  isValidCoordinates(manhole?.latitude, manhole?.longitude);
 
 const INTERNAL_TAG_LABELS: Record<string, string> = {
   unique_pokemon: '✨ このポケモンは全国でここだけ',
@@ -170,8 +114,6 @@ export default function HomePage() {
   const [feed, setFeed] = useState<FeedVisit[]>([]);
   const [journeyVisits, setJourneyVisits] = useState<JourneyVisit[]>([]);
   const [journeyManholes, setJourneyManholes] = useState<JourneyManhole[]>([]);
-  const [nearbyUnvisited, setNearbyUnvisited] = useState<JourneyManhole[]>([]);
-  const [nearbyStatus, setNearbyStatus] = useState<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
   const [totalUsers, setTotalUsers] = useState<number | null>(null);
   const [totalPosts, setTotalPosts] = useState<number | null>(null);
   const [manholesWithPhotos, setManholesWithPhotos] = useState<number | null>(null);
@@ -179,17 +121,8 @@ export default function HomePage() {
   const [rareManholes, setRareManholes] = useState<JourneyManhole[]>([]);
   const [rareLoaded, setRareLoaded] = useState(false);
   const [rareLoading, setRareLoading] = useState(false);
-  const [journeyTab, setJourneyTab] = useState<JourneyTab>('history');
   const feedPerPage = 24;
   const { trackView, trackCollectionOpen, updateUserProperties } = useAnalytics();
-
-  const selectJourneyTab = (tab: JourneyTab, hash?: string) => {
-    setJourneyTab(tab);
-    updateJourneyTabUrl(tab, hash);
-    if (hash) {
-      window.requestAnimationFrame(() => document.getElementById(hash)?.scrollIntoView({ behavior: 'smooth' }));
-    }
-  };
 
   useEffect(() => {
     document.title = 'ポケふた写真館 - ポケふた訪問記録';
@@ -224,23 +157,6 @@ export default function HomePage() {
 
     loadSiteStats();
   }, []);
-
-  useEffect(() => {
-    setJourneyTab(getJourneyTabFromUrl());
-
-    const handlePopState = () => {
-      setJourneyTab(getJourneyTabFromUrl());
-    };
-
-    window.addEventListener('popstate', handlePopState);
-    return () => window.removeEventListener('popstate', handlePopState);
-  }, []);
-
-  useEffect(() => {
-    if (!loading && journeyTab === 'unvisited' && window.location.hash === '#journey-unvisited') {
-      window.requestAnimationFrame(() => document.getElementById('journey-unvisited')?.scrollIntoView());
-    }
-  }, [journeyTab, loading]);
 
   useEffect(() => {
     loadFeed();
@@ -342,37 +258,6 @@ export default function HomePage() {
     }
   };
 
-  const loadNearbyUnvisited = async () => {
-    if (!navigator.geolocation) {
-      setNearbyStatus('unavailable');
-      return;
-    }
-
-    setNearbyStatus('loading');
-    navigator.geolocation.getCurrentPosition(
-      async (position) => {
-        try {
-          const { latitude, longitude } = position.coords;
-          const response = await fetch(
-            `/api/manholes?lat=${latitude}&lng=${longitude}&radius=30&visited=false&limit=4`
-          );
-          if (!response.ok) {
-            setNearbyStatus('unavailable');
-            return;
-          }
-          const data = await response.json();
-          setNearbyUnvisited(Array.isArray(data.manholes) ? data.manholes : []);
-          setNearbyStatus('ready');
-        } catch (error) {
-          console.error('Failed to load nearby unvisited:', error);
-          setNearbyStatus('unavailable');
-        }
-      },
-      () => setNearbyStatus('unavailable'),
-      { maximumAge: 1000 * 60 * 10, timeout: 6000 }
-    );
-  };
-
   const sortedFeed = [...feed].sort(
     (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
   );
@@ -437,82 +322,21 @@ export default function HomePage() {
     });
 
     const allJourneyManholes = Array.from(journeyManholesById.values());
-    const unvisitedManholes = allJourneyManholes
-      .filter((manhole) => !visitsByManholeId.has(manhole.id))
-      .sort((a, b) => `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(`${b.prefecture}${getMunicipality(b)}${b.id}`, 'ja'));
-    const visitedManholes = allJourneyManholes
-      .filter((manhole) => visitsByManholeId.has(manhole.id))
-      .sort((a, b) => {
-        const aVisit = getLatestVisit(visitsByManholeId.get(a.id));
-        const bVisit = getLatestVisit(visitsByManholeId.get(b.id));
-        return new Date(bVisit?.shot_at || 0).getTime() - new Date(aVisit?.shot_at || 0).getTime();
-      });
 
-    const latestVisitedManhole = visitedManholes.find(hasCoordinates);
-    const prefectureProgress: PrefectureProgress[] = Array.from(
+    const prefectureProgress = Array.from(
       allJourneyManholes.reduce((map, manhole) => {
         const name = manhole.prefecture || '都道府県未設定';
-        const current = map.get(name) || {
-          totalIds: new Set<number>(),
-          visitedIds: new Set<number>(),
-          unvisitedLatitudeSum: 0,
-          unvisitedLongitudeSum: 0,
-          unvisitedCoordinateCount: 0,
-        };
+        const current = map.get(name) ?? { totalIds: new Set<number>(), visitedIds: new Set<number>() };
         current.totalIds.add(manhole.id);
-        if (visitsByManholeId.has(manhole.id)) {
-          current.visitedIds.add(manhole.id);
-        } else if (hasCoordinates(manhole)) {
-          current.unvisitedLatitudeSum += manhole.latitude!;
-          current.unvisitedLongitudeSum += manhole.longitude!;
-          current.unvisitedCoordinateCount += 1;
-        }
+        if (visitsByManholeId.has(manhole.id)) current.visitedIds.add(manhole.id);
         map.set(name, current);
         return map;
-      }, new Map<string, {
-        totalIds: Set<number>;
-        visitedIds: Set<number>;
-        unvisitedLatitudeSum: number;
-        unvisitedLongitudeSum: number;
-        unvisitedCoordinateCount: number;
-      }>())
-    )
-      .map(([name, value]) => {
-        const total = value.totalIds.size;
-        const visited = value.visitedIds.size;
-        const unvisitedLatitude =
-          value.unvisitedCoordinateCount > 0 ? value.unvisitedLatitudeSum / value.unvisitedCoordinateCount : undefined;
-        const unvisitedLongitude =
-          value.unvisitedCoordinateCount > 0 ? value.unvisitedLongitudeSum / value.unvisitedCoordinateCount : undefined;
-        const distanceFromLatestKm =
-          latestVisitedManhole &&
-          typeof unvisitedLatitude === 'number' &&
-          typeof unvisitedLongitude === 'number'
-            ? calculateDistance(
-                latestVisitedManhole.latitude!,
-                latestVisitedManhole.longitude!,
-                unvisitedLatitude,
-                unvisitedLongitude
-              )
-            : undefined;
-        return {
-          name,
-          total,
-          visited,
-          remaining: Math.max(total - visited, 0),
-          rate: total > 0 ? (visited / total) * 100 : 0,
-          unvisitedLatitude,
-          unvisitedLongitude,
-          distanceFromLatestKm,
-        };
-      })
-      .sort((a, b) => {
-        const aNearComplete = a.remaining > 0 ? a.remaining : 999;
-        const bNearComplete = b.remaining > 0 ? b.remaining : 999;
-        if (aNearComplete !== bNearComplete) return aNearComplete - bNearComplete;
-        if (b.visited !== a.visited) return b.visited - a.visited;
-        return a.name.localeCompare(b.name, 'ja');
-      });
+      }, new Map<string, { totalIds: Set<number>; visitedIds: Set<number> }>())
+    ).map(([name, value]) => {
+      const total = value.totalIds.size;
+      const visited = value.visitedIds.size;
+      return { name, total, visited, remaining: Math.max(total - visited, 0) };
+    });
 
     const visitedPrefectureCount = prefectureProgress.filter((p) => p.visited > 0).length;
     const allPokemonSpecies = new Set<string>(allJourneyManholes.flatMap((m) => m.pokemons ?? []));
@@ -520,96 +344,10 @@ export default function HomePage() {
     const visitedPokemonSpeciesSet = new Set<string>(journeyVisits.flatMap((v) => v.manhole?.pokemons ?? []));
     const nextAchievement = prefectureProgress
       .filter((p) => p.visited > 0 && p.remaining > 0)
-      .reduce<PrefectureProgress | null>(
+      .reduce<{ name: string; visited: number; total: number; remaining: number } | null>(
         (best, p) => (!best || p.remaining < best.remaining) ? p : best,
         null
       );
-
-    const nearbyIds = new Set<number>();
-    const nearbyCandidates = nearbyUnvisited
-      .filter((manhole) => !visitsByManholeId.has(manhole.id))
-      .slice(0, 4)
-      .map((manhole) => {
-        nearbyIds.add(manhole.id);
-        return manhole;
-      });
-    const recentCandidates = unvisitedManholes
-      .filter((manhole) => !nearbyIds.has(manhole.id))
-      .sort((a, b) => {
-        const dateDiff = new Date(b.created_at || 0).getTime() - new Date(a.created_at || 0).getTime();
-        return dateDiff !== 0 ? dateDiff : b.id - a.id;
-      })
-      .slice(0, 4);
-
-    const completedPrefectures = prefectureProgress
-      .filter((prefecture) => prefecture.total > 0 && prefecture.remaining === 0)
-      .sort((a, b) => {
-        if (b.total !== a.total) return b.total - a.total;
-        return a.name.localeCompare(b.name, 'ja');
-      });
-    const unfinishedPrefectures = prefectureProgress.filter(
-      (prefecture) => prefecture.total > 0 && prefecture.remaining > 0
-    );
-    const continuingPrefecture =
-      unfinishedPrefectures
-        .filter((prefecture) => prefecture.visited > 0)
-        .sort((a, b) => {
-          if (a.remaining !== b.remaining) return a.remaining - b.remaining;
-          if (b.visited !== a.visited) return b.visited - a.visited;
-          return a.name.localeCompare(b.name, 'ja');
-        })[0] || null;
-    const nextPrefectureCandidates: PrefectureCandidate[] = unfinishedPrefectures
-      .map((prefecture) => {
-        const isNearComplete = prefecture.visited > 0 && prefecture.remaining <= 3;
-        const hasNearbySignal = typeof prefecture.distanceFromLatestKm === 'number';
-        const label: PrefectureCandidate['label'] = isNearComplete
-          ? '制覇目前'
-          : hasNearbySignal
-            ? '近くで行けそう'
-            : '旅の続き';
-        return { ...prefecture, label };
-      })
-      .sort((a, b) => {
-        const aNearComplete = a.visited > 0 && a.remaining <= 3 ? 0 : 1;
-        const bNearComplete = b.visited > 0 && b.remaining <= 3 ? 0 : 1;
-        if (aNearComplete !== bNearComplete) return aNearComplete - bNearComplete;
-
-        const aDistance = a.distanceFromLatestKm ?? Number.POSITIVE_INFINITY;
-        const bDistance = b.distanceFromLatestKm ?? Number.POSITIVE_INFINITY;
-        if (aDistance !== bDistance) return aDistance - bDistance;
-
-        if (b.remaining !== a.remaining) return b.remaining - a.remaining;
-        if (b.visited !== a.visited) return b.visited - a.visited;
-        return a.name.localeCompare(b.name, 'ja');
-      })
-      .slice(0, 3);
-    const progressByPrefecture = new Map(prefectureProgress.map((prefecture) => [prefecture.name, prefecture]));
-    const usedUnvisitedCandidateIds = new Set(
-      [...nearbyCandidates, ...recentCandidates].map((manhole) => manhole.id)
-    );
-    const journeyContinuationCandidates = unvisitedManholes
-      .filter((manhole) => !usedUnvisitedCandidateIds.has(manhole.id))
-      .sort((a, b) => {
-        const aProgress = progressByPrefecture.get(a.prefecture || '都道府県未設定');
-        const bProgress = progressByPrefecture.get(b.prefecture || '都道府県未設定');
-        const aSameAsContinuing = continuingPrefecture && a.prefecture === continuingPrefecture.name ? 0 : 1;
-        const bSameAsContinuing = continuingPrefecture && b.prefecture === continuingPrefecture.name ? 0 : 1;
-        if (aSameAsContinuing !== bSameAsContinuing) return aSameAsContinuing - bSameAsContinuing;
-
-        const aVisited = aProgress?.visited ?? 0;
-        const bVisited = bProgress?.visited ?? 0;
-        if (bVisited !== aVisited) return bVisited - aVisited;
-
-        const aRemaining = aProgress?.remaining ?? Number.POSITIVE_INFINITY;
-        const bRemaining = bProgress?.remaining ?? Number.POSITIVE_INFINITY;
-        if (aRemaining !== bRemaining) return aRemaining - bRemaining;
-
-        return `${a.prefecture}${getMunicipality(a)}${a.id}`.localeCompare(
-          `${b.prefecture}${getMunicipality(b)}${b.id}`,
-          'ja'
-        );
-      })
-      .slice(0, 4);
 
     return {
       visitsByManholeId,
@@ -618,15 +356,8 @@ export default function HomePage() {
       visitedPokemonSpecies: visitedPokemonSpeciesSet.size,
       totalPokemonSpecies: allPokemonSpecies.size,
       nextAchievement,
-      visitedManholes,
-      completedPrefectures,
-      continuingPrefecture,
-      nextPrefectureCandidates,
-      nearbyCandidates,
-      recentCandidates,
-      journeyContinuationCandidates,
     };
-  }, [journeyVisits, journeyManholes, nearbyUnvisited]);
+  }, [journeyVisits, journeyManholes]);
 
   const {
     visitsByManholeId,
@@ -635,13 +366,6 @@ export default function HomePage() {
     visitedPokemonSpecies,
     totalPokemonSpecies,
     nextAchievement,
-    visitedManholes,
-    completedPrefectures,
-    continuingPrefecture,
-    nextPrefectureCandidates,
-    nearbyCandidates,
-    recentCandidates,
-    journeyContinuationCandidates,
   } = journeyData;
   const completionRate = knownTotalManholes ? (visitedCount / knownTotalManholes) * 100 : null;
 
@@ -748,93 +472,20 @@ export default function HomePage() {
                 </section>
 
                 <section className="mt-6">
-                  <div className="-mx-4 overflow-x-auto px-4 pb-1">
-                    <div className="flex min-w-max gap-2 rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5]/90 p-1 shadow-sm sm:min-w-0">
-                      {journeyTabs.map((tab) => {
-                        const isActive = journeyTab === tab.key;
-                        return (
-                          <button
-                            key={tab.key}
-                            type="button"
-                            onClick={() => selectJourneyTab(tab.key)}
-                            className={`min-h-[44px] rounded-[7px] px-5 text-sm font-bold transition ${
-                              isActive
-                                ? 'bg-[#4F3828] text-[#FFF7E5] shadow-sm'
-                                : 'text-[#4F3828] hover:bg-white'
-                            }`}
-                          >
-                            {tab.label}
-                          </button>
-                        );
-                      })}
+                  {visitsByMonth.length === 0 ? (
+                    <JourneyEmptyState
+                      title="まだ訪問履歴がありません"
+                      description="最初の訪問を記録すると、ここに写真つきの旅のアルバムが育っていきます。"
+                      uploadHref={uploadHref}
+                    />
+                  ) : (
+                    <div className="space-y-8">
+                      {visitsByMonth.map(({ label, visits }) => (
+                        <VisitMonthGroup key={label} label={label} visits={visits} />
+                      ))}
                     </div>
-                  </div>
+                  )}
                 </section>
-
-                {journeyTab === 'history' ? (
-                  <section className="mt-6">
-                    {visitsByMonth.length === 0 ? (
-                      <JourneyEmptyState
-                        title="まだ訪問履歴がありません"
-                        description="最初の訪問を記録すると、ここに写真つきの旅のアルバムが育っていきます。"
-                        uploadHref={uploadHref}
-                      />
-                    ) : (
-                      <div className="space-y-8">
-                        {visitsByMonth.map(({ label, visits }) => (
-                          <VisitMonthGroup key={label} label={label} visits={visits} />
-                        ))}
-                      </div>
-                    )}
-                  </section>
-                ) : (
-                  <section className="mt-6 space-y-6">
-                    <JourneyCandidateSection
-                      title="近くにある未訪問"
-                      description="今いる場所から寄り道しやすい候補"
-                      action={
-                        <button
-                          type="button"
-                          onClick={loadNearbyUnvisited}
-                          disabled={nearbyStatus === 'loading'}
-                          className="min-h-[40px] rounded-[7px] border border-[#8C6A4A]/20 bg-white px-3 text-xs font-extrabold text-[#4F3828] transition hover:bg-[#F8D9C4] disabled:opacity-60"
-                        >
-                          {nearbyStatus === 'loading' ? '確認中...' : '近く候補を更新'}
-                        </button>
-                      }
-                    >
-                      {nearbyCandidates.length > 0 ? (
-                        nearbyCandidates.map((manhole) => (
-                          <JourneyUnvisitedCard key={manhole.id} manhole={manhole} badge="近くで行けそう" />
-                        ))
-                      ) : (
-                        <JourneyCandidateNotice
-                          text={nearbyStatus === 'unavailable' ? '位置情報が使えませんでした。最近追加の候補から探せます。' : '位置情報を使うと近くの未訪問を4件表示できます。'}
-                        />
-                      )}
-                    </JourneyCandidateSection>
-
-                    <JourneyCandidateSection title="最近できた未訪問" description="新しく追加されたポケふたから次の目的地を探す">
-                      {recentCandidates.length > 0 ? (
-                        recentCandidates.map((manhole) => (
-                          <JourneyUnvisitedCard key={manhole.id} manhole={manhole} badge="NEW" />
-                        ))
-                      ) : (
-                        <JourneyCandidateNotice text="最近追加された未訪問候補を準備中です。" />
-                      )}
-                    </JourneyCandidateSection>
-
-                    <JourneyCandidateSection id="journey-unvisited" title="旅の続きを見る" description="新しい目的地を地図から探す前の候補">
-                      {journeyContinuationCandidates.length > 0 ? (
-                        journeyContinuationCandidates.map((manhole) => (
-                          <JourneyUnvisitedCard key={manhole.id} manhole={manhole} badge="旅の続き" />
-                        ))
-                      ) : (
-                        <JourneyCandidateNotice text="未訪問候補を準備中です。" />
-                      )}
-                    </JourneyCandidateSection>
-                  </section>
-                )}
               </>
             ) : (
               <>
@@ -1122,283 +773,6 @@ export default function HomePage() {
   );
 }
 
-function JourneyPrefectureOverview({
-  completedPrefectures,
-  continuingPrefecture,
-  userId,
-}: {
-  completedPrefectures: PrefectureProgress[];
-  continuingPrefecture: PrefectureProgress | null;
-  userId: string | null;
-}) {
-  return (
-    <div className="mt-5 space-y-4">
-      <div>
-        <div className="mb-2 flex items-center gap-2 text-xs font-extrabold text-[#2C765E]">
-          <Award className="h-4 w-4" />
-          制覇済み
-        </div>
-        {completedPrefectures.length > 0 ? (
-          <div className="grid gap-3 sm:grid-cols-2">
-            {completedPrefectures.slice(0, 8).map((prefecture) => (
-              <JourneyPrefectureStat
-                key={prefecture.name}
-                prefecture={prefecture}
-                label="制覇済み"
-                userId={userId}
-              />
-            ))}
-          </div>
-        ) : (
-          <div className="rounded-[7px] border border-dashed border-[#8C6A4A]/25 bg-[#FFF7E5] px-3 py-3 text-xs font-bold text-[#6A4D36]">
-            はじめての県制覇まで、旅の記録を重ねていこう。
-          </div>
-        )}
-      </div>
-
-      <div>
-        <div className="mb-2 flex items-center gap-2 text-xs font-extrabold text-[#6A4D36]">
-          <Compass className="h-4 w-4 text-[#8C6A4A]" />
-          旅の続き
-        </div>
-        {continuingPrefecture ? (
-          <JourneyPrefectureStat prefecture={continuingPrefecture} label="旅の続き" userId={userId} />
-        ) : (
-          <div className="rounded-[7px] border border-dashed border-[#8C6A4A]/25 bg-[#FFF7E5] px-3 py-3 text-xs font-bold text-[#6A4D36]">
-            訪問を記録すると、続きにしたい県がここに出ます。
-          </div>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function JourneyPrefectureStat({
-  prefecture,
-  label,
-  userId,
-}: {
-  prefecture: PrefectureProgress;
-  label?: PrefectureCandidate['label'];
-  userId?: string | null;
-}) {
-  const complete = prefecture.total > 0 && prefecture.remaining === 0;
-  const displayLabel = label || (complete ? '制覇済み' : '旅の続き');
-  const content = (
-    <>
-      <div className="mb-2 flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="truncate text-sm font-extrabold text-[#4F3828]">{prefecture.name}</p>
-          <p className="mt-1 font-pixel text-sm leading-none text-[#B5483C]">
-            {prefecture.visited} / {prefecture.total}
-          </p>
-        </div>
-        <span className={`shrink-0 rounded-full px-2 py-1 text-[11px] font-extrabold ${
-          complete
-            ? 'bg-[#E6F4DD] text-[#2C765E]'
-            : displayLabel === '制覇目前'
-              ? 'bg-[#FFF0C7] text-[#8C6315]'
-              : displayLabel === '近くで行けそう'
-                ? 'bg-white text-[#B5483C]'
-                : 'bg-[#EFE2CE] text-[#6A4D36]'
-        }`}>
-          {displayLabel}
-        </span>
-      </div>
-      <div className="h-2 overflow-hidden rounded-sm border border-[#8C6A4A]/10 bg-[#E4D4B8]">
-        <div
-          className={`h-full ${complete ? 'bg-[#2C765E]' : 'bg-[#8C6A4A]'}`}
-          style={{ width: `${Math.min(prefecture.rate, 100)}%` }}
-        />
-      </div>
-      <div className="mt-2 flex items-center justify-between gap-2 text-[11px] font-bold text-[#6A4D36]">
-        <span>{complete ? '制覇済み' : `あと${prefecture.remaining}枚`}</span>
-        <span>{prefecture.rate.toFixed(0)}%</span>
-      </div>
-    </>
-  );
-
-  if (!userId) {
-    return (
-      <div className="rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm">
-        {content}
-      </div>
-    );
-  }
-
-  return (
-    <Link
-      href={`/users/${encodeURIComponent(userId)}/prefectures?prefecture=${encodeURIComponent(prefecture.name)}`}
-      className="block rounded-[7px] border border-[#8C6A4A]/15 bg-[#FFF7E5] p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-      aria-label={`${prefecture.name}の達成状況を見る`}
-    >
-      {content}
-    </Link>
-  );
-}
-
-function JourneyHistoryCard({ manhole, visits }: { manhole: JourneyManhole; visits?: JourneyVisit[] }) {
-  const latestVisit = getLatestVisit(visits);
-  const latestPhoto = getLatestPhoto(visits);
-  const visitCount = visits?.length ?? 0;
-  const photoCount = visits?.reduce((count, visit) => count + visit.photos.length, 0) ?? 0;
-  const tags = getManholeTags(manhole, 4);
-
-  return (
-    <Link
-      href={`/manhole/${manhole.id}`}
-      className="group overflow-hidden rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-    >
-      <div className="relative aspect-[4/3] overflow-hidden bg-[#E9DEC9]">
-        {latestPhoto?.thumbnail_url ? (
-          <img
-            src={latestPhoto.thumbnail_url}
-            alt=""
-            className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <div className="flex h-24 w-24 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#D94D3F] bg-white/60 text-center text-[#D94D3F] shadow-[inset_0_2px_8px_rgba(181,72,60,0.12)]">
-              <div>
-                <CircleDot className="mx-auto h-7 w-7" />
-                <p className="mt-1 font-pixel text-[10px] leading-none">POKEFUTA</p>
-              </div>
-            </div>
-          </div>
-        )}
-        <div className="absolute left-2 top-2 rounded-[6px] bg-[#D94D3F] px-2 py-1 text-xs font-extrabold text-white shadow-sm">
-          訪問済み
-        </div>
-        <div className="absolute bottom-2 right-2 flex gap-1">
-          {photoCount > 0 && (
-            <span className="inline-flex items-center gap-1 rounded-full bg-black/70 px-2 py-1 text-xs font-bold text-white">
-              <Camera className="h-3.5 w-3.5" />
-              {photoCount}
-            </span>
-          )}
-          {visitCount > 1 && (
-            <span className="rounded-full bg-[#4F3828] px-2 py-1 font-pixel text-xs text-white">
-              x{visitCount}
-            </span>
-          )}
-        </div>
-      </div>
-
-      <div className="p-3">
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <p className="line-clamp-1 text-base font-extrabold text-[#4F3828]">
-              {manhole.prefecture}{manhole.municipality ? ` ${manhole.municipality}` : ''}
-            </p>
-            {manhole.building && (
-              <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.building}</p>
-            )}
-          </div>
-          {latestVisit && (
-            <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] font-bold text-[#B5483C]">
-              {formatDateJa(latestVisit.shot_at)}
-            </span>
-          )}
-        </div>
-        <div className="mt-3 flex flex-wrap gap-1.5">
-          {tags.length > 0 ? (
-            tags.map((tag) => (
-              <span key={tag} className="rounded-full border border-[#8C6A4A]/15 bg-white/80 px-2 py-1 text-[11px] font-bold text-[#6A4D36]">
-                {tag}
-              </span>
-            ))
-          ) : (
-            <span className="rounded-full border border-[#8C6A4A]/15 bg-white/80 px-2 py-1 text-[11px] font-bold text-[#6A4D36]">
-              {getManholeTitle(manhole)}
-            </span>
-          )}
-        </div>
-      </div>
-    </Link>
-  );
-}
-
-function JourneyCandidateSection({
-  id,
-  title,
-  description,
-  action,
-  children,
-}: {
-  id?: string;
-  title: string;
-  description: string;
-  action?: ReactNode;
-  children: ReactNode;
-}) {
-  return (
-    <div id={id}>
-      <div className="mb-3 flex items-end justify-between gap-3">
-        <div>
-          <h2 className="text-lg font-extrabold text-[#4F3828]">{title}</h2>
-          <p className="mt-1 text-xs font-bold text-[#6A4D36]">{description}</p>
-        </div>
-        {action}
-      </div>
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">{children}</div>
-    </div>
-  );
-}
-
-function JourneyUnvisitedCard({ manhole, badge }: { manhole: JourneyManhole; badge: string }) {
-  const tags = getManholeTags(manhole, 3);
-
-  return (
-    <Link
-      href={`/manhole/${manhole.id}`}
-      className="group relative flex min-h-[210px] flex-col justify-between overflow-hidden rounded-[8px] border-2 border-dashed border-[#8C6A4A]/25 bg-[#E9DEC9] p-3 shadow-sm transition hover:-translate-y-0.5 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-[#DDA63A]"
-    >
-      <div className="absolute inset-0 opacity-[0.06] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:16px_16px]" />
-      <div className="relative flex items-center justify-between gap-2">
-        <span className="rounded-full bg-[#D5C8B3] px-2 py-1 text-[11px] font-extrabold text-[#7D715F]">
-          未訪問
-        </span>
-        <span className="rounded-full bg-white px-2 py-1 text-[11px] font-extrabold text-[#B5483C]">
-          {typeof manhole.distance === 'number' ? `${manhole.distance.toFixed(1)}km` : badge}
-        </span>
-      </div>
-
-      <div className="relative flex flex-1 items-center justify-center py-4">
-        <div className="flex h-20 w-20 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580]">
-          <div>
-            <Stamp className="mx-auto h-6 w-6" />
-            <p className="mt-1 font-pixel text-[10px] leading-none">NEXT</p>
-          </div>
-        </div>
-      </div>
-
-      <div className="relative">
-        <p className="line-clamp-1 text-sm font-extrabold text-[#4F3828]">
-          {manhole.prefecture}{manhole.municipality ? ` ${manhole.municipality}` : ''}
-        </p>
-        {manhole.building && (
-          <p className="mt-1 line-clamp-1 text-xs font-bold text-[#6A4D36]">{manhole.building}</p>
-        )}
-        <div className="mt-2 flex flex-wrap gap-1">
-          {(tags.length > 0 ? tags : [getManholeTitle(manhole)]).slice(0, 3).map((tag) => (
-            <span key={tag} className="rounded-full bg-white/70 px-2 py-0.5 text-[10px] font-bold text-[#6A4D36]">
-              {tag}
-            </span>
-          ))}
-        </div>
-      </div>
-    </Link>
-  );
-}
-
-function JourneyCandidateNotice({ text }: { text: string }) {
-  return (
-    <div className="col-span-full rounded-[8px] border border-[#8C6A4A]/15 bg-[#FFF7E5] px-4 py-5 text-sm font-bold text-[#6A4D36] shadow-sm">
-      {text}
-    </div>
-  );
-}
 
 function RareManholeCard({ manhole }: { manhole: JourneyManhole }) {
   const tags = getManholeTags(manhole, 3);

--- a/src/components/ApiErrorAnalytics.tsx
+++ b/src/components/ApiErrorAnalytics.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { useEffect } from 'react';
-import { errorEvents } from '@/lib/analytics/gtag';
+import { useEffect, useRef } from 'react';
+import { createBrowserClient } from '@/lib/supabase/client';
+import { errorEvents, setAnalyticsAuthState } from '@/lib/analytics/gtag';
 
 const API_ERROR_ANALYTICS_PATCHED = Symbol.for('pokefuta.apiErrorAnalyticsPatched');
 
@@ -38,7 +39,41 @@ function getMethod(input: RequestInfo | URL, init?: RequestInit): string {
   return 'GET';
 }
 
+function derivePageType(pathname: string): string {
+  if (/^\/manhole\//.test(pathname)) return 'manhole_detail';
+  if (pathname === '/') return 'gallery_index';
+  if (pathname === '/visits') return 'visits';
+  if (pathname === '/popular') return 'popular';
+  if (pathname === '/upload') return 'upload';
+  if (pathname === '/login') return 'login';
+  if (pathname === '/signup') return 'signup';
+  if (/^\/prefecture\//.test(pathname)) return 'prefecture';
+  if (/^\/user\//.test(pathname)) return 'user_profile';
+  if (pathname === '/nearby') return 'nearby';
+  return 'other';
+}
+
 export default function ApiErrorAnalytics() {
+  const isLoggedInRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    const supabase = createBrowserClient();
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      const v = Boolean(session?.user);
+      isLoggedInRef.current = v;
+      setAnalyticsAuthState(v);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      const v = Boolean(session?.user);
+      isLoggedInRef.current = v;
+      setAnalyticsAuthState(v);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
   useEffect(() => {
     const patchedWindow = window as PatchedWindow;
 
@@ -55,7 +90,11 @@ export default function ApiErrorAnalytics() {
         const response = await originalFetch(input, init);
 
         if (apiPath && !response.ok) {
-          errorEvents.api(apiPath, response.status, method, response.statusText);
+          errorEvents.api(apiPath, response.status, method, response.statusText, {
+            is_logged_in: isLoggedInRef.current === null ? 'unknown' : isLoggedInRef.current,
+            page_type: derivePageType(window.location.pathname),
+            component: 'ApiErrorAnalytics',
+          });
         }
 
         return response;
@@ -65,7 +104,12 @@ export default function ApiErrorAnalytics() {
             apiPath,
             0,
             method,
-            error instanceof Error ? error.message : 'Network request failed'
+            error instanceof Error ? error.message : 'Network request failed',
+            {
+              is_logged_in: isLoggedInRef.current === null ? 'unknown' : isLoggedInRef.current,
+              page_type: derivePageType(window.location.pathname),
+              component: 'ApiErrorAnalytics',
+            }
           );
         }
 

--- a/src/components/ApiErrorAnalytics.tsx
+++ b/src/components/ApiErrorAnalytics.tsx
@@ -48,7 +48,7 @@ function derivePageType(pathname: string): string {
   if (pathname === '/login') return 'login';
   if (pathname === '/signup') return 'signup';
   if (/^\/prefecture\//.test(pathname)) return 'prefecture';
-  if (/^\/user\//.test(pathname)) return 'user_profile';
+  if (/^\/users\//.test(pathname)) return 'user_profile';
   if (pathname === '/nearby') return 'nearby';
   return 'other';
 }
@@ -57,21 +57,27 @@ export default function ApiErrorAnalytics() {
   const isLoggedInRef = useRef<boolean | null>(null);
 
   useEffect(() => {
-    const supabase = createBrowserClient();
+    try {
+      const supabase = createBrowserClient();
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      const v = Boolean(session?.user);
-      isLoggedInRef.current = v;
-      setAnalyticsAuthState(v);
-    });
+      supabase.auth.getSession()
+        .then(({ data: { session } }) => {
+          const v = Boolean(session?.user);
+          isLoggedInRef.current = v;
+          setAnalyticsAuthState(v);
+        })
+        .catch(() => {});
 
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      const v = Boolean(session?.user);
-      isLoggedInRef.current = v;
-      setAnalyticsAuthState(v);
-    });
+      const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+        const v = Boolean(session?.user);
+        isLoggedInRef.current = v;
+        setAnalyticsAuthState(v);
+      });
 
-    return () => subscription.unsubscribe();
+      return () => subscription.unsubscribe();
+    } catch {
+      // analytics auth tracking is non-fatal
+    }
   }, []);
 
   useEffect(() => {

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -31,6 +31,9 @@ export interface ApiErrorEventParams extends GAEventParams {
   status_code: number;
   method: string;
   error_message?: string;
+  is_logged_in?: boolean | 'unknown';
+  page_type?: string;
+  component?: string;
 }
 
 // ==========================================
@@ -57,6 +60,17 @@ function isGtagAvailable(): boolean {
 }
 
 // ==========================================
+// auth 状態（全イベント自動付与用）
+// ==========================================
+
+let _analyticsIsLoggedIn: boolean | null = null;
+
+/** ApiErrorAnalytics や認証フローから呼ぶ。全イベントに is_logged_in が自動付与される。 */
+export function setAnalyticsAuthState(isLoggedIn: boolean): void {
+  _analyticsIsLoggedIn = isLoggedIn;
+}
+
+// ==========================================
 // コア関数: イベント送信
 // ==========================================
 
@@ -78,6 +92,7 @@ export function trackEvent(
     page_title: isClientSide() ? document.title : undefined,
     event_timestamp: new Date().toISOString(),
     user_locale: navigator.language || 'ja-JP',
+    is_logged_in: _analyticsIsLoggedIn !== null ? _analyticsIsLoggedIn : undefined,
     ...context,
     ...eventParams,
   };
@@ -228,7 +243,8 @@ export const errorEvents = {
     endpoint: string,
     statusCode: number,
     method: string = 'GET',
-    errorMessage?: string
+    errorMessage?: string,
+    additionalParams?: Partial<ApiErrorEventParams>
   ) =>
     trackEvent('error_event', {
       error_type: 'api_error',
@@ -237,6 +253,7 @@ export const errorEvents = {
       status_code: statusCode,
       method,
       error_message: errorMessage?.slice(0, 100),
+      ...additionalParams,
     } satisfies ApiErrorEventParams),
 
   auth: (errorCode: string) =>

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -244,7 +244,7 @@ export const errorEvents = {
     statusCode: number,
     method: string = 'GET',
     errorMessage?: string,
-    additionalParams?: Partial<ApiErrorEventParams>
+    additionalParams?: Pick<ApiErrorEventParams, 'is_logged_in' | 'page_type' | 'component'>
   ) =>
     trackEvent('error_event', {
       error_type: 'api_error',


### PR DESCRIPTION
## Summary

- **Phase 1: UI統一** — `/`のログイン後ヘッダーを `/visits` のスタイルに統一。大きい「まいたび」カードを廃止し、POKEFUTA PASSPORTコンパクトカードに置き換え。全国/都道府県/ポケモンの3統計 + 次の達成1件を表示。
- **Phase 1: CTA整理** — フローティングFABを廃止し、`/visits` と同じ固定ボトムCTAバー（訪問を記録 / スタンプ帳）に統一。ヘッダー内にも3カラムCTA（訪問を記録 / スタンプ帳 / 近くを探す）を追加。
- **Phase 2: まい旅再設計** — 訪問履歴タブを月別グループ表示に変更。写真あり訪問は2カラム写真グリッド、写真なし訪問はコンパクト行で表示し、写真つき訪問を優先的に見せる。
- **Phase 3: タブUI削除** — トップページ上部の「訪問履歴/未訪問」タブを削除。未訪問機能は `/visits` の未訪問タブ・`/nearby` に集約。

## Changes

- `POKEFUTA PASSPORT` ヘッダーカード（`/visits` と同レイアウト）
- 全国達成率プログレスバー + 3統計グリッド + 次の達成行
- `visitedPrefectureCount` / `visitedPokemonSpecies` / `totalPokemonSpecies` / `nextAchievement` を `journeyData` useMemo に追加
- `visitsByMonth` useMemo で訪問を月別グループ化
- `VisitMonthGroup` / `VisitHistoryCard` 新コンポーネント追加（manhole_id が null の場合は非クリック `div` にフォールバック）
- `pb-[10rem]` でボトムバーと BottomNav に重ならないよう調整
- 訪問履歴/未訪問タブ・関連コンポーネント群を全削除（JourneyPrefectureOverview等6コンポーネント）

## Test plan

- [ ] ログイン後トップページ（`/`）でパスポートカードが表示されること
- [ ] 全国/都道府県/ポケモン統計が正しく表示されること
- [ ] 次の達成行が未達成都道府県のある場合に表示されること
- [ ] 3カラムCTAボタンが正しくリンクされていること
- [ ] ボトムCTAバーが表示され、訪問を記録・スタンプ帳リンクが機能すること
- [ ] 訪問履歴が月別グループ（2026年N月）で表示されること
- [ ] 写真あり訪問は2カラムグリッド、写真なし訪問はコンパクト行で表示されること
- [ ] 訪問履歴/未訪問タブが**表示されないこと**（削除済み）
- [ ] 未訪問機能が `/visits` の未訪問タブで引き続き利用できること
- [ ] `/visits` ページが変更なく正常動作すること
- [ ] 未ログイン状態のトップページが変わらず正常表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)