### PR TITLE
fix: 未認証時の /api/auth/session 401 レスポンスによる error_event 急増を修正

### DIFF
--- a/.claude/commands/activity-check.md
+++ b/.claude/commands/activity-check.md
@@ -14,7 +14,8 @@ Steps:
   Auth users (registered) : {auth_users}
   Active users (7d login) : {active_users_7d}
   App users (active)      : {users}   ← wrote at least once; diff = signup-only users
-  Photos posted           : {posts}
+  Photos posted           : {posts} (公開: {public_posts}, 非公開: {private_posts})
+  Manhole comments        : {manhole_comments}
   Manholes total          : {manholes}
   Manholes w/ photos      : {manholes_with_photos}
 
@@ -33,6 +34,8 @@ Steps:
 
 Notes:
 - Use `jq` to parse JSON if available, otherwise parse manually.
+- Show `public_posts` and `private_posts` inline with Photos posted. If missing from response, show "N/A".
+- Show `manhole_comments` count. If missing, show "N/A".
 - If `latest_photo_at` is null, show "no photos yet".
 - Flag any anomalies:
   - `posts_last_7d == 0` → "No new photos this week"

--- a/src/app/api/auth/session/route.ts
+++ b/src/app/api/auth/session/route.ts
@@ -12,7 +12,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({
         authenticated: false,
         user: null
-      }, { status: 401 });
+      }, { status: 200 });
     }
 
     return NextResponse.json({

--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -26,12 +26,18 @@ async function fetchActivityStats(admin: SupabaseClient<Database>) {
     { data: latestVisit },
     { count: posts7d },
     { count: posts30d },
+    { count: commentsCount },
+    { count: publicPhotosCount },
+    { count: privatePhotosCount },
   ] = await Promise.all([
     admin.from('photo').select('created_at').order('created_at', { ascending: false }).limit(1),
     admin.from('app_user').select('created_at').order('created_at', { ascending: false }).limit(1),
     admin.from('visit').select('shot_at').order('shot_at', { ascending: false }).limit(1),
     admin.from('photo').select('id', { head: true, count: 'exact' }).gte('created_at', ago7d),
     admin.from('photo').select('id', { head: true, count: 'exact' }).gte('created_at', ago30d),
+    admin.from('manhole_comment').select('id', { head: true, count: 'exact' }),
+    admin.from('photo').select('id, visit:visit_id!inner(is_public)', { head: true, count: 'exact' }).eq('visit.is_public', true),
+    admin.from('photo').select('id, visit:visit_id!inner(is_public)', { head: true, count: 'exact' }).eq('visit.is_public', false),
   ]);
 
   // auth.users の総件数 + 直近7日ログイン数を Admin Auth REST API から取得
@@ -84,6 +90,9 @@ async function fetchActivityStats(admin: SupabaseClient<Database>) {
     posts_last_30d: posts30d ?? 0,
     auth_users,
     active_users_7d,
+    manhole_comments: commentsCount ?? 0,
+    public_posts: publicPhotosCount ?? 0,
+    private_posts: privatePhotosCount ?? 0,
   };
 }
 

--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -176,6 +176,9 @@ export async function GET() {
       latest_visit_at: null,
       posts_last_7d: null,
       posts_last_30d: null,
+      manhole_comments: null,
+      public_posts: null,
+      private_posts: null,
       source: 'unavailable',
     });
   } catch (error: unknown) {
@@ -193,6 +196,9 @@ export async function GET() {
         latest_visit_at: null,
         posts_last_7d: null,
         posts_last_30d: null,
+        manhole_comments: null,
+        public_posts: null,
+        private_posts: null,
         error: 'Failed to get site statistics',
         details: error instanceof Error ? error.message : 'Unknown error',
       },

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -648,17 +648,11 @@ export default function ManholeDetailPage() {
           {/* ── Gallery ── */}
           {photoState === 'none' ? (
             <div
-              className="relative overflow-hidden rounded-[18px] border-2 border-dashed border-[#cdbf9f]"
-              style={{
-                background: 'repeating-linear-gradient(135deg,#f3ecdc 0 12px,#ece2cd 12px 24px)',
-                minHeight: 210,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
+              className="relative overflow-hidden rounded-[16px] lg:rounded-[18px] border-2 border-dashed border-[#cdbf9f] h-[210px] lg:h-[360px] flex items-center justify-center"
+              style={{ background: 'repeating-linear-gradient(135deg,#f3ecdc 0 12px,#ece2cd 12px 24px)' }}
             >
               <div className="text-center">
-                <div className="font-['Outfit'] text-[44px] font-black leading-none text-[#cdbb92]">0</div>
+                <div className="font-['Outfit'] text-[44px] lg:text-[72px] font-black leading-none text-[#cdbb92]">0</div>
                 <div className="mt-2 font-pixelJp text-sm font-bold text-[#6f6657]">
                   この場所の写真はまだ0枚
                 </div>
@@ -677,14 +671,19 @@ export default function ManholeDetailPage() {
             <div className="flex flex-col gap-3">
               {/* Featured */}
               <div
-                className="relative overflow-hidden rounded-[18px] border border-[#e9dfc7] shadow-sm"
-                style={{ height: 232 }}
+                className="relative overflow-hidden rounded-[16px] lg:rounded-[18px] shadow-sm h-[300px] lg:h-[392px]"
+                style={{
+                  border: featuredPhoto?.visit?.user_id === currentUserId
+                    ? '2.5px solid #1f9d63'
+                    : '1px solid #e9dfc7',
+                  background: 'repeating-linear-gradient(135deg,#f3ecdc 0 12px,#ece2cd 12px 24px)',
+                }}
               >
                 {featuredPhoto && (
                   <img
                     src={`/api/photo/${featuredPhoto.id}?size=small`}
                     alt="ポケふた写真"
-                    className="h-full w-full object-cover"
+                    className="h-full w-full object-contain"
                     loading="lazy"
                   />
                 )}
@@ -739,7 +738,7 @@ export default function ManholeDetailPage() {
                           key={p.id}
                           type="button"
                           onClick={() => setSelectedPhotoIdx(i)}
-                          className="relative h-[60px] w-[60px] shrink-0 overflow-hidden rounded-[11px]"
+                          className="relative h-[60px] w-[60px] lg:h-[70px] lg:w-[70px] shrink-0 overflow-hidden rounded-[11px]"
                           style={{
                             border:
                               featuredPhoto?.id === p.id
@@ -771,7 +770,7 @@ export default function ManholeDetailPage() {
                       <button
                         type="button"
                         onClick={() => router.push('/upload')}
-                        className="flex h-[60px] w-[60px] shrink-0 items-center justify-center rounded-[11px] border-2 border-dashed border-[#cdbf9f]"
+                        className="flex h-[60px] w-[60px] lg:h-[70px] lg:w-[70px] shrink-0 items-center justify-center rounded-[11px] border-2 border-dashed border-[#cdbf9f]"
                         style={{ background: 'repeating-linear-gradient(135deg,#f3ecdc 0 6px,#ece2cd 6px 12px)' }}
                       >
                         <Plus className="h-[18px] w-[18px] text-[#bf5640]" strokeWidth={2.5} />
@@ -796,7 +795,7 @@ export default function ManholeDetailPage() {
                         type="button"
                         onClick={() => setSelectedPhotoIdx(myPhotos.length + i)}
                         title={`@${getPhotoUserLabel(p)}`}
-                        className="relative h-[60px] w-[60px] shrink-0 overflow-hidden rounded-[11px]"
+                        className="relative h-[60px] w-[60px] lg:h-[70px] lg:w-[70px] shrink-0 overflow-hidden rounded-[11px]"
                         style={{
                           border:
                             featuredPhoto?.id === p.id
@@ -816,7 +815,7 @@ export default function ManholeDetailPage() {
                       <button
                         type="button"
                         onClick={() => router.push(isLoggedIn ? '/upload' : '/login?redirect=/upload')}
-                        className="flex h-[60px] w-[60px] shrink-0 items-center justify-center rounded-[11px] border-2 border-dashed border-[#cdbf9f]"
+                        className="flex h-[60px] w-[60px] lg:h-[70px] lg:w-[70px] shrink-0 items-center justify-center rounded-[11px] border-2 border-dashed border-[#cdbf9f]"
                         style={{ background: 'repeating-linear-gradient(135deg,#f3ecdc 0 6px,#ece2cd 6px 12px)' }}
                       >
                         {isLoggedIn ? (


### PR DESCRIPTION
## 問題

未ログイン状態でマンホール詳細ページ（`/manhole/[id]`）を開くと、毎回 GA4 に `error_event` が送信されていた。

## 原因

`GET /api/auth/session` が未認証ユーザーに対して **401** を返していた。  
`ApiErrorAnalytics` はグローバルに `window.fetch` をパッチしており、`!response.ok`（≥400）の全レスポンスで `error_event` を送信する仕組みになっている。

```
未ログイン → fetch('/api/auth/session') → 401
→ ApiErrorAnalytics: !response.ok → error_event 送信
```

## 修正

`src/app/api/auth/session/route.ts` の未認証レスポンスを `401 → 200` に変更。  
セッション確認エンドポイントは「エラー」ではなく「認証状態を返す」ものなので 200 が正しい。

呼び出し元（`ManholePage.tsx:201`）は `response.ok` の後に `data.authenticated` でダブルチェックしているため、動作変更なし。

## その他の変更

- `site-stats` API に `manhole_comments`・`public_posts`・`private_posts` 統計を追加
- マンホール詳細ページのレスポンシブ対応 tweaks（`lg:` ブレークポイント）
- activity-check スキルに新フィールドの説明を追加

## 確認方法

1. 未ログイン状態で `https://pokefuta.com/manhole/133` を開く
2. DevTools Network → `/api/auth/session` が **200** を返すことを確認
3. GA4 リアルタイムで `error_event` が来なくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)