### PR TITLE
feat: 写真削除UXの改善とEXIFフォレンジクス収集

### DIFF
--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -165,9 +165,19 @@ export async function POST(request: NextRequest) {
 
     let photoExif: Record<string, any> | undefined;
     if (exifStr) {
+      const exifRaw = exifStr as string;
+      if (exifRaw.length > 51200) {
+        return NextResponse.json({ success: false, error: 'exif payload too large (max 50KB)' }, { status: 400 });
+      }
       try {
-        photoExif = JSON.parse(exifStr as string);
-      } catch {}
+        const parsed = JSON.parse(exifRaw);
+        if (typeof parsed !== 'object' || Array.isArray(parsed) || parsed === null) {
+          return NextResponse.json({ success: false, error: 'exif must be a JSON object' }, { status: 400 });
+        }
+        photoExif = parsed;
+      } catch {
+        return NextResponse.json({ success: false, error: 'exif is not valid JSON' }, { status: 400 });
+      }
     }
 
     if (!file) {

--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -161,6 +161,14 @@ export async function POST(request: NextRequest) {
     const isPublic = formData.get('is_public');  // 公開設定
     const latitude = formData.get('latitude');
     const longitude = formData.get('longitude');
+    const exifStr = formData.get('exif');
+
+    let photoExif: Record<string, any> | undefined;
+    if (exifStr) {
+      try {
+        photoExif = JSON.parse(exifStr as string);
+      } catch {}
+    }
 
     if (!file) {
       return NextResponse.json({
@@ -349,6 +357,7 @@ export async function POST(request: NextRequest) {
       if (fileSize) photoInsert.file_size = fileSize;
       if (file.type) photoInsert.content_type = file.type;
       if (file.name) photoInsert.original_name = file.name;
+      if (photoExif) photoInsert.exif = photoExif;
 
       const { data: photoData, error: photoError } = await supabase
         .from('photo')

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -749,6 +749,15 @@ export default function ManholeDetailPage() {
                         {formatPhotoDate(featuredPhoto.visit.shot_at)}
                       </span>
                     )}
+                    {featuredPhoto.visit?.user_id === currentUserId && (
+                      <button
+                        type="button"
+                        onClick={(e) => { e.stopPropagation(); handleDeleteClick(featuredPhoto.id, featuredPhoto.visit?.id); }}
+                        style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 11, fontWeight: 700, color: '#fff', background: 'rgba(180,30,30,0.75)', borderRadius: 99, padding: '3px 9px', flexShrink: 0, border: 'none', cursor: 'pointer' }}
+                      >
+                        削除
+                      </button>
+                    )}
                   </div>
                 )}
               </button>
@@ -784,16 +793,6 @@ export default function ManholeDetailPage() {
                           <span className="absolute left-0.5 top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-[#1f9d63]">
                             <Camera className="h-2.5 w-2.5 text-white" strokeWidth={2.4} />
                           </span>
-                          {/* delete button — only reachable here since myPhotos excludes commPhotos */}
-                          <button
-                            type="button"
-                            onClick={(e) => { e.stopPropagation(); handleDeleteClick(p.id, p.visit?.id); }}
-                            className="absolute right-0.5 top-0.5 flex h-4 w-4 items-center justify-center rounded-full bg-black/60"
-                            title="削除"
-                            style={{ color: '#fff' }}
-                          >
-                            <span className="text-[9px] leading-none">×</span>
-                          </button>
                         </button>
                       ))}
                       {/* add slot */}
@@ -1085,7 +1084,6 @@ export default function ManholeDetailPage() {
       {selectedPhotoId && (
         <DeletePhotoModal
           isOpen={deleteModalOpen}
-          photoId={selectedPhotoId}
           onConfirm={handleDeleteConfirm}
           onCancel={handleDeleteCancel}
           isDeleting={isDeleting}

--- a/src/app/p/[photoId]/page.tsx
+++ b/src/app/p/[photoId]/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { cookies } from 'next/headers';
 import { ArrowLeft, Camera, MapPin, Sparkles } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';

--- a/src/app/p/[photoId]/page.tsx
+++ b/src/app/p/[photoId]/page.tsx
@@ -1,13 +1,16 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { cookies } from 'next/headers';
 import { ArrowLeft, Camera, MapPin, Sparkles } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import ShareButtons from '@/components/ShareButtons';
+import PhotoDeleteButton from '@/components/PhotoDeleteButton';
 import { formatDateJa } from '@/lib/date';
 import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import { photoShareText } from '@/lib/share';
+import { createServerClient } from '@/lib/supabase/server';
 import {
   getManholeLocationLabel,
   getSortedTitles,
@@ -69,6 +72,10 @@ export default async function SharedPhotoPage({ params }: PageProps) {
   const photo = await loadPublicSharedPhoto(params.photoId);
 
   if (!photo) notFound();
+
+  const supabase = createServerClient();
+  const { data: { session } } = await supabase.auth.getSession();
+  const isOwner = session?.user?.id === photo.visit.user_id;
 
   const titles = getSortedTitles(photo.manhole.titles);
   const locationLabel = getManholeLocationLabel(photo.manhole);
@@ -158,6 +165,12 @@ export default async function SharedPhotoPage({ params }: PageProps) {
               >
                 自分も記録する
               </Link>
+              {isOwner && (
+                <PhotoDeleteButton
+                  visitId={photo.visit.id}
+                  manholeId={photo.manhole.id}
+                />
+              )}
             </div>
           </div>
         </article>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -19,7 +19,7 @@ interface PhotoMetadata {
   datetime?: string;
   camera?: string;
   lens?: string;
-  rawExif?: Record<string, any>;
+  exifPayload?: Record<string, any>;
 }
 
 interface UploadedPhoto {
@@ -246,7 +246,7 @@ export default function UploadPage() {
         datetime: raw?.DateTimeOriginal || raw?.DateTime,
         camera: raw?.Make && raw?.Model ? `${raw.Make} ${raw.Model}` : undefined,
         lens: raw?.LensModel,
-        rawExif: exifPayload,
+        exifPayload,
       };
     } catch (error) {
       console.warn('Failed to extract EXIF data:', error);
@@ -487,8 +487,8 @@ export default function UploadPage() {
       // Add is_public setting
       formData.append('is_public', isPublic.toString());
 
-      if (photo.metadata.rawExif) {
-        formData.append('exif', JSON.stringify(photo.metadata.rawExif));
+      if (photo.metadata.exifPayload) {
+        formData.append('exif', JSON.stringify(photo.metadata.exifPayload));
       }
 
       // Upload to binary storage API

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -19,6 +19,7 @@ interface PhotoMetadata {
   datetime?: string;
   camera?: string;
   lens?: string;
+  rawExif?: Record<string, any>;
 }
 
 interface UploadedPhoto {
@@ -183,13 +184,69 @@ export default function UploadPage() {
 
   const extractMetadata = async (file: File): Promise<PhotoMetadata> => {
     try {
-      const metadata = await exifr.parse(file);
+      const raw = await exifr.parse(file, { gps: true, tiff: true, exif: true, xmp: false, icc: false, iptc: false });
+      // GPS詐称調査・不正検知に有用なフィールドを保存
+      // キーとなるGPS整合性フィールドは存在しない場合も null として明示記録（不在自体がシグナル）
+      const rawExif: Record<string, any> = {};
+      const required = (key: string) => { rawExif[key] = raw?.[key] ?? null; };
+      const optional = (key: string) => { if (raw?.[key] != null) rawExif[key] = raw[key]; };
+
+      // タイムスタンプ整合性（DateTimeOriginal vs GPSDateStamp のズレで詐称を検知）
+      required('DateTimeOriginal'); optional('DateTimeDigitized'); optional('ModifyDate');
+      optional('OffsetTime'); optional('OffsetTimeOriginal');
+      required('GPSDateStamp'); required('GPSTimeStamp');
+      // SubSecTimeOriginal: 本物撮影なら通常あり、後付けGPSでは消える傾向
+      required('SubSecTimeOriginal'); optional('SubSecTimeDigitized');
+
+      // GPS品質・出所シグナル（不在も記録）
+      required('GPSProcessingMethod'); // Android: "GPS"/"NETWORK"/"FUSED" — GPS出所の直接証拠
+      required('GPSVersionID');
+      required('GPSStatus');           // A=有効計測 / V=無効
+      required('GPSMeasureMode');      // "2"=2Dfix / "3"=3Dfix
+      required('GPSDOP');              // 精度指標
+      required('GPSHPositioningError'); // iOS: 水平誤差(m)
+      optional('GPSSatellites');
+      optional('GPSSpeed'); optional('GPSSpeedRef');
+      optional('GPSImgDirection'); optional('GPSImgDirectionRef');
+      optional('GPSAltitude'); optional('GPSAltitudeRef');
+
+      // 編集検知
+      optional('Software');
+
+      // デバイス・レンズ一貫性
+      optional('Make'); optional('Model');
+      optional('LensMake'); optional('LensModel'); optional('LensInfo');
+      optional('HostComputer'); // iOSで端末名が入ることがある
+
+      // カメラ動作（実際に撮影されたことを示す特徴量）
+      optional('ExifVersion'); optional('FlashPixVersion');
+      optional('FNumber'); optional('ExposureTime'); optional('ISO');
+      optional('Flash'); optional('FocalLength'); optional('FocalLengthIn35mmFormat');
+      optional('PixelXDimension'); optional('PixelYDimension');
+      optional('WhiteBalance'); optional('ExposureMode');
+      optional('MeteringMode'); optional('SceneCaptureType');
+      optional('BrightnessValue');
+
+      const hasGps = isValidCoordinates(raw?.latitude, raw?.longitude);
+      const method = rawExif.GPSProcessingMethod;
+      const gpsSource: string | null = !hasGps ? null
+        : method === 'GPS'     ? 'hardware_gps'
+        : method === 'NETWORK' ? 'network'
+        : method === 'FUSED'   ? 'fused'
+        : rawExif.GPSDateStamp != null ? 'camera'
+        : 'unknown';
+
+      const exifPayload = Object.keys(rawExif).length > 0
+        ? { raw: rawExif, judge: { gps_source: gpsSource } }
+        : undefined;
+
       return {
-        latitude: metadata?.latitude,
-        longitude: metadata?.longitude,
-        datetime: metadata?.DateTimeOriginal || metadata?.DateTime,
-        camera: metadata?.Make && metadata?.Model ? `${metadata.Make} ${metadata.Model}` : undefined,
-        lens: metadata?.LensModel
+        latitude: raw?.latitude,
+        longitude: raw?.longitude,
+        datetime: raw?.DateTimeOriginal || raw?.DateTime,
+        camera: raw?.Make && raw?.Model ? `${raw.Make} ${raw.Model}` : undefined,
+        lens: raw?.LensModel,
+        rawExif: exifPayload,
       };
     } catch (error) {
       console.warn('Failed to extract EXIF data:', error);
@@ -430,16 +487,9 @@ export default function UploadPage() {
       // Add is_public setting
       formData.append('is_public', isPublic.toString());
 
-      // Add metadata
-      const metadata = {
-        metadata: {
-          ...photo.metadata,
-          originalFilename: photo.file.name,
-          uploadedAt: new Date().toISOString()
-        },
-        exif: photo.metadata
-      };
-      formData.append('metadata', JSON.stringify(metadata));
+      if (photo.metadata.rawExif) {
+        formData.append('exif', JSON.stringify(photo.metadata.rawExif));
+      }
 
       // Upload to binary storage API
       const uploadResponse = await fetch('/api/image-upload', {

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -523,6 +523,8 @@ export default function VisitsPage() {
   const visitedPrefectureCount = prefectureProgress.filter((p) => p.visited > 0).length;
   const visitedFeaturesCount = hashtagProgress.length;
 
+  // TODO: handleDeleteClick は定義済みだが visits ページに削除ボタンが未配置。
+  // VisitPhotoCard に削除導線を追加する際にここを呼ぶ。
   const handleDeleteClick = (photoId: string, visitId: string) => {
     setSelectedPhotoId(photoId);
     setSelectedVisitId(visitId);

--- a/src/app/visits/page.tsx
+++ b/src/app/visits/page.tsx
@@ -1237,7 +1237,6 @@ export default function VisitsPage() {
       {selectedPhotoId && (
         <DeletePhotoModal
           isOpen={deleteModalOpen}
-          photoId={selectedPhotoId}
           onConfirm={handleDeleteConfirm}
           onCancel={handleDeleteCancel}
           isDeleting={isDeleting}

--- a/src/components/DeletePhotoModal.tsx
+++ b/src/components/DeletePhotoModal.tsx
@@ -23,11 +23,11 @@ export default function DeletePhotoModal({
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black bg-opacity-70"
-        onClick={onCancel}
+        onClick={isDeleting ? undefined : onCancel}
         role="button"
         tabIndex={0}
         onKeyDown={(e) => {
-          if (e.key === 'Enter' || e.key === ' ') {
+          if (!isDeleting && (e.key === 'Enter' || e.key === ' ')) {
             e.preventDefault();
             onCancel();
           }

--- a/src/components/DeletePhotoModal.tsx
+++ b/src/components/DeletePhotoModal.tsx
@@ -4,7 +4,6 @@ import { X } from 'lucide-react';
 
 interface DeletePhotoModalProps {
   isOpen: boolean;
-  photoId: string;
   onConfirm: () => void;
   onCancel: () => void;
   isDeleting?: boolean;
@@ -12,7 +11,6 @@ interface DeletePhotoModalProps {
 
 export default function DeletePhotoModal({
   isOpen,
-  photoId,
   onConfirm,
   onCancel,
   isDeleting = false
@@ -62,13 +60,6 @@ export default function DeletePhotoModal({
           <div className="bg-rpg-red bg-opacity-10 border-2 border-rpg-red p-3">
             <p className="font-pixelJp text-xs text-rpg-textDark">
               <span className="font-bold text-rpg-red">注意:</span> この操作は取り消せません。同じ訪問記録に紐づく写真、コメント、いいね、ブックマークも削除されます。
-            </p>
-          </div>
-
-          {/* Photo ID */}
-          <div className="bg-white/70 border border-[#7B63A8]/15 p-2">
-            <p className="font-pixel text-[10px] text-rpg-textDark opacity-70">
-              Photo ID: {photoId.slice(0, 8)}...
             </p>
           </div>
 

--- a/src/components/PhotoDeleteButton.tsx
+++ b/src/components/PhotoDeleteButton.tsx
@@ -46,7 +46,7 @@ export default function PhotoDeleteButton({ visitId, manholeId }: PhotoDeleteBut
       <DeletePhotoModal
         isOpen={modalOpen}
         onConfirm={handleConfirm}
-        onCancel={() => setModalOpen(false)}
+        onCancel={() => { if (!isDeleting) setModalOpen(false); }}
         isDeleting={isDeleting}
       />
     </>

--- a/src/components/PhotoDeleteButton.tsx
+++ b/src/components/PhotoDeleteButton.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Trash2 } from 'lucide-react';
+import DeletePhotoModal from '@/components/DeletePhotoModal';
+
+interface PhotoDeleteButtonProps {
+  visitId: string;
+  manholeId: number;
+}
+
+export default function PhotoDeleteButton({ visitId, manholeId }: PhotoDeleteButtonProps) {
+  const [modalOpen, setModalOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const router = useRouter();
+
+  const handleConfirm = async () => {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/visits/${visitId}`, { method: 'DELETE' });
+      const data = await res.json();
+      if (res.ok && data.success) {
+        router.push(`/manhole/${manholeId}`);
+      } else {
+        alert(`削除に失敗しました: ${data.error || '不明なエラー'}`);
+        setIsDeleting(false);
+        setModalOpen(false);
+      }
+    } catch {
+      alert('削除中にエラーが発生しました');
+      setIsDeleting(false);
+      setModalOpen(false);
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setModalOpen(true)}
+        className="inline-flex items-center justify-center gap-2 rounded-lg border border-red-300 bg-white px-5 py-3 text-sm font-bold text-red-600 shadow-sm transition hover:bg-red-50"
+      >
+        <Trash2 className="h-4 w-4" />
+        削除
+      </button>
+      <DeletePhotoModal
+        isOpen={modalOpen}
+        onConfirm={handleConfirm}
+        onCancel={() => setModalOpen(false)}
+        isDeleting={isDeleting}
+      />
+    </>
+  );
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -215,7 +215,6 @@ export interface Database {
           binary_data: ArrayBuffer | null;
           thumbnail_small: ArrayBuffer | null;
           thumbnail_medium: ArrayBuffer | null;
-          metadata: Record<string, any> | null;
         };
         Insert: {
           id?: string;
@@ -236,7 +235,6 @@ export interface Database {
           binary_data?: ArrayBuffer | null;
           thumbnail_small?: ArrayBuffer | null;
           thumbnail_medium?: ArrayBuffer | null;
-          metadata?: Record<string, any> | null;
         };
         Update: {
           visit_id?: string | null;
@@ -256,7 +254,6 @@ export interface Database {
           binary_data?: ArrayBuffer | null;
           thumbnail_small?: ArrayBuffer | null;
           thumbnail_medium?: ArrayBuffer | null;
-          metadata?: Record<string, any> | null;
         };
         Relationships: [];
       };


### PR DESCRIPTION
## Summary

- **削除UX改善**: ManholePage の featured photo キャプションに「削除」ボタンを追加。従来の発見困難な 16×16px × ボタンと、入力欄に誤認されていた Photo ID 表示を廃止
- **EXIF フォレンジクス**: アップロード時に GPS詐称調査・不正検知用の構造化 EXIF データを `photo.exif` に保存
- **型定義修正**: `database.ts` から実 DB に存在しない `metadata` フィールドを削除

## 変更詳細

### 削除UX
- `ManholePage`: サムネイル `×` ボタン廃止 → featured photo キャプションに赤い「削除」ボタン（オーナーのみ）
- `DeletePhotoModal`: Photo ID テキスト表示を削除（入力欄と誤認される原因だった）
- `/p/[photoId]`: `PhotoDeleteButton` コンポーネントを追加（オーナーのみ表示）

### EXIF フォレンジクス
`photo.exif` に以下の構造で保存：
```json
{
  "raw": {
    "GPSProcessingMethod": "GPS" | "NETWORK" | "FUSED" | null,
    "GPSDateStamp": "2026:06:21" | null,
    "GPSHPositioningError": 4.7,
    "SubSecTimeOriginal": "905",
    ...
  },
  "judge": {
    "gps_source": "hardware_gps" | "network" | "fused" | "camera" | "unknown" | null
  }
}
```
- キーとなる GPS 整合性フィールドは **不在も `null` として明示記録**（不在自体がシグナル）
- `gps_source` は `GPSProcessingMethod`（Android）→ `GPSDateStamp`（iOS）の順で判定

## Test plan
- [ ] `/manhole/[id]` で自分の写真サムネイルをクリック → featured に表示される
- [ ] featured が自分の写真のとき「削除」ボタンが表示される
- [ ] 削除モーダルに Photo ID テキストボックスが表示されないこと
- [ ] 写真アップロード後、`photo.exif` に `raw` + `judge` 構造が保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)