### PR TITLE
写真投稿プロンプト（PhotoPrompt）実装 — 未投稿ユーザーへの写真投稿導線強化

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 /* Import Modern Japanese Fonts */
-@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700;800&family=Noto+Sans+JP:wght@400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@400;500;700;800&family=Noto+Sans+JP:wght@400;500;700&family=Outfit:wght@600;700;800&display=swap');
 
 @layer base {
   html {

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -11,6 +11,7 @@ import { ja } from 'date-fns/locale';
 import { Manhole } from '@/types/database';
 import DeletePhotoModal from '@/components/DeletePhotoModal';
 import ShareButtons from '@/components/ShareButtons';
+import PhotoPrompt from '@/components/PhotoPrompt';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import { formatDateJa } from '@/lib/date';
@@ -100,6 +101,11 @@ export default function ManholeDetailPage() {
   const [isDeleting, setIsDeleting] = useState(false);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
+  const [photosLoaded, setPhotosLoaded] = useState(false);
+  const [userLoaded, setUserLoaded] = useState(false);
+  const [prefectureDex, setPrefectureDex] = useState<{ current: number; total: number } | null>(null);
+  const [photoPromptDismissed, setPhotoPromptDismissed] = useState(false);
+
   const [manholeComments, setManholeComments] = useState<ManholeComment[]>([]);
   const [commentsLoading, setCommentsLoading] = useState(false);
   const [commentsSubmitting, setCommentsSubmitting] = useState(false);
@@ -133,6 +139,21 @@ export default function ManholeDetailPage() {
       });
     }
   }, [manhole?.id]);
+
+  // 都道府県写真図鑑の進捗をフェッチ（ログイン時のみ）
+  useEffect(() => {
+    if (!currentUserId || !manhole) return;
+    fetch('/api/badges/prefectures')
+      .then(r => r.ok ? r.json() : null)
+      .then(data => {
+        if (!data) return;
+        const badge = data.badges?.find((b: { name: string; visitedCount: number; totalManholes: number }) => b.name === manhole.prefecture);
+        if (badge) {
+          setPrefectureDex({ current: badge.visitedCount ?? 0, total: badge.totalManholes ?? 0 });
+        }
+      })
+      .catch(() => {});
+  }, [currentUserId, manhole?.id]);
 
   // Update document title and meta tags
   useEffect(() => {
@@ -209,6 +230,8 @@ export default function ManholeDetailPage() {
       }
     } catch (err) {
       console.error('Failed to load current user:', err);
+    } finally {
+      setUserLoaded(true);
     }
   };
 
@@ -248,6 +271,8 @@ export default function ManholeDetailPage() {
       }
     } catch (err) {
       console.error('Failed to load photos:', err);
+    } finally {
+      setPhotosLoaded(true);
     }
   };
 
@@ -455,6 +480,15 @@ export default function ManholeDetailPage() {
 
   const titleBadges = getSortedTitles(manhole.titles);
 
+  const viewerHasPhoto = currentUserId !== null && photos.some(p => p.visit?.user_id === currentUserId);
+  const showPhotoPrompt = photosLoaded && userLoaded && !viewerHasPhoto && !photoPromptDismissed;
+
+  const municipality = manhole.city || manhole.municipality || '';
+  const rarityTags = getSortedTitles(manhole.titles).map(t => t.label);
+  const heroImageUrl = photos.find(p => p.visit?.is_public === true)
+    ? `/api/photo/${photos.find(p => p.visit?.is_public === true)!.id}?size=small`
+    : undefined;
+
   return (
     <div className="min-h-screen safe-area-inset bg-[#F6EEDC]">
       <Header
@@ -472,169 +506,175 @@ export default function ManholeDetailPage() {
       />
 
       <div className="p-4 max-w-2xl mx-auto space-y-4 pb-32">
-        {/* Visit Achievement Hero Card */}
-        <div className="relative overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5] shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
-          <div className="absolute inset-0 opacity-[0.04] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
+        {/* Hero Section: PhotoPrompt（未投稿）or 訪問済みカード */}
+        {showPhotoPrompt ? (
+          <PhotoPrompt
+            pokefuta={{
+              id: manhole.id,
+              title: `${manhole.prefecture}${municipality}のポケふた`,
+              prefecture: manhole.prefecture,
+              area: municipality,
+              photoCount: photos.length,
+              viewerHasPhoto: false,
+              rarityTags,
+              heroImageUrl,
+            }}
+            prefectureDex={prefectureDex}
+            onPost={() => router.push(currentUserId ? '/upload' : '/login?redirect=/upload')}
+            onRoute={manhole.latitude && manhole.longitude ? openInMaps : undefined}
+            onLater={() => setPhotoPromptDismissed(true)}
+          />
+        ) : (
+          <div className="relative overflow-hidden rounded-lg border border-[#8C6A4A]/20 bg-[#FFF7E5] shadow-[0_12px_30px_rgba(95,68,42,0.13)]">
+            <div className="absolute inset-0 opacity-[0.04] [background-image:linear-gradient(90deg,#8C6A4A_1px,transparent_1px),linear-gradient(#8C6A4A_1px,transparent_1px)] [background-size:18px_18px]" />
 
-          <div className="relative">
-            {/* Status Badge - Floating on top */}
-            <div className="absolute top-4 right-4 z-10">
-              <div className={`rounded-full px-3 py-1.5 border shadow-md ${
-                manhole.is_visited
-                  ? 'border-[#B5483C]/30 bg-[#F8D9C4]'
-                  : 'border-[#8C6A4A]/25 bg-white/90 backdrop-blur'
-              }`}>
-                <span className={`font-pixelJp text-xs font-bold ${
-                  manhole.is_visited ? 'text-[#B5483C]' : 'text-[#8C6A4A]'
+            <div className="relative">
+              {/* Status Badge */}
+              <div className="absolute top-4 right-4 z-10">
+                <div className={`rounded-full px-3 py-1.5 border shadow-md ${
+                  manhole.is_visited
+                    ? 'border-[#B5483C]/30 bg-[#F8D9C4]'
+                    : 'border-[#8C6A4A]/25 bg-white/90 backdrop-blur'
                 }`}>
-                  {manhole.is_visited ? '✓ 訪問済み' : '未訪問'}
-                </span>
-              </div>
-            </div>
-
-            {/* Hero Photo Section */}
-            {(() => {
-              const userPublicPhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId && p.visit?.is_public === true);
-              const userPrivatePhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId && p.visit?.is_public !== true);
-              const publicPhoto = photos.find(p => p.visit?.is_public === true);
-              const mainPhoto = userPublicPhoto || userPrivatePhoto || publicPhoto;
-
-              return mainPhoto ? (
-                // Photo hero - prefer own public photo, then own private photo, then public community photo.
-                <div className="relative aspect-[4/3] overflow-hidden">
-                  <img
-                    src={`/api/photo/${mainPhoto.id}?size=small`}
-                    alt="訪問記念写真"
-                    className="w-full h-full object-cover"
-                    loading="lazy"
-                    onError={(e) => {
-                      e.currentTarget.style.display = 'none';
-                      const parent = e.currentTarget.parentElement;
-                      if (parent) {
-                        parent.classList.add('bg-[#E9DEC9]');
-                        parent.innerHTML = `
-                          <div class="absolute inset-0 flex items-center justify-center">
-                            <div class="text-center">
-                              <svg class="w-16 h-16 text-[#8C6A4A] opacity-30 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
-                              </svg>
-                              <p class="font-pixelJp text-xs text-[#8C6A4A]">写真を読み込めませんでした</p>
-                            </div>
-                          </div>
-                        `;
-                      }
-                    }}
-                  />
-                  {/* Gradient overlay for text readability */}
-                  <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
-
-                  {/* Achievement badge */}
-                  <div className="absolute bottom-4 right-4">
-                    <div className="bg-[#D94D3F] border-2 border-white rounded-full p-2 shadow-lg">
-                      <CheckCircle2 className="h-6 w-6 text-white" />
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                // Unvisited or no photo - Stamp placeholder
-                <div className="flex items-center justify-center py-12 bg-gradient-to-b from-[#F6EEDC] to-[#E9DEC9]">
-                  <div className="flex h-32 w-32 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580] bg-white/50 shadow-lg">
-                    <div>
-                      <Stamp className="mx-auto h-10 w-10" />
-                      <p className="mt-2 font-pixel text-xs leading-none">NEXT STAMP</p>
-                    </div>
-                  </div>
-                </div>
-              );
-            })()}
-
-            {/* Info Section */}
-            <div className="p-5">
-              {titleBadges.length > 0 && (
-                <div className="mb-5 rounded-[8px] border-2 border-[#D94D3F]/25 bg-[#FFF0E2] p-3 shadow-[0_8px_18px_rgba(181,72,60,0.12)]">
-                  <div className="mb-2 flex items-center gap-2 text-xs font-extrabold text-[#9F392F]">
-                    <Sparkles className="h-4 w-4" />
-                    このポケふたの注目タグ
-                  </div>
-                  <div className="grid gap-2">
-                    {titleBadges.map((title, index) => (
-                      <div
-                        key={title.key}
-                        className={`flex items-center gap-2 rounded-[8px] border px-3 py-2 text-sm font-extrabold shadow-sm ${getTitleAccentClass(index)}`}
-                      >
-                        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/75 text-base shadow-sm">
-                          {title.emoji || '★'}
-                        </span>
-                        <span className="leading-tight">{title.label}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {/* Location & Title */}
-              <div className="mb-4">
-                <div className="flex items-center gap-2 mb-2">
-                  <MapPin className="w-4 h-4 text-[#B5483C]" />
-                  <span className="font-pixelJp text-sm text-[#6A4D36] font-bold">
-                    {manhole.prefecture} / {manhole.city || manhole.municipality}
+                  <span className={`font-pixelJp text-xs font-bold ${
+                    manhole.is_visited ? 'text-[#B5483C]' : 'text-[#8C6A4A]'
+                  }`}>
+                    {manhole.is_visited ? '✓ 訪問済み' : '未訪問'}
                   </span>
                 </div>
-                <h2 className="font-pixelJp text-2xl font-bold text-[#4F3828] leading-tight mb-2">
-                  {manhole.prefecture}{manhole.city || manhole.municipality}のポケふた
-                </h2>
-                {manhole.pokemons && manhole.pokemons.length > 0 && (
-                  <p className="font-pixelJp text-sm text-[#6A4D36]">
-                    {manhole.pokemons.join('・')}が描かれたポケモンマンホール
-                  </p>
-                )}
-                {manhole.building && (
-                  <div className="mt-3 flex items-start gap-2 rounded-md border border-[#8C6A4A]/15 bg-white/60 p-3">
-                    <Building2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#B5483C]" />
-                    <div>
-                      <p className="font-pixelJp text-[11px] font-bold text-[#8C6A4A]">建物・目印</p>
-                      <p className="mt-1 font-pixelJp text-sm font-bold leading-relaxed text-[#4F3828]">
-                        {manhole.building}
-                      </p>
-                    </div>
-                  </div>
-                )}
               </div>
 
-              {/* Visit Date */}
-              {manhole.is_visited && manhole.last_visit && (
-                <div className="flex items-center gap-2 mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
-                  <Clock className="w-4 h-4 text-[#B5483C]" />
-                  <span className="font-pixelJp text-sm text-[#4F3828] font-bold">
-                    訪問日: {new Date(manhole.last_visit).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}
-                  </span>
-                </div>
-              )}
-
-              {/* Your Visit Comment (if exists) */}
+              {/* Hero Photo Section */}
               {(() => {
-                const userPhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId);
-                return userPhoto?.visit?.comment ? (
-                  <div className="mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
-                    <p className="font-pixelJp text-sm text-[#4F3828] leading-relaxed">
-                      {userPhoto.visit.comment}
-                    </p>
+                const userPublicPhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId && p.visit?.is_public === true);
+                const userPrivatePhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId && p.visit?.is_public !== true);
+                const publicPhoto = photos.find(p => p.visit?.is_public === true);
+                const mainPhoto = userPublicPhoto || userPrivatePhoto || publicPhoto;
+
+                return mainPhoto ? (
+                  <div className="relative aspect-[4/3] overflow-hidden">
+                    <img
+                      src={`/api/photo/${mainPhoto.id}?size=small`}
+                      alt="訪問記念写真"
+                      className="w-full h-full object-cover"
+                      loading="lazy"
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                        const parent = e.currentTarget.parentElement;
+                        if (parent) {
+                          parent.classList.add('bg-[#E9DEC9]');
+                          parent.innerHTML = `
+                            <div class="absolute inset-0 flex items-center justify-center">
+                              <div class="text-center">
+                                <svg class="w-16 h-16 text-[#8C6A4A] opacity-30 mx-auto mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
+                                <p class="font-pixelJp text-xs text-[#8C6A4A]">写真を読み込めませんでした</p>
+                              </div>
+                            </div>
+                          `;
+                        }
+                      }}
+                    />
+                    <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent" />
+                    <div className="absolute bottom-4 right-4">
+                      <div className="bg-[#D94D3F] border-2 border-white rounded-full p-2 shadow-lg">
+                        <CheckCircle2 className="h-6 w-6 text-white" />
+                      </div>
+                    </div>
                   </div>
-                ) : null;
+                ) : (
+                  <div className="flex items-center justify-center py-12 bg-gradient-to-b from-[#F6EEDC] to-[#E9DEC9]">
+                    <div className="flex h-32 w-32 rotate-[-8deg] items-center justify-center rounded-full border-4 border-[#B8AB96] text-center text-[#A39580] bg-white/50 shadow-lg">
+                      <div>
+                        <Stamp className="mx-auto h-10 w-10" />
+                        <p className="mt-2 font-pixel text-xs leading-none">NEXT STAMP</p>
+                      </div>
+                    </div>
+                  </div>
+                );
               })()}
 
-              {/* Description */}
-              {manhole.description && (
-                <div className="mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
-                  <p className="font-pixelJp text-xs text-[#4F3828] leading-relaxed">
-                    {manhole.description}
-                  </p>
-                </div>
-              )}
+              {/* Info Section */}
+              <div className="p-5">
+                {titleBadges.length > 0 && (
+                  <div className="mb-5 rounded-[8px] border-2 border-[#D94D3F]/25 bg-[#FFF0E2] p-3 shadow-[0_8px_18px_rgba(181,72,60,0.12)]">
+                    <div className="mb-2 flex items-center gap-2 text-xs font-extrabold text-[#9F392F]">
+                      <Sparkles className="h-4 w-4" />
+                      このポケふたの注目タグ
+                    </div>
+                    <div className="grid gap-2">
+                      {titleBadges.map((title, index) => (
+                        <div
+                          key={title.key}
+                          className={`flex items-center gap-2 rounded-[8px] border px-3 py-2 text-sm font-extrabold shadow-sm ${getTitleAccentClass(index)}`}
+                        >
+                          <span className="flex h-7 w-7 items-center justify-center rounded-full bg-white/75 text-base shadow-sm">
+                            {title.emoji || '★'}
+                          </span>
+                          <span className="leading-tight">{title.label}</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
 
-              {/* Call to Actions */}
-              {manhole.is_visited ? (
-                // Visited: Add more photos + Directions
+                <div className="mb-4">
+                  <div className="flex items-center gap-2 mb-2">
+                    <MapPin className="w-4 h-4 text-[#B5483C]" />
+                    <span className="font-pixelJp text-sm text-[#6A4D36] font-bold">
+                      {manhole.prefecture} / {municipality}
+                    </span>
+                  </div>
+                  <h2 className="font-pixelJp text-2xl font-bold text-[#4F3828] leading-tight mb-2">
+                    {manhole.prefecture}{municipality}のポケふた
+                  </h2>
+                  {manhole.pokemons && manhole.pokemons.length > 0 && (
+                    <p className="font-pixelJp text-sm text-[#6A4D36]">
+                      {manhole.pokemons.join('・')}が描かれたポケモンマンホール
+                    </p>
+                  )}
+                  {manhole.building && (
+                    <div className="mt-3 flex items-start gap-2 rounded-md border border-[#8C6A4A]/15 bg-white/60 p-3">
+                      <Building2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-[#B5483C]" />
+                      <div>
+                        <p className="font-pixelJp text-[11px] font-bold text-[#8C6A4A]">建物・目印</p>
+                        <p className="mt-1 font-pixelJp text-sm font-bold leading-relaxed text-[#4F3828]">
+                          {manhole.building}
+                        </p>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {manhole.is_visited && manhole.last_visit && (
+                  <div className="flex items-center gap-2 mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
+                    <Clock className="w-4 h-4 text-[#B5483C]" />
+                    <span className="font-pixelJp text-sm text-[#4F3828] font-bold">
+                      訪問日: {new Date(manhole.last_visit).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })}
+                    </span>
+                  </div>
+                )}
+
+                {(() => {
+                  const userPhoto = photos.find(p => currentUserId && p.visit?.user_id === currentUserId);
+                  return userPhoto?.visit?.comment ? (
+                    <div className="mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
+                      <p className="font-pixelJp text-sm text-[#4F3828] leading-relaxed">
+                        {userPhoto.visit.comment}
+                      </p>
+                    </div>
+                  ) : null;
+                })()}
+
+                {manhole.description && (
+                  <div className="mb-4 p-3 rounded-md bg-white/60 border border-[#8C6A4A]/15">
+                    <p className="font-pixelJp text-xs text-[#4F3828] leading-relaxed">
+                      {manhole.description}
+                    </p>
+                  </div>
+                )}
+
                 <div className="grid grid-cols-2 gap-2">
                   <button
                     onClick={() => router.push(currentUserId ? '/upload' : '/login?redirect=/upload')}
@@ -651,49 +691,21 @@ export default function ManholeDetailPage() {
                     <span className="font-pixelJp text-xs">経路案内</span>
                   </button>
                 </div>
-              ) : (
-                // Unvisited: Directions + Record visit/Login CTA
-                <div className="grid grid-cols-2 gap-2">
-                  <button
-                    onClick={openInMaps}
-                    className="rpg-button rpg-button-success flex items-center justify-center gap-1 px-2"
-                  >
-                    <Navigation className="w-4 h-4" />
-                    <span className="font-pixelJp text-xs">経路案内</span>
-                  </button>
-                  {currentUserId ? (
-                    <button
-                      onClick={() => router.push('/upload')}
-                      className="rpg-button rpg-button-primary flex items-center justify-center gap-1 px-2"
-                    >
-                      <Camera className="w-4 h-4" />
-                      <span className="font-pixelJp text-xs">訪問記録</span>
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => router.push('/login?redirect=/upload')}
-                      className="rpg-button flex items-center justify-center gap-1 px-2 bg-white/70 border border-[#7B63A8] hover:bg-[#7B63A8]/5"
-                    >
-                      <Camera className="w-4 h-4 text-[#7B63A8]" />
-                      <span className="font-pixelJp text-xs text-[#7B63A8]">旅の続きで記録</span>
-                    </button>
-                  )}
-                </div>
-              )}
 
-              {sharePayload && (
-                <ShareButtons
-                  label="このポケふたを共有する"
-                  shareText={sharePayload.shareText}
-                  shareUrl={sharePayload.shareUrl}
-                  hashtags={sharePayload.hashtags}
-                  analyticsParams={sharePayload.analyticsParams}
-                  className="mt-3"
-                />
-              )}
+                {sharePayload && (
+                  <ShareButtons
+                    label="このポケふたを共有する"
+                    shareText={sharePayload.shareText}
+                    shareUrl={sharePayload.shareUrl}
+                    hashtags={sharePayload.hashtags}
+                    analyticsParams={sharePayload.analyticsParams}
+                    className="mt-3"
+                  />
+                )}
+              </div>
             </div>
           </div>
-        </div>
+        )}
 
         {/* Pokemon Info */}
         {manhole.pokemons && manhole.pokemons.length > 0 && (

--- a/src/components/PhotoPrompt.tsx
+++ b/src/components/PhotoPrompt.tsx
@@ -1,0 +1,403 @@
+'use client';
+
+import { Flag, ImageIcon, MapPin, ChevronRight, Trophy, Star, Sparkles, Route, Plus } from 'lucide-react';
+
+const NUM = '"Outfit", "M PLUS Rounded 1c", system-ui, sans-serif';
+const ROUND = '"M PLUS Rounded 1c", system-ui, sans-serif';
+
+const VARIETY_TAGS = ['夜・雪の構図はまだ無い', 'ベスト写真を狙える', 'あなたの季節を残す'];
+
+const TINTS = [
+  { bg: '#fdeae2', color: '#bf5640' },
+  { bg: '#ece9fb', color: '#6a5fc4' },
+  { bg: '#e2f2e9', color: '#1f9d63' },
+];
+
+const TAG_ICONS = [Star, Trophy, Sparkles] as const;
+
+export interface PhotoPromptProps {
+  pokefuta: {
+    id: string | number;
+    title: string;
+    prefecture: string;
+    area: string;
+    photoCount: number;
+    viewerHasPhoto: boolean;
+    rarityTags: string[];
+    heroImageUrl?: string;
+  };
+  prefectureDex?: { current: number; total: number } | null;
+  seriesProgressDelta?: number;
+  onPost: () => void;
+  onRoute?: () => void;
+  onLater?: () => void;
+}
+
+export default function PhotoPrompt({
+  pokefuta,
+  prefectureDex,
+  seriesProgressDelta = 1,
+  onPost,
+  onRoute,
+  onLater,
+}: PhotoPromptProps) {
+  if (pokefuta.viewerHasPhoto) return null;
+
+  const isEmpty = pokefuta.photoCount === 0;
+  const rawTags = isEmpty ? pokefuta.rarityTags.slice(0, 3) : VARIETY_TAGS;
+  // Pad to 3
+  const tags = Array.from({ length: 3 }, (_, i) => rawTags[i] || VARIETY_TAGS[i]);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
+
+      {/* ── 1. HERO ── */}
+      {isEmpty ? (
+        <div
+          style={{
+            position: 'relative',
+            borderRadius: 16,
+            overflow: 'hidden',
+            height: 192,
+            background: 'repeating-linear-gradient(135deg,#f3ecdc 0 11px,#ece2cd 11px 22px)',
+            border: '2px dashed #cdbf9f',
+            display: 'grid',
+            placeItems: 'center',
+            textAlign: 'center',
+          }}
+        >
+          <div>
+            <div style={{ fontFamily: NUM, fontWeight: 800, fontSize: 40, lineHeight: 1, color: '#cdbb92' }}>
+              0
+            </div>
+            <div style={{ fontWeight: 700, fontSize: 13.5, color: '#6f6657', marginTop: 7 }}>
+              この場所の写真はまだ0枚
+            </div>
+            <div style={{ fontSize: 11.5, color: '#bf5640', fontWeight: 700, marginTop: 2 }}>
+              あなたが最初の記録者に
+            </div>
+          </div>
+          <Badge top={12} left={12} bg="#bf5640" color="#fff">
+            <Flag size={13} />一番乗りチャンス
+          </Badge>
+        </div>
+      ) : (
+        <div
+          style={{
+            position: 'relative',
+            borderRadius: 16,
+            overflow: 'hidden',
+            height: 192,
+            border: '1px solid #e9dfc7',
+            background: '#ece2cd',
+          }}
+        >
+          {pokefuta.heroImageUrl ? (
+            <img
+              src={pokefuta.heroImageUrl}
+              alt={pokefuta.title}
+              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+            />
+          ) : (
+            <div
+              style={{
+                width: '100%',
+                height: '100%',
+                background: 'repeating-linear-gradient(45deg,#d9cdb2 0 7px,#cfc2a3 7px 14px)',
+                display: 'grid',
+                placeItems: 'center',
+              }}
+            >
+              <span style={{ fontFamily: 'ui-monospace,monospace', fontSize: 11, color: '#7c6f50' }}>写真</span>
+            </div>
+          )}
+          <Badge top={12} left={12} bg="rgba(255,255,255,.92)" color="#6f6657">
+            <ImageIcon size={13} />みんなの写真 {pokefuta.photoCount}枚
+          </Badge>
+          <Badge top={12} right={12} bg="rgba(191,86,64,.95)" color="#fff">
+            あなたは未投稿
+          </Badge>
+        </div>
+      )}
+
+      {/* ── 2. LOCATION + TITLE ── */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 5, color: '#9b917e', fontSize: 12, fontWeight: 600 }}>
+          <MapPin size={13} />
+          {pokefuta.prefecture} / {pokefuta.area}
+        </div>
+        <div style={{ fontFamily: ROUND, fontWeight: 800, fontSize: 21, marginTop: 4, color: '#2c2a26', lineHeight: 1.25 }}>
+          {pokefuta.title}
+        </div>
+        {!isEmpty && (
+          <div style={{ fontSize: 13, color: '#bf5640', fontWeight: 700, marginTop: 3 }}>
+            あなたの構図で塗り替える
+          </div>
+        )}
+      </div>
+
+      {/* ── 3. COMBINED CARD ── */}
+      <div
+        style={{
+          background: '#fffdf7',
+          border: '1.5px solid #efd9a3',
+          borderRadius: 18,
+          overflow: 'hidden',
+          boxShadow: '0 1px 2px rgba(72,55,20,.06), 0 3px 8px rgba(72,55,20,.05)',
+        }}
+      >
+        {/* Ribbon */}
+        <div
+          style={{
+            background: 'linear-gradient(100deg,#fdeae2,#fdf1e6)',
+            padding: '11px 14px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 9,
+          }}
+        >
+          {isEmpty ? <Flag size={16} color="#bf5640" /> : <ImageIcon size={16} color="#bf5640" />}
+          <span
+            style={{
+              fontFamily: ROUND,
+              fontWeight: 800,
+              fontSize: 12.5,
+              color: '#7d4536',
+              flex: '1 1 auto',
+              minWidth: 0,
+              whiteSpace: 'nowrap',
+            }}
+          >
+            {isEmpty ? 'まだ誰も投稿していない' : 'あなたはまだ未記録'}
+          </span>
+          {isEmpty ? (
+            <span style={{ display: 'flex', alignItems: 'baseline', gap: 4, whiteSpace: 'nowrap', flex: '0 0 auto' }}>
+              <span style={{ fontFamily: NUM, fontWeight: 800, fontSize: 15, color: '#9b917e' }}>0人</span>
+              <ChevronRight size={13} color="#d6b8a8" />
+              <span style={{ fontFamily: NUM, fontWeight: 800, fontSize: 18, color: '#bf5640' }}>#1</span>
+            </span>
+          ) : (
+            <span style={{ display: 'flex', alignItems: 'baseline', gap: 3, whiteSpace: 'nowrap', flex: '0 0 auto' }}>
+              <span style={{ fontFamily: NUM, fontWeight: 800, fontSize: 18, color: '#bf5640' }}>0</span>
+              <span style={{ fontFamily: NUM, fontWeight: 700, fontSize: 12, color: '#9b917e' }}>/1 図鑑</span>
+            </span>
+          )}
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: 14, display: 'flex', flexDirection: 'column', gap: 11 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 8,
+                background: '#fde2c2',
+                display: 'grid',
+                placeItems: 'center',
+                flexShrink: 0,
+              }}
+            >
+              <Trophy size={16} color="#b87d0a" />
+            </span>
+            <div style={{ fontFamily: ROUND, fontWeight: 800, fontSize: 13.5, color: '#2c2a26' }}>
+              撮ると写真図鑑も埋まる
+            </div>
+          </div>
+
+          {prefectureDex && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                background: '#fbf6ea',
+                borderRadius: 12,
+                padding: '11px 13px',
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <div style={{ fontSize: 11.5, color: '#6f6657', fontWeight: 600 }}>
+                  {pokefuta.prefecture} 写真図鑑
+                </div>
+                <div style={{ fontFamily: NUM, fontWeight: 800, fontSize: 18, color: '#2c2a26' }}>
+                  {prefectureDex.current}{' '}
+                  <span style={{ color: '#9b917e', fontSize: 13 }}>→</span>{' '}
+                  <span style={{ color: '#bf5640' }}>{prefectureDex.current + 1}</span>{' '}
+                  <span style={{ color: '#9b917e', fontSize: 13, fontWeight: 600 }}>
+                    / {prefectureDex.total}
+                  </span>
+                </div>
+              </div>
+              <div style={{ width: 1, height: 30, background: '#e9dfc7', flexShrink: 0 }} />
+              <div style={{ textAlign: 'center' }}>
+                <div style={{ fontFamily: NUM, fontWeight: 800, fontSize: 18, color: '#1f9d63' }}>
+                  +{seriesProgressDelta}
+                </div>
+                <div style={{ fontSize: 10.5, color: '#9b917e', fontWeight: 600 }}>シリーズ進捗</div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── 4. PILLS ── */}
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6 }}>
+        {tags.filter(Boolean).map((tag, i) => {
+          const tint = TINTS[i % 3];
+          const Icon = TAG_ICONS[i % 3];
+          return (
+            <span
+              key={tag}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 5,
+                fontSize: 11.5,
+                fontWeight: 700,
+                padding: '5px 10px',
+                borderRadius: 999,
+                background: tint.bg,
+                color: tint.color,
+                lineHeight: 1,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <Icon size={12} />
+              {tag}
+            </span>
+          );
+        })}
+      </div>
+
+      {/* ── 5. PRIMARY CTA ── */}
+      <CtaButton onClick={onPost} bg="#bf5640" color="#fff" shadow="0 2px 0 #a8462f">
+        {isEmpty ? <Flag size={19} /> : <Plus size={19} />}
+        {isEmpty ? '一番乗りで投稿する' : 'あなたの1枚を加える'}
+      </CtaButton>
+
+      {/* ── 6. SECONDARY CTAs ── */}
+      <div style={{ display: 'flex', gap: 10 }}>
+        {onRoute && (
+          <CtaButton onClick={onRoute} bg="#1f9d63" color="#fff" flex={1} size={13.5}>
+            <Route size={16} />経路案内
+          </CtaButton>
+        )}
+        {onLater && (
+          <CtaButton
+            onClick={onLater}
+            bg="#fff"
+            color="#6f6657"
+            flex={1}
+            size={13.5}
+            border="1px solid #e9dfc7"
+          >
+            あとで
+          </CtaButton>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Badge({
+  children,
+  top,
+  left,
+  right,
+  bg,
+  color,
+}: {
+  children: React.ReactNode;
+  top?: number;
+  left?: number;
+  right?: number;
+  bg: string;
+  color: string;
+}) {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        top,
+        left,
+        right,
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 5,
+        fontSize: 11.5,
+        fontWeight: 700,
+        padding: '5px 10px',
+        borderRadius: 999,
+        background: bg,
+        color,
+        boxShadow: '0 1px 2px rgba(72,55,20,.06), 0 3px 8px rgba(72,55,20,.05)',
+      }}
+    >
+      {children}
+    </span>
+  );
+}
+
+function CtaButton({
+  children,
+  onClick,
+  bg,
+  color,
+  shadow,
+  border,
+  flex,
+  size = 16,
+}: {
+  children: React.ReactNode;
+  onClick?: () => void;
+  bg: string;
+  color: string;
+  shadow?: string;
+  border?: string;
+  flex?: number;
+  size?: number;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        border: border ?? 'none',
+        borderRadius: 12,
+        fontFamily: '"M PLUS Rounded 1c", system-ui, sans-serif',
+        fontWeight: 800,
+        fontSize: size,
+        padding: size >= 16 ? 15 : 12,
+        width: flex ? undefined : '100%',
+        flex: flex ? `${flex} 1 0` : undefined,
+        cursor: 'pointer',
+        display: 'inline-flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        letterSpacing: '.02em',
+        background: bg,
+        color,
+        boxShadow: shadow ?? 'none',
+        transition: 'box-shadow 0.1s, transform 0.1s',
+      }}
+      onPointerDown={(e) => {
+        const el = e.currentTarget;
+        el.style.transform = 'translateY(2px)';
+        el.style.boxShadow = 'none';
+      }}
+      onPointerUp={(e) => {
+        const el = e.currentTarget;
+        el.style.transform = '';
+        el.style.boxShadow = shadow ?? 'none';
+      }}
+      onPointerLeave={(e) => {
+        const el = e.currentTarget;
+        el.style.transform = '';
+        el.style.boxShadow = shadow ?? 'none';
+      }}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- `PhotoPrompt` コンポーネント新規作成（`src/components/PhotoPrompt.tsx`）
  - `empty` variant: 写真0枚 → 「一番乗りチャンス」バッジ・斜めストライプヒーロー・terracotta CTA
  - `posted` variant: 他者投稿あり・自分未投稿 → 実写真ヒーロー・「あなたは未投稿」バッジ・「あなたの1枚を加える」CTA
  - `done` variant: 自分投稿済み → `null`（非表示）
- `ManholePage.tsx` にPhotoPrompt統合
  - 未投稿時は PhotoPrompt を表示、投稿済み時は既存ヒーローカードを表示するよう条件分岐
  - 都道府県写真図鑑の進捗（ログイン時）を `GET /api/badges/prefectures` からフェッチして表示
  - 「あとで」でプロンプトを一時非表示にし元のカードへフォールバック
  - 未ログイン時の主CTA → `/login?redirect=/upload` にリダイレクト
- `globals.css` に Outfit フォント（数値表示用）を追加

## Design

デザインハンドオフ（`design_handoff_photo_prompt/`）の screens-AB.jsx を基準に、既存の Lucide アイコン・M PLUS Rounded 1c・Tailwind を使って hifi 再現。

事業KPI: **写真投稿率向上**（未投稿 300+ 枚に対して「一番乗り」収集欲/FOMO 訴求）

## Test plan

- [ ] 未ログイン・写真なしポケふた → `empty` variant（一番乗りチャンス・斜めストライプ・0人 → #1）
- [ ] 未ログイン・写真ありポケふた → `posted` variant（みんなの写真N枚・あなたは未投稿）
- [ ] 主CTA クリック（未ログイン）→ `/login?redirect=/upload` へ遷移
- [ ] 「あとで」クリック → PhotoPrompt 消滅・元カードにフォールバック
- [ ] ログイン済み・投稿済みユーザー → 既存ヒーローカード表示（PhotoPrompt 非表示）
- [ ] ログイン済み・未投稿 → PhotoPrompt 表示＋都道府県図鑑進捗ブロック表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)