### PR TITLE
feat: 投稿導線のグローバル化 — PC常設ボタン・SP中央FAB・レールCTA格下げ

### DIFF
--- a/public/data/latest-manhole-photos.json
+++ b/public/data/latest-manhole-photos.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-06-14T08:53:19.000336Z",
+  "generated_at": "2026-06-15T11:21:16.026825Z",
   "source": "pokefuta photo table",
   "image": {
     "r2_public_base_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image"
   },
-  "count": 127,
+  "count": 131,
   "photos": {
     "1": {
       "manhole_id": 1,
@@ -155,6 +155,21 @@
       "shot_at": "2026-01-04T08:13:06+00:00",
       "comment": null,
       "display_name": "ロイ"
+    },
+    "54": {
+      "manhole_id": 54,
+      "photo_id": "0bc53f77-f438-4647-ae1f-4be7b1e8f6b5",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/3e7c4903-938e-4de6-a0b6-d2ad03bfde37.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/3e7c4903-938e-4de6-a0b6-d2ad03bfde37.jpg",
+      "storage_key": "photos/original/2026/06/3e7c4903-938e-4de6-a0b6-d2ad03bfde37.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1006655,
+      "created_at": "2026-06-14T13:25:08.57604+00:00",
+      "shot_at": "2026-06-13T15:35:26+00:00",
+      "comment": null,
+      "display_name": "Sky134z"
     },
     "59": {
       "manhole_id": 59,
@@ -410,6 +425,51 @@
       "shot_at": "2025-03-09T04:17:31+00:00",
       "comment": "大津市は、公園南側",
       "display_name": "tako"
+    },
+    "125": {
+      "manhole_id": 125,
+      "photo_id": "ab2974a9-d2d1-4b72-86fe-553f54851dbd",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/5f4ecc14-bcf3-457a-afe8-e9284ea3523e.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/5f4ecc14-bcf3-457a-afe8-e9284ea3523e.jpg",
+      "storage_key": "photos/original/2026/06/5f4ecc14-bcf3-457a-afe8-e9284ea3523e.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1446158,
+      "created_at": "2026-06-14T13:27:20.73437+00:00",
+      "shot_at": "2026-06-12T02:46:02+00:00",
+      "comment": null,
+      "display_name": "Sky134z"
+    },
+    "133": {
+      "manhole_id": 133,
+      "photo_id": "249ed8d5-f36d-4bfa-b091-e73da208b95a",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/38987fcb-880b-408a-99d6-6c02db21e357.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/38987fcb-880b-408a-99d6-6c02db21e357.jpg",
+      "storage_key": "photos/original/2026/06/38987fcb-880b-408a-99d6-6c02db21e357.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1470013,
+      "created_at": "2026-06-14T13:28:32.693357+00:00",
+      "shot_at": "2026-06-12T02:23:57+00:00",
+      "comment": null,
+      "display_name": "Sky134z"
+    },
+    "135": {
+      "manhole_id": 135,
+      "photo_id": "b5c38bd6-a4b2-4fac-a890-be45ef8803f5",
+      "url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/ecdd7585-b8bf-4697-95e0-755f027d2877.jpg",
+      "original_url": "https://509ce5c2ad8789cb0c6b20908ab44404.r2.cloudflarestorage.com/image/photos/original/2026/06/ecdd7585-b8bf-4697-95e0-755f027d2877.jpg",
+      "storage_key": "photos/original/2026/06/ecdd7585-b8bf-4697-95e0-755f027d2877.jpg",
+      "content_type": "image/jpeg",
+      "width": null,
+      "height": null,
+      "file_size": 1492191,
+      "created_at": "2026-06-14T13:28:00.862032+00:00",
+      "shot_at": "2026-06-12T01:43:14+00:00",
+      "comment": null,
+      "display_name": "Sky134z"
     },
     "140": {
       "manhole_id": 140,
@@ -1920,6 +1980,16 @@
         "content": "rわr",
         "created_at": "2026-05-15T11:55:00.013485+00:00",
         "updated_at": "2026-05-15T11:55:00.013485+00:00",
+        "display_name": "tako"
+      }
+    ],
+    "220": [
+      {
+        "id": "c11cbefe-e9fb-4e85-aa43-01db5a56cf93",
+        "manhole_id": 220,
+        "content": "ちょっとわかりにくいかも",
+        "created_at": "2026-06-14T15:35:15.644682+00:00",
+        "updated_at": "2026-06-14T15:35:15.644682+00:00",
         "display_name": "tako"
       }
     ],

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -589,7 +589,11 @@ export default function ManholeDetailPage() {
             <button
               type="button"
               onClick={() => router.push(isLoggedIn ? '/upload' : '/login?redirect=/upload')}
-              className="flex w-full items-center justify-center gap-2 rounded-[14px] border border-[#ecccc1] bg-white py-3 font-pixelJp text-sm font-bold text-[#bf5640] transition-colors hover:bg-[#fdeae2]"
+              className={`flex w-full items-center justify-center gap-2 rounded-[14px] py-3 font-pixelJp text-sm font-bold transition-colors ${
+                isLoggedIn
+                  ? 'border border-[#ecccc1] bg-white text-[#bf5640] hover:bg-[#fdeae2]'
+                  : 'bg-[#bf5640] text-white shadow-[0_2px_0_#a8462f] hover:opacity-90'
+              }`}
             >
               {!isLoggedIn ? (
                 <Lock className="h-4 w-4" strokeWidth={2} />

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -585,26 +585,34 @@ export default function ManholeDetailPage() {
             別の構図を追加する
           </button>
         ) : (
-          <button
-            type="button"
-            onClick={() => router.push(isLoggedIn ? '/upload' : '/login?redirect=/upload')}
-            className="flex w-full items-center justify-center gap-2 rounded-[14px] bg-[#bf5640] py-3 font-pixelJp text-sm font-bold text-white shadow-[0_2px_0_#a8462f] transition-colors hover:bg-[#a84b36]"
-          >
-            {!isLoggedIn ? (
-              <Lock className="h-4 w-4" strokeWidth={2} />
-            ) : photoState === 'none' ? (
-              <Flag className="h-4 w-4" strokeWidth={2.5} />
-            ) : (
-              <Plus className="h-4 w-4" strokeWidth={2.5} />
+          <>
+            <button
+              type="button"
+              onClick={() => router.push(isLoggedIn ? '/upload' : '/login?redirect=/upload')}
+              className="flex w-full items-center justify-center gap-2 rounded-[14px] border border-[#ecccc1] bg-white py-3 font-pixelJp text-sm font-bold text-[#bf5640] transition-colors hover:bg-[#fdeae2]"
+            >
+              {!isLoggedIn ? (
+                <Lock className="h-4 w-4" strokeWidth={2} />
+              ) : photoState === 'none' ? (
+                <Flag className="h-4 w-4" strokeWidth={2.5} />
+              ) : (
+                <Plus className="h-4 w-4" strokeWidth={2.5} />
+              )}
+              {!isLoggedIn
+                ? photoState === 'none'
+                  ? 'ログインして一番乗り'
+                  : 'ログインして投稿する'
+                : photoState === 'none'
+                ? '一番乗りで投稿する'
+                : 'あなたの1枚を加える'}
+            </button>
+            {isLoggedIn && (
+              <p className="flex items-center gap-1.5 font-pixelJp text-[11px] leading-snug text-[#9b917e]">
+                <Users className="h-3 w-3 shrink-0" strokeWidth={2} />
+                ナビの「投稿する」からいつでも追加できます
+              </p>
             )}
-            {!isLoggedIn
-              ? photoState === 'none'
-                ? 'ログインして一番乗り'
-                : 'ログインして投稿する'
-              : photoState === 'none'
-              ? '一番乗りで投稿する'
-              : 'あなたの1枚を加える'}
-          </button>
+          </>
         )}
 
         {/* Hints */}

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -2,8 +2,8 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
-import { BookOpen, CircleDot, Image, Search } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { BookOpen, Camera, CircleDot, Search } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
@@ -41,35 +41,100 @@ export default function BottomNav() {
     };
   }, []);
 
-  const items = useMemo(
-    () => isLoggedIn
-      ? [
-          { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
-          { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
-          { href: '/my-trip', label: 'マイ旅', icon: <BookOpen className="w-6 h-6 mb-1" /> },
-        ]
-      : [
-          { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
-          { href: '/', label: '投稿', icon: <Image className="w-6 h-6 mb-1" /> },
-          { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
-        ],
-    [isLoggedIn]
-  );
+  const guestItems = [
+    { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
+    { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
+    { href: '/my-trip', label: 'マイ旅', icon: <BookOpen className="w-6 h-6 mb-1" /> },
+  ];
+
+  const leftItems = [
+    { href: '/nearby', label: '探す', icon: <Search className="w-6 h-6 mb-1" /> },
+    { href: '/visits', label: 'スタンプ帳', icon: <CircleDot className="w-6 h-6 mb-1" /> },
+  ];
+
+  const rightItems = [
+    { href: '/my-trip', label: 'マイ旅', icon: <BookOpen className="w-6 h-6 mb-1" /> },
+  ];
+
+  if (!isLoggedIn) {
+    return (
+      <nav className="nav-rpg lg:hidden">
+        <div className="flex justify-around items-center max-w-md mx-auto py-2">
+          {guestItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`nav-rpg-item ${isActivePath(pathname, item.href) ? 'active' : ''}`}
+              onClick={() => trackNavClick(item.label)}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </div>
+      </nav>
+    );
+  }
 
   return (
     <nav className="nav-rpg lg:hidden">
-      <div className="flex justify-around items-center max-w-md mx-auto py-2">
-        {items.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className={`nav-rpg-item ${isActivePath(pathname, item.href) ? 'active' : ''}`}
-            onClick={() => trackNavClick(item.label)}
-          >
-            {item.icon}
-            <span>{item.label}</span>
-          </Link>
-        ))}
+      <div className="flex items-stretch max-w-md mx-auto" style={{ paddingBottom: 10, paddingTop: 8 }}>
+        {/* Left tabs */}
+        <div className="flex flex-1 justify-around">
+          {leftItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`nav-rpg-item ${isActivePath(pathname, item.href) ? 'active' : ''}`}
+              onClick={() => trackNavClick(item.label)}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </div>
+
+        {/* Center FAB slot */}
+        <div style={{ width: 72, flexShrink: 0, position: 'relative' }}>
+          <div style={{ position: 'absolute', left: '50%', top: -22, transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+            <Link
+              href="/upload"
+              onClick={() => trackNavClick('投稿')}
+              style={{
+                width: 58,
+                height: 58,
+                borderRadius: 999,
+                border: '3px solid #fff',
+                background: 'radial-gradient(120% 120% at 30% 25%, #d06a4f, #bf5640)',
+                color: '#fff',
+                display: 'grid',
+                placeItems: 'center',
+                boxShadow: '0 4px 0 #a8462f, 0 10px 22px rgba(191,86,64,.45)',
+                textDecoration: 'none',
+                flexShrink: 0,
+              }}
+              aria-label="投稿する"
+            >
+              <Camera size={26} strokeWidth={2.4} />
+            </Link>
+            <span style={{ fontSize: 10.5, fontWeight: 800, color: '#bf5640', fontFamily: '"M PLUS Rounded 1c", system-ui, sans-serif', lineHeight: 1 }}>投稿</span>
+          </div>
+        </div>
+
+        {/* Right tabs */}
+        <div className="flex flex-1 justify-around">
+          {rightItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`nav-rpg-item ${isActivePath(pathname, item.href) ? 'active' : ''}`}
+              onClick={() => trackNavClick(item.label)}
+            >
+              {item.icon}
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </div>
       </div>
     </nav>
   );

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -15,7 +15,7 @@ function isActivePath(pathname: string, href: string) {
 
 export default function BottomNav() {
   const pathname = usePathname();
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean | null>(null);
   const { trackNavClick } = useAnalytics();
 
   useEffect(() => {
@@ -55,6 +55,8 @@ export default function BottomNav() {
   const rightItems = [
     { href: '/my-trip', label: 'マイ旅', icon: <BookOpen className="w-6 h-6 mb-1" /> },
   ];
+
+  if (isLoggedIn === null) return null;
 
   if (!isLoggedIn) {
     return (
@@ -96,11 +98,20 @@ export default function BottomNav() {
 
         {/* Center FAB slot */}
         <div style={{ width: 72, flexShrink: 0, position: 'relative' }}>
-          <div style={{ position: 'absolute', left: '50%', top: -22, transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 3 }}>
+          <div style={{ position: 'absolute', left: '50%', top: -22, transform: 'translateX(-50%)', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             <Link
               href="/upload"
               onClick={() => trackNavClick('投稿')}
+              aria-current={isActivePath(pathname, '/upload') ? 'page' : undefined}
               style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 3,
+                textDecoration: 'none',
+              }}
+            >
+              <span style={{
                 width: 58,
                 height: 58,
                 borderRadius: 999,
@@ -110,14 +121,12 @@ export default function BottomNav() {
                 display: 'grid',
                 placeItems: 'center',
                 boxShadow: '0 4px 0 #a8462f, 0 10px 22px rgba(191,86,64,.45)',
-                textDecoration: 'none',
                 flexShrink: 0,
-              }}
-              aria-label="投稿する"
-            >
-              <Camera size={26} strokeWidth={2.4} />
+              }}>
+                <Camera size={26} strokeWidth={2.4} />
+              </span>
+              <span style={{ fontSize: 10.5, fontWeight: 800, color: '#bf5640', fontFamily: '"M PLUS Rounded 1c", system-ui, sans-serif', lineHeight: 1 }}>投稿</span>
             </Link>
-            <span style={{ fontSize: 10.5, fontWeight: 800, color: '#bf5640', fontFamily: '"M PLUS Rounded 1c", system-ui, sans-serif', lineHeight: 1 }}>投稿</span>
           </div>
         </div>
 

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -175,9 +175,10 @@ function PCTopNav({ active }: PCTopNavProps) {
       </a>
 
       {/* 投稿する */}
-      {authLoaded && displayName && (
+      {isLoggedIn && (
         <Link
           href="/upload"
+          aria-current={pathname === '/upload' || pathname.startsWith('/upload/') ? 'page' : undefined}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -190,10 +191,9 @@ function PCTopNav({ active }: PCTopNavProps) {
             fontWeight: 800,
             fontSize: 14,
             textDecoration: 'none',
-            boxShadow: '0 2px 0 #a8462f, 0 7px 18px rgba(191,86,64,.38)',
-            outline: '3px solid rgba(191,86,64,.13)',
-            outlineOffset: 0,
+            boxShadow: '0 2px 0 #a8462f, 0 7px 18px rgba(191,86,64,.38), 0 0 0 3px rgba(191,86,64,.13)',
             flexShrink: 0,
+            opacity: pathname === '/upload' || pathname.startsWith('/upload/') ? 0.7 : 1,
           }}
         >
           <Camera size={17} strokeWidth={2.5} />投稿する

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -3,14 +3,13 @@
 import React, { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
-import { Info, LogOut, UserPlus } from 'lucide-react';
+import { Camera, Info, LogOut, UserPlus } from 'lucide-react';
 import { createBrowserClient } from '@/lib/supabase/client';
 
 type NavTab = 'search' | 'post' | 'stamp' | 'mytrip';
 
 const GUEST_NAV_ITEMS: { key: NavTab; label: string; href: string }[] = [
   { key: 'search', label: '探す', href: '/nearby' },
-  { key: 'post', label: '投稿', href: '/' },
   { key: 'stamp', label: 'スタンプ帳', href: '/visits' },
 ];
 
@@ -174,6 +173,32 @@ function PCTopNav({ active }: PCTopNavProps) {
       >
         X
       </a>
+
+      {/* 投稿する */}
+      {authLoaded && displayName && (
+        <Link
+          href="/upload"
+          style={{
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: 8,
+            background: '#bf5640',
+            color: '#fff',
+            borderRadius: 999,
+            padding: '9px 18px 9px 15px',
+            fontFamily: ROUND,
+            fontWeight: 800,
+            fontSize: 14,
+            textDecoration: 'none',
+            boxShadow: '0 2px 0 #a8462f, 0 7px 18px rgba(191,86,64,.38)',
+            outline: '3px solid rgba(191,86,64,.13)',
+            outlineOffset: 0,
+            flexShrink: 0,
+          }}
+        >
+          <Camera size={17} strokeWidth={2.5} />投稿する
+        </Link>
+      )}
 
       {/* ユーザー */}
       {authLoaded && (


### PR DESCRIPTION
## Summary

投稿 (KEY ACTION) をグローバルナビに常設し、ログイン中はどの画面からでも1タップで届くようにする。

- **PC トップナビ**: ログイン中のみ terracotta の「投稿する」ボタンを右端に常設（`PCShell.tsx`）
- **SP ボトムナビ**: ログイン中は 2+FAB中央+1 レイアウトに変更。中央に隆起した camera FAB → `/upload`（`BottomNav.tsx`）
- **SP ゲスト**: 「投稿→/」タブを廃止し「探す・スタンプ帳・マイ旅」3タブに統一
- **詳細ページ レール CTA**: 塗り Terracotta → アウトラインに格下げ（ナビに主声を集約）。ログイン中は「ナビの〜」ヒントを表示

## コードレビュー修正（実装後に発見・同コミットに含む）

| 問題 | 修正 |
|---|---|
| `position:relative` が `nav-rpg` の `fixed` を上書きしてnavが固定されない | `style` を削除 |
| `GUEST_NAV_ITEMS` に残存していた「投稿→/」タブ | エントリを削除 |
| `useMemo` 未使用 import | import から削除 |
| ヒント文言「上の」がSPでは方向逆 | 「ナビの」に変更 |

## Test plan

- [ ] ログイン状態で PC アクセス → トップナビ右に赤い「投稿する」ボタンが表示され `/upload` に遷移する
- [ ] ログアウト状態で PC アクセス → 投稿ボタンは表示されず、既存のログイン/新規登録ボタンのみ
- [ ] ログイン状態でスマホアクセス → ボトムナビ中央に隆起した camera FAB が表示され `/upload` に遷移する
- [ ] ログアウト状態でスマホアクセス → ボトムナビは「探す・スタンプ帳・マイ旅」3タブのみ（FABなし）
- [ ] ログイン状態でスマホアクセス → ボトムナビが画面下部に固定されたまま（スクロールで流れない）
- [ ] マンホール詳細ページのレールCTAがアウトライン表示になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)