### PR TITLE
fix: サインアップ時の display_name 自動生成を削除

### DIFF
--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -149,7 +149,7 @@ export async function POST(request: NextRequest) {
     const displayName = session.user.user_metadata?.display_name;
 
     // ✅ Ensure app_user exists, auto-create if missing
-    await ensureAppUser(supabase, userId, session.user.email, displayName);
+    await ensureAppUser(supabase, userId, displayName);
 
     // Parse multipart form data
     const formData = await request.formData();

--- a/src/app/api/visits/[id]/bookmark/route.ts
+++ b/src/app/api/visits/[id]/bookmark/route.ts
@@ -87,7 +87,7 @@ export async function POST(
     const displayName = session.user.user_metadata?.display_name;
 
     // ✅ Ensure app_user exists, auto-create if missing
-    await ensureAppUser(supabase, userId, session.user.email, displayName);
+    await ensureAppUser(supabase, userId, displayName);
 
     // ✅ 2. 訪問記録の存在確認
     const { data: visit, error: visitError } = await supabase

--- a/src/app/api/visits/[id]/comments/route.ts
+++ b/src/app/api/visits/[id]/comments/route.ts
@@ -201,7 +201,7 @@ export async function POST(
     const metadataDisplayName = session.user.user_metadata?.display_name;
 
     // ✅ Ensure app_user exists, auto-create if missing
-    await ensureAppUser(supabase, userId, session.user.email, metadataDisplayName);
+    await ensureAppUser(supabase, userId, metadataDisplayName);
 
     // ✅ 2. 入力検証
     if (!content || typeof content !== 'string' || content.trim() === '') {

--- a/src/app/api/visits/[id]/like/route.ts
+++ b/src/app/api/visits/[id]/like/route.ts
@@ -87,7 +87,7 @@ export async function POST(
     const displayName = session.user.user_metadata?.display_name;
 
     // ✅ Ensure app_user exists, auto-create if missing
-    await ensureAppUser(supabase, userId, session.user.email, displayName);
+    await ensureAppUser(supabase, userId, displayName);
 
     // ✅ 2. 訪問記録の存在確認
     const { data: visit, error: visitError } = await supabase

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -353,7 +353,7 @@ function LoginForm() {
         password,
         options: {
           emailRedirectTo: callbackUrl.toString(),
-          data: { display_name: email.split('@')[0] },
+          data: {},
         },
       });
       if (signUpError) throw signUpError;

--- a/src/lib/auth/ensureAppUser.ts
+++ b/src/lib/auth/ensureAppUser.ts
@@ -25,7 +25,7 @@ export async function ensureAppUser(
       .upsert(
         {
           auth_uid: userId,
-          display_name: displayName || email?.split('@')[0] || 'User'
+          display_name: displayName || null
         },
         {
           onConflict: 'auth_uid',

--- a/src/lib/auth/ensureAppUser.ts
+++ b/src/lib/auth/ensureAppUser.ts
@@ -8,13 +8,11 @@ import type { Database } from '@/types/database';
  *
  * @param supabase - Supabase client (server or browser)
  * @param userId - Auth user ID (auth.uid())
- * @param email - Optional email for display_name fallback
- * @param displayName - Optional display_name from user metadata (preferred over email-derived name)
+ * @param displayName - Optional display_name from user metadata
  */
 export async function ensureAppUser(
   supabase: SupabaseClient<any>,
   userId: string,
-  email?: string,
   displayName?: string
 ): Promise<void> {
   try {


### PR DESCRIPTION
## Summary

- サインアップ時に `email.split('@')[0]` で自動生成していた `display_name` を廃止
- `ensureAppUser` の `email` パラメータを削除（display_name フォールバックとして使われていたが不要に）
- 新規ユーザーは display_name を明示的に設定するまで `null` を許容する

## Test plan

- [ ] 新規メール登録後、`app_user.display_name` が `null` になっている（Supabase で確認）
- [ ] display_name が `null` のユーザーが写真投稿・コメント等の操作を正常に行えること
- [ ] 既存ユーザーの display_name は `ignoreDuplicates: true` により上書きされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)