### PR TITLE
fix: auth callback が Amplify で localhost にリダイレクトする問題を修正

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -41,6 +41,7 @@ const nextConfig = {
     return config;
   },
   experimental: {
+    trustHost: true,
     serverComponentsExternalPackages: ['sharp'],
     outputFileTracingIncludes: {
       '/manhole/[id]/opengraph-image': [

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
+import { SITE_URL } from '@/lib/constants';
 
 function getSafeRedirectPath(value: string | null) {
   if (!value || !value.startsWith('/') || value.startsWith('//')) return '/';
@@ -16,7 +17,10 @@ export async function GET(request: Request) {
   // Provider-level errors (user denied, invalid client) arrive as ?error= before our code runs
   const providerError = requestUrl.searchParams.get('error');
 
-  const loginUrl = new URL('/login', requestUrl.origin);
+  // requestUrl.origin はリバースプロキシ環境で localhost を返すことがある。
+  // NEXT_PUBLIC_SITE_URL > SITE_URL の順で優先し requestUrl.origin は使わない。
+  const appOrigin = process.env.NEXT_PUBLIC_SITE_URL ?? SITE_URL;
+  const loginUrl = new URL('/login', appOrigin);
 
   if (providerError) {
     loginUrl.searchParams.set(


### PR DESCRIPTION
## 問題

本番（AWS Amplify）で Google ログイン後、ブラウザが `https://localhost:3000/login?from=google_oauth&code=...` にリダイレクトされてログインできない。

## 原因

`auth/callback/route.ts` で `requestUrl.origin` を使ってリダイレクト先を組み立てていたが、Amplify のリバースプロキシ環境では `request.url` が内部サーバーの URL (`https://localhost:3000/...`) を返すため、localhost に飛んでいた。

Supabase のログで確認した流れ：
1. Google 認証後、Supabase は `https://pokefuta.com/auth/callback?code=...` に正しくリダイレクト ✅
2. `/auth/callback` route handler が `requestUrl.origin` = `https://localhost:3000` を返す ❌
3. `https://localhost:3000/login?from=google_oauth&code=...` にリダイレクト → ログイン失敗

## 修正

`requestUrl.origin` の代わりに `NEXT_PUBLIC_SITE_URL`（Amplify 環境変数に `https://pokefuta.com` で設定済み）を使用。未設定時は `SITE_URL` 定数にフォールバック。

```diff
- const loginUrl = new URL('/login', requestUrl.origin);
+ const appOrigin = process.env.NEXT_PUBLIC_SITE_URL ?? SITE_URL;
+ const loginUrl = new URL('/login', appOrigin);
```

## テスト計画

- [ ] 本番で Google ログインを実行し、`https://pokefuta.com/login?from=google_oauth&code=...` にリダイレクトされることを確認
- [ ] ログインが正常に完了してセッションが作成されることを確認
- [ ] パスワードログインが引き続き正常に動作することを確認
- [ ] メール確認フロー（新規登録）が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)