### PR TITLE
未ログインUI 3タブ対応 — PCShell認証切替・各ページゲストUI・SP表示修正

### DIFF
--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -378,7 +378,7 @@ export default function NearbyPage() {
     </div>
   );
 
-  const nearbyRail = isLoggedIn ? authNearbyRail : guestNearbyRail;
+  const nearbyRail = sessionChecked ? (isLoggedIn ? authNearbyRail : guestNearbyRail) : undefined;
 
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#efe6cf] text-[#2A2A2A]">
@@ -437,7 +437,7 @@ export default function NearbyPage() {
         </section>
 
         {sessionChecked && !isLoggedIn && (
-          <div className="mt-4 rounded-[8px] border border-[#7B63A8]/10 bg-white/70 px-4 py-4 shadow-sm space-y-3">
+          <div className="mt-4 lg:hidden rounded-[8px] border border-[#7B63A8]/10 bg-white/70 px-4 py-4 shadow-sm space-y-3">
             <div className="flex items-center justify-between gap-3 flex-wrap">
               <p className="font-bold text-sm text-[#7B63A8]">無料でポケふたスタンプ帳を作れます</p>
               <Link

--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -11,6 +11,7 @@ import {
   Navigation,
   RefreshCw,
   Search,
+  Stamp,
 } from 'lucide-react';
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
@@ -310,7 +311,7 @@ export default function NearbyPage() {
     : filteredAllManholes;
   const nearestDistance = nearbyManholes[0]?.distance;
 
-  const nearbyRail = (
+  const authNearbyRail = (
     <div className="space-y-3">
       <div className="overflow-hidden rounded-[14px] border border-[#e9dfc7] bg-[#fffdf7] p-4 shadow-sm">
         <p style={{ fontFamily: ROUND, fontSize: 10, fontWeight: 800, letterSpacing: '0.08em', color: '#c47e0f', textTransform: 'uppercase' as const, marginBottom: 10 }}>
@@ -350,6 +351,35 @@ export default function NearbyPage() {
     </div>
   );
 
+  const guestNearbyRail = (
+    <div className="rounded-[14px] border border-[#e9dfc7] bg-[#fffdf7] p-4 shadow-sm space-y-3">
+      <p className="font-bold text-sm text-[#7B63A8]">無料でポケふたスタンプ帳を作れます</p>
+      <div className="grid grid-cols-2 gap-y-1.5 gap-x-4 text-xs text-[#6B6B6B]">
+        <span className="flex items-center gap-1.5"><MapPin className="h-3.5 w-3.5 text-[#B5483C]" />行ったポケふたを記録</span>
+        <span className="flex items-center gap-1.5"><Camera className="h-3.5 w-3.5 text-[#B5483C]" />写真で思い出を保存</span>
+        <span className="flex items-center gap-1.5"><Navigation className="h-3.5 w-3.5 text-[#B5483C]" />都道府県の達成状況</span>
+        <span className="flex items-center gap-1.5"><Search className="h-3.5 w-3.5 text-[#B5483C]" />近くの未訪問を探せる</span>
+      </div>
+      <Link
+        href="/signup"
+        className="flex items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-3 text-sm font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+      >
+        <Stamp className="h-4 w-4" />
+        スタンプ帳をはじめる
+      </Link>
+      <Link
+        href="/nearby"
+        className="flex items-center justify-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white px-4 py-2 text-sm font-bold text-[#7B63A8]"
+      >
+        <MapPin className="h-4 w-4" />
+        近くのポケふたを見る
+      </Link>
+      <p className="text-right text-[11px] text-[#9B9B9B]">地図で探す → data.pokefuta.com</p>
+    </div>
+  );
+
+  const nearbyRail = isLoggedIn ? authNearbyRail : guestNearbyRail;
+
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#efe6cf] text-[#2A2A2A]">
       <div className="lg:hidden">
@@ -360,18 +390,73 @@ export default function NearbyPage() {
       <main className="relative px-0 lg:px-0">
         <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-4 py-4 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-10 sm:py-10">
           <div className="relative max-w-3xl">
-            <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-2.5 py-1 text-[11px] font-bold text-[#7B63A8] sm:mb-4 sm:px-3 sm:text-xs">
-              <Compass className="h-3.5 w-3.5" />
-              旅先で探す
-            </div>
-            <h1 className="max-w-2xl text-2xl font-extrabold leading-tight tracking-normal sm:text-5xl">
-              ポケふたを探す
-            </h1>
-            <p className="mt-2 max-w-2xl text-sm font-medium leading-snug sm:mt-4 sm:text-lg sm:leading-relaxed">
-              現在地の近くから、全国一覧まで。次に会いに行くポケふたをここで見つけよう。
-            </p>
+            {sessionChecked && !isLoggedIn ? (
+              <>
+                <div className="mb-2 inline-flex items-center gap-1.5 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-2.5 py-1 text-[11px] font-bold text-[#7B63A8] sm:mb-4 sm:px-3 sm:text-xs">
+                  <Stamp className="h-3 w-3" />
+                  ポケふたスタンプ帳
+                </div>
+                <h1 className="max-w-2xl text-2xl font-extrabold leading-tight tracking-normal sm:text-4xl">
+                  ポケふた巡りを、あなただけのスタンプ帳に。
+                </h1>
+                <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-[#4A4A4A] sm:mt-3 sm:text-base">
+                  旅先で見つけたポケふたを写真と一緒に記録。訪問済みの場所やみんなの投稿写真を見ながら、ポケふた巡りを楽しく残しましょう。
+                </p>
+                <div className="mt-3 flex flex-wrap gap-2 sm:mt-4">
+                  <Link
+                    href="/signup"
+                    className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+                  >
+                    <Stamp className="h-4 w-4" />
+                    スタンプ帳をはじめる
+                  </Link>
+                  <Link
+                    href="/nearby"
+                    className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
+                  >
+                    <MapPin className="h-4 w-4" />
+                    近くのポケふたを見る
+                  </Link>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-2.5 py-1 text-[11px] font-bold text-[#7B63A8] sm:mb-4 sm:px-3 sm:text-xs">
+                  <Compass className="h-3.5 w-3.5" />
+                  旅先で探す
+                </div>
+                <h1 className="max-w-2xl text-2xl font-extrabold leading-tight tracking-normal sm:text-5xl">
+                  ポケふたを探す
+                </h1>
+                <p className="mt-2 max-w-2xl text-sm font-medium leading-snug sm:mt-4 sm:text-lg sm:leading-relaxed">
+                  現在地の近くから、全国一覧まで。次に会いに行くポケふたをここで見つけよう。
+                </p>
+              </>
+            )}
           </div>
         </section>
+
+        {sessionChecked && !isLoggedIn && (
+          <div className="mt-4 rounded-[8px] border border-[#7B63A8]/10 bg-white/70 px-4 py-4 shadow-sm space-y-3">
+            <div className="flex items-center justify-between gap-3 flex-wrap">
+              <p className="font-bold text-sm text-[#7B63A8]">無料でポケふたスタンプ帳を作れます</p>
+              <Link
+                href="/signup"
+                className="shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-3 py-2 text-xs font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+              >
+                <Stamp className="h-3 w-3" />
+                無料ではじめる
+              </Link>
+            </div>
+            <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs text-[#6B6B6B]">
+              <span className="flex items-center gap-1.5"><MapPin className="h-3.5 w-3.5 text-[#B5483C]" />行ったポケふたを記録</span>
+              <span className="flex items-center gap-1.5"><Camera className="h-3.5 w-3.5 text-[#B5483C]" />写真で思い出を保存</span>
+              <span className="flex items-center gap-1.5"><Navigation className="h-3.5 w-3.5 text-[#B5483C]" />都道府県の達成状況</span>
+              <span className="flex items-center gap-1.5"><Search className="h-3.5 w-3.5 text-[#B5483C]" />近くの未訪問を探せる</span>
+            </div>
+            <p className="text-right text-[11px] text-[#9B9B9B]">地図で探す → data.pokefuta.com</p>
+          </div>
+        )}
 
         {locationError && (
           <div className="mt-4 rounded-[8px] border border-red-200 bg-red-50 px-4 py-3 shadow-sm">

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -7,6 +7,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Heart,
+  Lock,
   MapPin,
   MessageCircle,
   Sparkles,
@@ -16,6 +17,7 @@ import {
 import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import PCShell from '@/components/PCShell';
 import StampBookMockup from '@/components/StampBookMockup';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { formatDateJa } from '@/lib/date';
@@ -135,57 +137,90 @@ export default function PopularPage() {
   const canGoNext = totalPages ? currentPage < totalPages : feed.length === feedPerPage;
   const showPagination = totalPages ? totalPages > 1 : currentPage > 1 || feed.length === feedPerPage;
 
+  const unmetPhotoCount =
+    manholesWithPhotos != null && totalManholes != null
+      ? totalManholes - manholesWithPhotos
+      : null;
+
+  const pcGuestRail = !isLoggedIn ? (
+    <div className="overflow-hidden rounded-[14px] border border-[#efd9a3] bg-white shadow-sm">
+      <div className="flex items-center gap-2 bg-gradient-to-r from-[#fdeae2] to-[#fdf1e6] px-4 py-3">
+        <TrendingUp className="h-4 w-4 text-[#B5483C]" />
+        <span className="font-bold text-sm text-[#7d4536]">写真ゼロを埋めよう</span>
+        <span className="ml-auto">
+          <span className="font-mono text-lg font-bold text-[#B5483C]">{unmetPhotoCount ?? 279}</span>
+          <span className="text-xs text-[#6B6B6B]"> 件 募集中</span>
+        </span>
+      </div>
+      <div className="flex flex-col gap-3 p-4">
+        <p className="text-sm text-[#4A4A4A] leading-relaxed">
+          まだ写真の無いポケふたは残り{' '}
+          <b className="text-[#B5483C]">{unmetPhotoCount ?? 279}</b> 件。あなたの1枚目が、この場所の最初の記録になります。
+        </p>
+        <Link
+          href="/signup"
+          className="flex items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-3 text-sm font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+        >
+          <Camera className="h-4 w-4" />
+          無料で旅の記録をはじめる
+        </Link>
+        <p className="flex items-center justify-center gap-1 text-center text-xs text-[#9B9B9B]">
+          <Lock className="h-3 w-3" />
+          ログインして写真を投稿できます
+        </p>
+      </div>
+    </div>
+  ) : undefined;
+
   return (
     <div className="min-h-screen safe-area-inset pb-nav-safe bg-[#F6EEDC] text-[#2A2A2A]">
-      <Header title="全国のポケふた写真館" />
+      <div className="lg:hidden">
+        <Header title="ポケふた写真館" />
+      </div>
 
-      <main className="mx-auto max-w-6xl px-4 pb-6 pt-5 sm:pt-8">
+      <PCShell active="post" rail={pcGuestRail} className="pb-32 pt-5 lg:pt-6">
+      <main>
         {/* Hero Section */}
         <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-5 py-6 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-8 sm:py-8">
-          <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_340px] lg:items-start xl:grid-cols-[minmax(0,1fr)_380px]">
-            <div className="relative max-w-3xl">
-              <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
-                <Sparkles className="h-3.5 w-3.5" />
-                ポケふた写真館
-              </div>
-              <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
-                全国のポケふたを写真で埋めよう
-              </h1>
-              <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
-                {totalPosts != null && totalPosts > 0 ? (
-                  <>
-                    {totalPosts}枚の旅写真が集まっています。
-                    {totalManholes != null && manholesWithPhotos != null && totalManholes > manholesWithPhotos && (
-                      <>残り{totalManholes - manholesWithPhotos}枚以上はまだ募集中。</>
-                    )}
-                  </>
-                ) : (
-                  <>全国のポケふたを旅して写真を記録しよう。まだ写真がない場所がたくさんあります。</>
-                )}
-              </p>
-
-              {!isLoggedIn && (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  <Link
-                    href="/signup"
-                    className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-                  >
-                    <Camera className="h-4 w-4" />
-                    無料で旅の記録をはじめる
-                  </Link>
-                  <Link
-                    href="/visits"
-                    className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
-                  >
-                    スタンプ帳を見る
-                  </Link>
-                </div>
+          <div className="relative max-w-3xl">
+            <div className="mb-3 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
+              <Sparkles className="h-3.5 w-3.5" />
+              ポケふた写真館
+            </div>
+            <h1 className="max-w-2xl text-3xl font-extrabold leading-tight tracking-normal sm:text-5xl">
+              全国のポケふたを写真で埋めよう
+            </h1>
+            <p className="mt-4 max-w-2xl text-base font-medium leading-relaxed sm:text-lg">
+              {totalPosts != null && totalPosts > 0 ? (
+                <>
+                  いま <b>{totalPosts}</b> 枚の写真が集まっています。
+                  {unmetPhotoCount != null && unmetPhotoCount > 0 && (
+                    <>写真がまだ無いポケふたは残り <b className="text-[#B5483C]">{unmetPhotoCount}</b> 件。</>
+                  )}
+                </>
+              ) : (
+                <>全国のポケふたを旅して写真を記録しよう。まだ写真がない場所がたくさんあります。</>
               )}
-            </div>
+            </p>
 
-            <div className="hidden rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block">
-              <StampBookMockup />
-            </div>
+            {!isLoggedIn && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                <Link
+                  href="/signup"
+                  className="inline-flex items-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+                >
+                  <Camera className="h-4 w-4" />
+                  無料で旅の記録をはじめる
+                </Link>
+                <Link
+                  href="/visits"
+                  className="inline-flex items-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white/80 px-4 py-2.5 text-sm font-bold text-[#7B63A8] shadow-sm transition hover:bg-white"
+                >
+                  <Stamp className="h-4 w-4" />
+                  スタンプ帳を見る
+                </Link>
+              </div>
+            )}
           </div>
         </section>
 
@@ -389,6 +424,7 @@ export default function PopularPage() {
           </>
         )}
       </main>
+      </PCShell>
 
       <BottomNav />
     </div>

--- a/src/app/popular/page.tsx
+++ b/src/app/popular/page.tsx
@@ -18,7 +18,6 @@ import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PCShell from '@/components/PCShell';
-import StampBookMockup from '@/components/StampBookMockup';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { formatDateJa } from '@/lib/date';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
@@ -48,6 +47,7 @@ export default function PopularPage() {
   const [rareManholes, setRareManholes] = useState<Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title'>[]>([]);
   const [rareLoading, setRareLoading] = useState(true);
   const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [sessionChecked, setSessionChecked] = useState(false);
   const feedPerPage = 24;
   const { trackView } = useAnalytics();
 
@@ -62,10 +62,12 @@ export default function PopularPage() {
         } = await supabase.auth.getSession();
         const loggedIn = Boolean(session?.user);
         setIsLoggedIn(loggedIn);
+        setSessionChecked(true);
         trackView('/popular', '全国のポケふた写真館', 'popular', loggedIn);
       } catch (error) {
         console.error('Session check error:', error);
         setIsLoggedIn(false);
+        setSessionChecked(true);
         trackView('/popular', '全国のポケふた写真館', 'popular', false);
       }
     })();
@@ -142,20 +144,20 @@ export default function PopularPage() {
       ? totalManholes - manholesWithPhotos
       : null;
 
-  const pcGuestRail = !isLoggedIn ? (
+  const pcGuestRail = sessionChecked && !isLoggedIn ? (
     <div className="overflow-hidden rounded-[14px] border border-[#efd9a3] bg-white shadow-sm">
       <div className="flex items-center gap-2 bg-gradient-to-r from-[#fdeae2] to-[#fdf1e6] px-4 py-3">
         <TrendingUp className="h-4 w-4 text-[#B5483C]" />
         <span className="font-bold text-sm text-[#7d4536]">写真ゼロを埋めよう</span>
         <span className="ml-auto">
-          <span className="font-mono text-lg font-bold text-[#B5483C]">{unmetPhotoCount ?? 279}</span>
+          <span className="font-mono text-lg font-bold text-[#B5483C]">{unmetPhotoCount ?? '–'}</span>
           <span className="text-xs text-[#6B6B6B]"> 件 募集中</span>
         </span>
       </div>
       <div className="flex flex-col gap-3 p-4">
         <p className="text-sm text-[#4A4A4A] leading-relaxed">
           まだ写真の無いポケふたは残り{' '}
-          <b className="text-[#B5483C]">{unmetPhotoCount ?? 279}</b> 件。あなたの1枚目が、この場所の最初の記録になります。
+          <b className="text-[#B5483C]">{unmetPhotoCount ?? '–'}</b> 件。あなたの1枚目が、この場所の最初の記録になります。
         </p>
         <Link
           href="/signup"

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -657,15 +657,35 @@ export default function VisitsPage() {
       ? new Set(manholes.flatMap((m) => m.pokemons ?? [])).size
       : null;
 
+    const unAuthRail = (
+      <div className="rounded-[14px] border border-[#e9dfc7] bg-[#fffdf7] p-4 shadow-sm space-y-3">
+        <p className="font-bold text-sm text-[#7B63A8]">あなた専用のスタンプ帳を無料で作れます</p>
+        <Link
+          href="/signup"
+          className="flex items-center justify-center gap-2 rounded-lg bg-[#7B63A8] px-4 py-3 text-sm font-bold text-white shadow-[0_2px_0_#5f55b8] transition hover:bg-[#6A5299]"
+        >
+          <Stamp className="h-4 w-4" /> 無料でスタンプ帳を作る
+        </Link>
+        <Link
+          href="/nearby"
+          className="flex items-center justify-center gap-2 rounded-lg border border-[#7B63A8]/30 bg-white px-4 py-2 text-sm font-bold text-[#7B63A8]"
+        >
+          <MapPin className="h-4 w-4" /> 近くのポケふたを探す
+        </Link>
+      </div>
+    );
+
     return (
       <div className="min-h-screen safe-area-inset bg-[#F3E7CC] pb-nav-safe">
-        <Header title="スタンプ帳" />
+        <div className="lg:hidden">
+          <Header title="スタンプ帳" />
+        </div>
 
-        <main className="mx-auto max-w-6xl px-4 pb-6 pt-5 space-y-4 sm:pt-8">
-          {/* Hero — same grid layout as top page */}
+        <PCShell active="stamp" rail={unAuthRail} className="pb-32 pt-5 lg:pt-6">
+        <main className="space-y-4">
+          {/* Hero */}
           <section className="relative overflow-hidden rounded-[8px] border border-[#7B63A8]/15 bg-[#FFF8EB] px-4 py-3 shadow-[0_8px_24px_rgba(123,99,168,0.10)] sm:px-8 sm:py-7">
-            <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start xl:grid-cols-[minmax(0,1fr)_320px]">
-              <div className="relative max-w-3xl">
+            <div className="relative max-w-3xl">
                 <div className="mb-2 inline-flex items-center gap-2 rounded-full border border-[#FFB347]/50 bg-[#FFB347]/20 px-3 py-1 text-xs font-bold text-[#7B63A8]">
                   <Sparkles className="h-3.5 w-3.5" />
                   ポケふたスタンプ帳
@@ -684,11 +704,11 @@ export default function VisitsPage() {
                     <span className="ml-1 text-xs font-bold text-[#9B9B9B]">全国のポケふた</span>
                   </div>
                   <div>
-                    <span className="font-pixel text-2xl font-extrabold text-[#2C765E]">{prefectureCount ?? '47'}</span>
+                    <span className="font-pixel text-2xl font-extrabold text-[#2C765E]">{prefectureCount ?? '41'}</span>
                     <span className="ml-1 text-xs font-bold text-[#9B9B9B]">都道府県</span>
                   </div>
                   <div>
-                    <span className="font-pixel text-2xl font-extrabold text-[#FFB347]">{pokemonCount ?? '500+'}</span>
+                    <span className="font-pixel text-2xl font-extrabold text-[#FFB347]">{pokemonCount ?? '534'}</span>
                     <span className="ml-1 text-xs font-bold text-[#9B9B9B]">種類のポケモン</span>
                   </div>
                 </div>
@@ -711,16 +731,14 @@ export default function VisitsPage() {
                   </Link>
                 </div>
               </div>
-
-              <div className="hidden rotate-2 overflow-hidden rounded-[8px] border border-[#E2CFAE] bg-white p-2 shadow-lg lg:block">
-                <StampBookMockup />
-              </div>
-            </div>
           </section>
 
           {/* 旅を続けると… モックカード */}
           <section className="rounded-[8px] border border-[#7B63A8]/15 bg-white/80 px-4 py-4 shadow-sm sm:px-6">
-            <p className="mb-3 text-xs font-extrabold uppercase tracking-widest text-[#9B9B9B]">旅を続けると…</p>
+            <p className="mb-3 flex items-center gap-2 text-xs font-extrabold uppercase tracking-widest text-[#9B9B9B]">
+              旅を続けると…
+              <span className="rounded border border-[#D8CCAE] px-1.5 py-0.5 text-[10px] font-bold text-[#9B9B9B] normal-case tracking-normal">例</span>
+            </p>
             <div className="grid grid-cols-3 gap-3">
               <div className="rounded-lg bg-[#F5F0FF] px-3 py-3 text-center">
                 <p className="text-[10px] font-bold text-[#9B9B9B]">全国</p>
@@ -731,13 +749,13 @@ export default function VisitsPage() {
               <div className="rounded-lg bg-[#EDFAF5] px-3 py-3 text-center">
                 <p className="text-[10px] font-bold text-[#9B9B9B]">都道府県</p>
                 <p className="font-pixel text-xl font-extrabold text-[#2C765E]">
-                  10<span className="text-[11px] font-bold text-[#A8D5C4]">/{prefectureCount ?? '47'}</span>
+                  10<span className="text-[11px] font-bold text-[#A8D5C4]">/{prefectureCount ?? '41'}</span>
                 </p>
               </div>
               <div className="rounded-lg bg-[#FFF8EB] px-3 py-3 text-center">
                 <p className="text-[10px] font-bold text-[#9B9B9B]">ポケモン</p>
                 <p className="font-pixel text-xl font-extrabold text-[#C87C2A]">
-                  104<span className="text-[11px] font-bold text-[#D4BC8A]">/{pokemonCount ?? '500+'}</span>
+                  104<span className="text-[11px] font-bold text-[#D4BC8A]">/{pokemonCount ?? '534'}</span>
                 </p>
               </div>
             </div>
@@ -787,6 +805,7 @@ export default function VisitsPage() {
             </section>
           )}
         </main>
+        </PCShell>
 
         <BottomNav />
       </div>

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -22,7 +22,6 @@ import { Manhole } from '@/types/database';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PCShell from '@/components/PCShell';
-import StampBookMockup from '@/components/StampBookMockup';
 import DeletePhotoModal from '@/components/DeletePhotoModal';
 import ShareButtons from '@/components/ShareButtons';
 import { createBrowserClient } from '@/lib/supabase/client';

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -141,8 +141,8 @@ export default function Header({
 
           {user ? (
             <div className="flex min-w-0 items-center gap-1.5">
-              <div className="hidden max-w-[9rem] items-center gap-1.5 truncate rounded-lg border border-[#7B63A8]/15 bg-white/70 px-2.5 py-2 text-xs font-bold text-[#2A2A2A] sm:flex">
-                <UserIcon className="h-4 w-4 flex-shrink-0 text-[#7B63A8]" />
+              <div className="flex max-w-[7rem] items-center gap-1 truncate rounded-lg border border-[#7B63A8]/15 bg-white/70 px-2 py-1.5 text-xs font-bold text-[#2A2A2A] sm:max-w-[9rem] sm:gap-1.5 sm:px-2.5 sm:py-2">
+                <UserIcon className="h-3.5 w-3.5 flex-shrink-0 text-[#7B63A8] sm:h-4 sm:w-4" />
                 <span className="truncate">{getDisplayName(user)}</span>
               </div>
               <button

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -133,7 +133,7 @@ function PCTopNav({ active }: PCTopNavProps) {
 
       {/* ナビリンク */}
       <div style={{ display: 'flex', gap: 4, marginLeft: 18 }}>
-        {navItems.map(({ key, label, href }) => {
+        {authLoaded && navItems.map(({ key, label, href }) => {
           const isActive = resolveActive(key, href);
           return (
             <Link

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -3,12 +3,18 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Info, LogOut } from 'lucide-react';
+import { Info, LogOut, UserPlus } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 
-type NavTab = 'search' | 'stamp' | 'mytrip';
+type NavTab = 'search' | 'post' | 'stamp' | 'mytrip';
 
-const NAV_ITEMS: { key: NavTab; label: string; href: string }[] = [
+const GUEST_NAV_ITEMS: { key: NavTab; label: string; href: string }[] = [
+  { key: 'search', label: '探す', href: '/nearby' },
+  { key: 'post', label: '投稿', href: '/popular' },
+  { key: 'stamp', label: 'スタンプ帳', href: '/visits' },
+];
+
+const AUTH_NAV_ITEMS: { key: NavTab; label: string; href: string }[] = [
   { key: 'search', label: '探す', href: '/nearby' },
   { key: 'stamp', label: 'スタンプ帳', href: '/visits' },
   { key: 'mytrip', label: 'マイ旅', href: '/my-trip' },
@@ -100,6 +106,9 @@ function PCTopNav({ active }: PCTopNavProps) {
     } catch { /* ignore */ }
   };
 
+  const isLoggedIn = authLoaded && displayName !== null;
+  const navItems = isLoggedIn ? AUTH_NAV_ITEMS : GUEST_NAV_ITEMS;
+
   const resolveActive = (key: NavTab, href: string) => {
     if (active) return active === key;
     return pathname === href || pathname.startsWith(`${href}/`);
@@ -119,12 +128,12 @@ function PCTopNav({ active }: PCTopNavProps) {
       {/* ロゴ */}
       <Link href="/" className="flex items-center gap-2 shrink-0" style={{ textDecoration: 'none' }}>
         <PokeballMark size={28} />
-        <span style={{ fontWeight: 700, fontSize: 18, color: '#38414f', fontFamily: ROUND }}>ポケふた</span>
+        <span style={{ fontWeight: 700, fontSize: 18, color: '#38414f', fontFamily: ROUND }}>ポケふた写真館</span>
       </Link>
 
       {/* ナビリンク */}
       <div style={{ display: 'flex', gap: 4, marginLeft: 18 }}>
-        {NAV_ITEMS.map(({ key, label, href }) => {
+        {navItems.map(({ key, label, href }) => {
           const isActive = resolveActive(key, href);
           return (
             <Link
@@ -187,21 +196,42 @@ function PCTopNav({ active }: PCTopNavProps) {
             </button>
           </span>
         ) : (
-          <Link
-            href="/login"
-            style={{
-              fontSize: 13,
-              fontWeight: 600,
-              color: '#bf5640',
-              padding: '6px 14px',
-              borderRadius: 999,
-              border: '1px solid #bf5640',
-              textDecoration: 'none',
-              flexShrink: 0,
-            }}
-          >
-            ログイン
-          </Link>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+            <Link
+              href="/login"
+              style={{
+                fontSize: 13,
+                fontWeight: 600,
+                color: '#7B63A8',
+                padding: '6px 14px',
+                borderRadius: 999,
+                border: '1px solid #d7d0ef',
+                textDecoration: 'none',
+                flexShrink: 0,
+              }}
+            >
+              ログイン
+            </Link>
+            <Link
+              href="/signup"
+              className="flex items-center gap-1.5"
+              style={{
+                fontSize: 13,
+                fontWeight: 800,
+                color: '#fff',
+                background: '#7B63A8',
+                padding: '6px 14px',
+                borderRadius: 999,
+                boxShadow: '0 2px 0 #5f55b8',
+                textDecoration: 'none',
+                flexShrink: 0,
+              }}
+              aria-label="新規登録"
+            >
+              <UserPlus size={15} strokeWidth={2.2} />
+              新規登録
+            </Link>
+          </span>
         )
       )}
     </nav>


### PR DESCRIPTION
## Summary
- **PCShell**: ゲスト時タブを「探す/投稿/スタンプ帳」、ログイン時を「探す/スタンプ帳/マイ旅」に切替。サービス名を「ポケふた写真館」に統一、ゲスト向け「ログイン」+「新規登録」ボタン追加
- **popular**: PCShell + ゲスト向け右レール（「写真ゼロを埋めよう」CTA）追加。ヒーローコピーを「写真がまだ無いポケふたは残り N 件」に修正
- **visits**: 未ログイン時にPCShell追加、「旅を続けると…」カードに「例」バッジ追加、フォールバック値を都道府県41・ポケモン534に修正
- **nearby**: ゲスト向けヒーローセクション・プロモバー・PC右レール（登録CTA）追加
- **Header**: SPログイン時にアカウント名が表示されない不具合を修正（`hidden sm:flex` → 常時表示）

## Test plan
- [ ] SP幅（390px）で `/popular`, `/nearby`, `/visits` を未ログイン状態で確認 — 下タブが「探す/投稿/スタンプ帳」
- [ ] PC幅（1280px）で上記3ページを確認 — PCTopNavが「探す/投稿/スタンプ帳」、右レールにゲストCTA表示
- [ ] ログイン後 — PCTopNavが「探す/スタンプ帳/マイ旅」に切替、右レールがログイン済み用に変わる
- [ ] SP幅でログイン時 — ヘッダーにアカウント名が表示される
- [ ] `/visits` 未ログイン状態 — 「旅を続けると…」カードに「例」バッジ、都道府県41/ポケモン534が表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)