### PR TITLE
feat: /api/manholes・/api/site-stats を静的スナップショット読みに変更

### DIFF
--- a/src/app/api/manholes/route.ts
+++ b/src/app/api/manholes/route.ts
@@ -1,8 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
-import { Database } from '@/types/database';
-import { extractCoordinatesFromWKB, calculateDistance } from '@/lib/location';
+import { calculateDistance } from '@/lib/location';
+import {
+  fetchManholeSnapshot,
+  SnapshotManhole,
+} from '@/lib/manhole-snapshot';
 
 /**
  * @swagger
@@ -10,7 +13,7 @@ import { extractCoordinatesFromWKB, calculateDistance } from '@/lib/location';
  *   get:
  *     summary: マンホール一覧を取得
  *     tags: [manholes]
- *     description: 全マンホール情報を取得します。位置情報を含みます。
+ *     description: 全マンホール情報を取得します。位置情報を含みます。マスターデータは data.pokefuta.com の静的スナップショット（日次更新）から取得し、ログインユーザーの訪問状態のみ Supabase から合成します。
  *     responses:
  *       200:
  *         description: マンホール一覧
@@ -31,10 +34,8 @@ import { extractCoordinatesFromWKB, calculateDistance } from '@/lib/location';
  *                   description: マンホール総数
  *       500:
  *         description: サーバーエラー
- *         content:
- *           application/json:
- *             schema:
- *               $ref: '#/components/schemas/Error'
+ *       503:
+ *         description: スナップショット取得失敗
  */
 
 export async function GET(request: NextRequest) {
@@ -57,219 +58,105 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Check if this is a nearby search (lat/lng provided)
     const isNearbySearch = lat !== null && lng !== null;
 
-    // Check if Supabase is configured
+    // マスターデータは静的スナップショットから（Supabase は読まない）
+    const snapshot = await fetchManholeSnapshot();
+    if (!snapshot || !snapshot.manholes) {
+      return NextResponse.json(
+        { error: 'Manhole data is temporarily unavailable. Please try again later.' },
+        { status: 503 }
+      );
+    }
+
+    // ✅ ログインユーザーの訪問記録だけを Supabase から取得（ユーザー単位の小データ）
+    const visitedManholeIds = new Set<number>();
+    const visitedManholeData = new Map<number, { last_visit: string }>();
+
     const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
     const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-    if (!supabaseUrl || !supabaseKey || supabaseUrl.includes('dummy')) {
-      console.error('Supabase is not configured properly');
-      return NextResponse.json(
-        { error: 'Database configuration error. Please check your Supabase settings.' },
-        { status: 500 }
-      );
+    if (supabaseUrl && supabaseKey && !supabaseUrl.includes('dummy')) {
+      try {
+        const supabase = createRouteHandlerClient({ cookies });
+        const { data: { session } } = await supabase.auth.getSession();
+        const userId = session?.user?.id || null;
+
+        if (userId) {
+          const { data: visitsData } = await supabase
+            .from('visit')
+            .select('manhole_id, shot_at')
+            .eq('user_id', userId)
+            .not('manhole_id', 'is', null)
+            .order('shot_at', { ascending: false });
+
+          if (visitsData) {
+            visitsData.forEach(visit => {
+              if (visit.manhole_id) {
+                visitedManholeIds.add(visit.manhole_id);
+                // 最新の訪問日を保存
+                if (!visitedManholeData.has(visit.manhole_id)) {
+                  visitedManholeData.set(visit.manhole_id, {
+                    last_visit: visit.shot_at
+                  });
+                }
+              }
+            });
+          }
+        }
+      } catch (visitError) {
+        // 訪問状態の合成に失敗しても匿名相当のデータは返す
+        console.error('Failed to overlay visit status:', visitError);
+      }
     }
 
-    const supabase = createRouteHandlerClient({ cookies });
+    const withVisitStatus = (manhole: SnapshotManhole) => ({
+      ...manhole,
+      is_visited: visitedManholeIds.has(manhole.id),
+      last_visit: visitedManholeData.get(manhole.id)?.last_visit || null,
+    });
 
-    // ✅ ユーザーの認証状態を確認
-    const { data: { session } } = await supabase.auth.getSession();
-    const userId = session?.user?.id || null;
+    const matchesVisitedFilter = (manhole: { is_visited: boolean }) => {
+      if (visited === 'true') return manhole.is_visited;
+      if (visited === 'false') return !manhole.is_visited;
+      return true;
+    };
 
-    try {
-      // まず全体の統計情報を取得（軽量クエリ）
-      const { count: totalCount, error: countError } = await supabase
-        .from('manhole')
-        .select('*', { count: 'exact', head: true });
+    if (isNearbySearch) {
+      const manholesWithDistance = snapshot.manholes
+        .map(manhole => ({
+          ...withVisitStatus(manhole),
+          distance: calculateDistance(lat!, lng!, manhole.latitude, manhole.longitude),
+        }))
+        .filter(manhole => manhole.distance <= radius)
+        .filter(matchesVisitedFilter)
+        .filter(manhole => !noPhotos || manhole.photo_count === 0)
+        .sort((a, b) => a.distance - b.distance)
+        .slice(0, limit);
 
-      if (countError) {
-        console.error('Count query error:', countError);
-      }
-
-      // 写真があるマンホールの数を取得（COUNT DISTINCT）
-      const { data: photoCountData, error: photoCountError } = await supabase
-        .rpc('count_manholes_with_photos' as any)
-        .single();
-
-      let photosCount = 0;
-      if (!photoCountError && photoCountData) {
-        photosCount = (photoCountData as any).count || 0;
-      } else {
-        // フォールバック: 全件取得
-        const { data: photosData } = await supabase
-          .from('photo')
-          .select('manhole_id')
-          .not('manhole_id', 'is', null);
-        photosCount = new Set(photosData?.map(p => p.manhole_id) || []).size;
-      }
-
-      // ✅ ログインユーザーの訪問記録を取得
-      let visitedManholeIds = new Set<number>();
-      let visitedManholeData = new Map<number, { last_visit: string }>();
-
-      if (userId) {
-        const { data: visitsData } = await supabase
-          .from('visit')
-          .select('manhole_id, shot_at')
-          .eq('user_id', userId)
-          .not('manhole_id', 'is', null)
-          .order('shot_at', { ascending: false });
-
-        if (visitsData) {
-          visitsData.forEach(visit => {
-            if (visit.manhole_id) {
-              visitedManholeIds.add(visit.manhole_id);
-              // 最新の訪問日を保存
-              if (!visitedManholeData.has(visit.manhole_id)) {
-                visitedManholeData.set(visit.manhole_id, {
-                  last_visit: visit.shot_at
-                });
-              }
-            }
-          });
-        }
-      }
-
-      // 実際のマンホールデータを取得
-      // ⚠️ nearby検索の場合はlimitを適用せず、全件取得してから距離でフィルタする
-      let query = supabase.from('manhole').select('*');
-
-      // nearby検索でない場合のみlimitを適用
-      if (!isNearbySearch) {
-        const actualLimit = Math.min(limit, 1000);
-        query = query.order('id', { ascending: false }).limit(actualLimit);
-      }
-
-      const { data: allManholes, error: queryError } = await query;
-
-      if (queryError) {
-        console.error('Database query error:', queryError);
-        throw new Error(`Database query failed: ${queryError.message}`);
-      }
-
-      if (!allManholes || allManholes.length === 0) {
-        console.log('No manholes found in database');
-        return NextResponse.json({
-          success: true,
-          manholes: [],
-          total: totalCount || 0,
-          with_photos: photosCount
-        });
-      }
-
-      // 取得したマンホールの写真有無を確認
-      const manholeIds = allManholes.map(m => m.id);
-      const { data: photosData } = await supabase
-        .from('photo')
-        .select('manhole_id')
-        .in('manhole_id', manholeIds)
-        .not('manhole_id', 'is', null);
-
-      const manholesWithPhotosSet = new Set(
-        photosData?.map(p => p.manhole_id) || []
-      );
-
-      if (isNearbySearch) {
-        console.log(`Searching for manholes within ${radius}km of ${lat}, ${lng}`);
-
-        // Process manholes and extract real coordinates from PostGIS location field
-        const manholesWithDistance = allManholes
-          .map(manhole => {
-            const realCoords = extractCoordinatesFromWKB(manhole.location);
-
-            if (!realCoords) {
-              return null; // Skip manholes without extractable coordinates
-            }
-
-            const distance = calculateDistance(lat!, lng!, realCoords.lat, realCoords.lng);
-
-            const hasPhotos = manholesWithPhotosSet.has(manhole.id);
-            const isVisited = visitedManholeIds.has(manhole.id);
-            const visitData = visitedManholeData.get(manhole.id);
-
-            return {
-              ...manhole,
-              name: manhole.title || 'ポケふた',
-              city: manhole.municipality || '',
-              latitude: realCoords.lat,
-              longitude: realCoords.lng,
-              is_visited: isVisited,
-              last_visit: visitData?.last_visit || null,
-              photo_count: hasPhotos ? 1 : 0,
-              distance: distance
-            };
-          })
-          .filter(manhole => manhole !== null)
-          .filter(manhole => manhole.distance <= radius)
-          .filter(manhole => {
-            if (visited === 'true') return manhole.is_visited;
-            if (visited === 'false') return !manhole.is_visited;
-            return true;
-          })
-          .filter(manhole => !noPhotos || manhole.photo_count === 0)
-          .sort((a, b) => a.distance - b.distance)
-          .slice(0, limit);
-
-        console.log(`Found ${manholesWithDistance.length} nearby manholes`);
-        return NextResponse.json({
-          success: true,
-          manholes: manholesWithDistance,
-          total: totalCount || 0,
-          with_photos: photosCount
-        });
-      }
-
-      // Regular search for all manholes (no location filtering)
-      console.log(`Processing ${allManholes.length} manholes from database`);
-
-      const manholesWithCoordinates = allManholes
-        .map(manhole => {
-          const realCoords = extractCoordinatesFromWKB(manhole.location);
-
-          if (!realCoords) {
-            return null; // Skip manholes without extractable coordinates
-          }
-
-          const hasPhotos = manholesWithPhotosSet.has(manhole.id);
-          const isVisited = visitedManholeIds.has(manhole.id);
-          const visitData = visitedManholeData.get(manhole.id);
-
-          return {
-            ...manhole,
-            name: manhole.title || 'ポケふた',
-            city: manhole.municipality || '',
-            latitude: realCoords.lat,
-            longitude: realCoords.lng,
-            is_visited: isVisited,
-            last_visit: visitData?.last_visit || null,
-            photo_count: hasPhotos ? 1 : 0
-          };
-        })
-        .filter(manhole => manhole !== null)
-        .filter(manhole => {
-          if (visited === 'true') return manhole.is_visited;
-          if (visited === 'false') return !manhole.is_visited;
-          return true;
-        })
-        .filter(manhole => !noPhotos || manhole.photo_count === 0);
-
-      console.log(`Returning ${manholesWithCoordinates.length} manholes with coordinates`);
       return NextResponse.json({
         success: true,
-        manholes: manholesWithCoordinates,
-        total: totalCount || 0,
-        with_photos: photosCount
+        manholes: manholesWithDistance,
+        total: snapshot.total,
+        with_photos: snapshot.with_photos
       });
-
-    } catch (dbError) {
-      console.error('Database error:', (dbError as Error).message);
-      return NextResponse.json(
-        { error: 'Database query failed. Please try again later.' },
-        { status: 500 }
-      );
     }
+
+    // 通常一覧: id 降順で limit 件（従来の DB クエリと同じ挙動）
+    const actualLimit = Math.min(limit, 1000);
+    const manholes = [...snapshot.manholes]
+      .sort((a, b) => b.id - a.id)
+      .slice(0, actualLimit)
+      .map(withVisitStatus)
+      .filter(matchesVisitedFilter)
+      .filter(manhole => !noPhotos || manhole.photo_count === 0);
+
+    return NextResponse.json({
+      success: true,
+      manholes,
+      total: snapshot.total,
+      with_photos: snapshot.with_photos
+    });
 
   } catch (error) {
     console.error('API Error:', error);

--- a/src/app/api/manholes/route.ts
+++ b/src/app/api/manholes/route.ts
@@ -47,6 +47,7 @@ export async function GET(request: NextRequest) {
     const lng = searchParams.get('lng') ? parseFloat(searchParams.get('lng')!) : null;
     const radius = parseFloat(searchParams.get('radius') || '50'); // km, default 50km
     const limit = parseInt(searchParams.get('limit') || '500');
+    const actualLimit = Math.min(Number.isFinite(limit) ? limit : 500, 1000);
     const visited = searchParams.get('visited'); // 'true', 'false', or null for all
     const noPhotos = searchParams.get('no_photos') === 'true';
 
@@ -132,7 +133,7 @@ export async function GET(request: NextRequest) {
         .filter(matchesVisitedFilter)
         .filter(manhole => !noPhotos || manhole.photo_count === 0)
         .sort((a, b) => a.distance - b.distance)
-        .slice(0, limit);
+        .slice(0, actualLimit);
 
       return NextResponse.json({
         success: true,
@@ -143,7 +144,6 @@ export async function GET(request: NextRequest) {
     }
 
     // 通常一覧: id 降順で limit 件（従来の DB クエリと同じ挙動）
-    const actualLimit = Math.min(limit, 1000);
     const manholes = [...snapshot.manholes]
       .sort((a, b) => b.id - a.id)
       .slice(0, actualLimit)

--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -15,22 +15,27 @@ export async function GET() {
     return NextResponse.json(stats);
   }
 
-  return NextResponse.json({
-    success: true,
-    users: null,
-    auth_users: null,
-    active_users_7d: null,
-    posts: null,
-    manholes: null,
-    manholes_with_photos: null,
-    latest_photo_at: null,
-    latest_user_at: null,
-    latest_visit_at: null,
-    posts_last_7d: null,
-    posts_last_30d: null,
-    manhole_comments: null,
-    public_posts: null,
-    private_posts: null,
-    source: 'unavailable',
-  });
+  // 他 API と同様、取得失敗は success: false + 5xx で返す
+  return NextResponse.json(
+    {
+      success: false,
+      users: null,
+      auth_users: null,
+      active_users_7d: null,
+      posts: null,
+      manholes: null,
+      manholes_with_photos: null,
+      latest_photo_at: null,
+      latest_user_at: null,
+      latest_visit_at: null,
+      posts_last_7d: null,
+      posts_last_30d: null,
+      manhole_comments: null,
+      public_posts: null,
+      private_posts: null,
+      error: 'Site statistics snapshot is unavailable',
+      source: 'unavailable',
+    },
+    { status: 503 }
+  );
 }

--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -1,208 +1,36 @@
 import { NextResponse } from 'next/server';
-import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
-import { cookies } from 'next/headers';
-import { Database } from '@/types/database';
-import { supabaseAdmin } from '@/lib/supabase/client';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { fetchSiteStatsSnapshot } from '@/lib/manhole-snapshot';
 
-type SiteStatsRow = {
-  total_manhole: number | string | null;
-  total_manholes_with_photos?: number | string | null;
-  total_posts: number | string | null;
-  total_users: number | string | null;
-};
-
-const toCount = (value: number | string | null | undefined) =>
-  typeof value === 'number' ? value : Number(value ?? 0);
-
-async function fetchActivityStats(admin: SupabaseClient<Database>) {
-  const now = new Date();
-  const ago7d = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString();
-  const ago30d = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
-
-  const [
-    { data: latestPhoto },
-    { data: latestUser },
-    { data: latestVisit },
-    { count: posts7d },
-    { count: posts30d },
-    { count: commentsCount },
-    { count: publicPhotosCount },
-    { count: privatePhotosCount },
-  ] = await Promise.all([
-    admin.from('photo').select('created_at').order('created_at', { ascending: false }).limit(1),
-    admin.from('app_user').select('created_at').order('created_at', { ascending: false }).limit(1),
-    admin.from('visit').select('shot_at').order('shot_at', { ascending: false }).limit(1),
-    admin.from('photo').select('id', { head: true, count: 'exact' }).gte('created_at', ago7d),
-    admin.from('photo').select('id', { head: true, count: 'exact' }).gte('created_at', ago30d),
-    admin.from('manhole_comment').select('id', { head: true, count: 'exact' }),
-    admin.from('photo').select('id, visit:visit_id!inner(is_public)', { head: true, count: 'exact' }).eq('visit.is_public', true),
-    admin.from('photo').select('id, visit:visit_id!inner(is_public)', { head: true, count: 'exact' }).eq('visit.is_public', false),
-  ]);
-
-  // auth.users の総件数 + 直近7日ログイン数を Admin Auth REST API から取得
-  let auth_users: number | null = null;
-  let active_users_7d: number | null = null;
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (supabaseUrl && serviceRoleKey) {
-    try {
-      const ago7dDate = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-      const perPage = 1000;
-      let page = 1;
-      let activeCount = 0;
-      let totalAuthUsers: number | null = null;
-
-      while (true) {
-        const res = await fetch(
-          `${supabaseUrl}/auth/v1/admin/users?per_page=${perPage}&page=${page}`,
-          { headers: { apikey: serviceRoleKey, Authorization: `Bearer ${serviceRoleKey}` } }
-        );
-        if (!res.ok) break;
-
-        if (page === 1) {
-          const totalCount = res.headers.get('x-total-count');
-          totalAuthUsers = totalCount !== null ? parseInt(totalCount, 10) : null;
-        }
-
-        const json = await res.json();
-        const users: Array<{ last_sign_in_at?: string | null }> = json.users ?? [];
-        activeCount += users.filter(
-          (u) => u.last_sign_in_at && new Date(u.last_sign_in_at) >= ago7dDate
-        ).length;
-
-        if (users.length < perPage) break;
-        page++;
-      }
-
-      auth_users = totalAuthUsers;
-      active_users_7d = activeCount;
-    } catch {
-      // non-critical
-    }
-  }
-
-  return {
-    latest_photo_at: (latestPhoto as Array<{ created_at: string }> | null)?.[0]?.created_at ?? null,
-    latest_user_at: (latestUser as Array<{ created_at: string }> | null)?.[0]?.created_at ?? null,
-    latest_visit_at: (latestVisit as Array<{ shot_at: string }> | null)?.[0]?.shot_at ?? null,
-    posts_last_7d: posts7d ?? 0,
-    posts_last_30d: posts30d ?? 0,
-    auth_users,
-    active_users_7d,
-    manhole_comments: commentsCount ?? 0,
-    public_posts: publicPhotosCount ?? 0,
-    private_posts: privatePhotosCount ?? 0,
-  };
-}
-
+/**
+ * サイト統計。
+ *
+ * data.pokefuta.com の静的スナップショット（bake-app-data.yml が日次生成）を
+ * そのまま返す。リクエスト毎の Supabase 読み出し（旧実装では auth admin API の
+ * 全ユーザー走査まで毎回行っていた）を排除するための構成。
+ */
 export async function GET() {
-  try {
-    const routeClient = createRouteHandlerClient({ cookies });
+  const stats = await fetchSiteStatsSnapshot();
 
-    // Prefer RPC to avoid RLS issues (works for anon/auth when DB migration is applied)
-    const { data: rpcData, error: rpcError } = await routeClient.rpc('get_site_stats');
-
-    const row = (Array.isArray(rpcData) ? rpcData[0] : rpcData) as Partial<SiteStatsRow> | null;
-
-    const admin = supabaseAdmin as unknown as SupabaseClient<Database> | null;
-
-    if (!rpcError && row) {
-      let manholesWithPhotos = toCount(row.total_manholes_with_photos);
-
-      if (row.total_manholes_with_photos == null && admin) {
-        const { data: photoManholes } = await admin
-          .from('photo')
-          .select('manhole_id')
-          .not('manhole_id', 'is', null);
-
-        manholesWithPhotos = new Set(
-          (photoManholes as Array<{ manhole_id: number | null }> | null)?.map(photo => photo.manhole_id) || []
-        ).size;
-      }
-
-      const activity = admin ? await fetchActivityStats(admin) : null;
-
-      return NextResponse.json({
-        success: true,
-        users: toCount(row.total_users),
-        posts: toCount(row.total_posts),
-        manholes: toCount(row.total_manhole),
-        manholes_with_photos: manholesWithPhotos,
-        ...(activity ?? {}),
-        source: 'rpc',
-      });
-    }
-
-    // Fallback (requires service role)
-    if (admin) {
-      const [
-        { count: userCount },
-        { count: postCount },
-        { count: manholeCount },
-        { data: photoManholes },
-      ] = await Promise.all([
-        admin.from('app_user').select('id', { head: true, count: 'exact' }),
-        admin.from('photo').select('id', { head: true, count: 'exact' }),
-        admin.from('manhole').select('id', { head: true, count: 'exact' }),
-        admin.from('photo').select('manhole_id').not('manhole_id', 'is', null),
-      ]);
-
-      const activity = await fetchActivityStats(admin);
-
-      return NextResponse.json({
-        success: true,
-        users: userCount ?? 0,
-        posts: postCount ?? 0,
-        manholes: manholeCount ?? 0,
-        manholes_with_photos: new Set(
-          (photoManholes as Array<{ manhole_id: number | null }> | null)?.map(photo => photo.manhole_id) || []
-        ).size,
-        ...activity,
-        source: 'admin',
-      });
-    }
-
-    return NextResponse.json({
-      success: true,
-      users: null,
-      auth_users: null,
-      active_users_7d: null,
-      posts: null,
-      manholes: null,
-      manholes_with_photos: null,
-      latest_photo_at: null,
-      latest_user_at: null,
-      latest_visit_at: null,
-      posts_last_7d: null,
-      posts_last_30d: null,
-      manhole_comments: null,
-      public_posts: null,
-      private_posts: null,
-      source: 'unavailable',
-    });
-  } catch (error: unknown) {
-    return NextResponse.json(
-      {
-        success: false,
-        users: null,
-        auth_users: null,
-        active_users_7d: null,
-        posts: null,
-        manholes: null,
-        manholes_with_photos: null,
-        latest_photo_at: null,
-        latest_user_at: null,
-        latest_visit_at: null,
-        posts_last_7d: null,
-        posts_last_30d: null,
-        manhole_comments: null,
-        public_posts: null,
-        private_posts: null,
-        error: 'Failed to get site statistics',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
-      { status: 500 }
-    );
+  if (stats) {
+    return NextResponse.json(stats);
   }
+
+  return NextResponse.json({
+    success: true,
+    users: null,
+    auth_users: null,
+    active_users_7d: null,
+    posts: null,
+    manholes: null,
+    manholes_with_photos: null,
+    latest_photo_at: null,
+    latest_user_at: null,
+    latest_visit_at: null,
+    posts_last_7d: null,
+    posts_last_30d: null,
+    manhole_comments: null,
+    public_posts: null,
+    private_posts: null,
+    source: 'unavailable',
+  });
 }

--- a/src/lib/manhole-snapshot.ts
+++ b/src/lib/manhole-snapshot.ts
@@ -66,7 +66,13 @@ async function fetchSnapshotJson<T>(path: string): Promise<T | null> {
         next: { revalidate: REVALIDATE_SECONDS },
       });
       if (res.ok) {
-        return (await res.json()) as T;
+        const data = (await res.json()) as T & { success?: boolean };
+        // 生成側がエラー内容の JSON を返している場合は配信しない
+        if (data.success === true) {
+          return data;
+        }
+        console.error(`Snapshot payload not successful: ${base}${path}`);
+        continue;
       }
       console.error(`Snapshot fetch failed (${res.status}): ${base}${path}`);
     } catch (error) {

--- a/src/lib/manhole-snapshot.ts
+++ b/src/lib/manhole-snapshot.ts
@@ -1,0 +1,85 @@
+import 'server-only';
+
+/**
+ * data.pokefuta.com (GitHub Pages) が日次で配信する静的スナップショットを読む。
+ *
+ * マンホールマスターとサイト統計はリクエスト毎に Supabase を読まず、
+ * ここを経由して取得する（Supabase egress を PV 非依存にするため）。
+ * 生成元: pokefuta-tracker リポジトリの bake-app-data.yml。
+ */
+
+const STATIC_BASE =
+  process.env.POKEFUTA_STATIC_BASE ?? 'https://data.pokefuta.com';
+const FALLBACK_BASE =
+  'https://raw.githubusercontent.com/nishiokya/pokefuta-tracker/main/docs';
+
+const REVALIDATE_SECONDS = 3600;
+
+export interface SnapshotManhole {
+  id: number;
+  title: string;
+  name: string;
+  prefecture: string;
+  municipality: string | null;
+  city: string;
+  latitude: number;
+  longitude: number;
+  pokemons: string[];
+  is_visited: boolean;
+  last_visit: string | null;
+  photo_count: number;
+  [key: string]: unknown;
+}
+
+export interface ManholeSnapshot {
+  success: boolean;
+  generated_at: string;
+  total: number;
+  with_photos: number;
+  manholes: SnapshotManhole[];
+}
+
+export interface SiteStatsSnapshot {
+  success: boolean;
+  generated_at: string;
+  users: number;
+  posts: number;
+  manholes: number;
+  manholes_with_photos: number;
+  latest_photo_at: string | null;
+  latest_user_at: string | null;
+  latest_visit_at: string | null;
+  posts_last_7d: number;
+  posts_last_30d: number;
+  auth_users: number | null;
+  active_users_7d: number | null;
+  manhole_comments: number;
+  public_posts: number;
+  private_posts: number;
+  source: string;
+}
+
+async function fetchSnapshotJson<T>(path: string): Promise<T | null> {
+  for (const base of [STATIC_BASE, FALLBACK_BASE]) {
+    try {
+      const res = await fetch(`${base}${path}`, {
+        next: { revalidate: REVALIDATE_SECONDS },
+      });
+      if (res.ok) {
+        return (await res.json()) as T;
+      }
+      console.error(`Snapshot fetch failed (${res.status}): ${base}${path}`);
+    } catch (error) {
+      console.error(`Snapshot fetch error: ${base}${path}`, error);
+    }
+  }
+  return null;
+}
+
+export function fetchManholeSnapshot(): Promise<ManholeSnapshot | null> {
+  return fetchSnapshotJson<ManholeSnapshot>('/api/manholes.json');
+}
+
+export function fetchSiteStatsSnapshot(): Promise<SiteStatsSnapshot | null> {
+  return fetchSnapshotJson<SiteStatsSnapshot>('/api/site-stats.json');
+}


### PR DESCRIPTION
## 概要
マスターデータとサイト統計をリクエスト毎に Supabase から読む構成をやめ、data.pokefuta.com の日次スナップショット（pokefuta-tracker#270 が生成）を Next data cache (revalidate 1h) 経由で読む。**Supabase egress が PV 非依存になり、20k PV/月でも無料枠内に収まる。**

## 変更内容
- `src/lib/manhole-snapshot.ts` 新規 — data.pokefuta.com → raw.githubusercontent.com の順でフォールバック取得
- `/api/manholes` GET — スナップショット読み＋ログインユーザーの訪問状態のみ Supabase から合成。クエリパラメータ（lat/lng/radius/limit/visited/no_photos）とレスポンス形状は従来互換。POST は変更なし
- `/api/site-stats` GET — スナップショットをそのまま返す。旧実装の毎リクエスト auth admin API 全ユーザー走査を廃止

## 検証
ローカルで docs/api を静的配信し dev サーバーで確認済み:
- 一覧 (limit=5)・nearby (指宿 50km→9件, 最寄り0.9km)・no_photos フィルタ・site-stats すべて期待通り
- `tsc --noEmit` 通過

## デプロイ順
pokefuta-tracker#270 を先にマージ（スナップショット配信開始後）にこの PR をマージ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)