### PR TITLE
feat: 認証を @supabase/ssr に移行し data.pokefuta.com とセッション共有

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.901.0",
         "@aws-sdk/s3-request-presigner": "^3.901.0",
-        "@supabase/auth-helpers-nextjs": "^0.8.7",
         "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.75.0",
         "@types/crypto-js": "^4.2.1",
@@ -3851,33 +3850,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-nextjs": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.8.7.tgz",
-      "integrity": "sha512-iYdOjFo0GkRvha340l8JdCiBiyXQuG9v8jnq7qMJ/2fakrskRgHTCOt7ryWbip1T6BExcWKC8SoJrhCzPOxhhg==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "@supabase/auth-helpers-shared": "0.6.3",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.19.0"
-      }
-    },
-    "node_modules/@supabase/auth-helpers-shared": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.6.3.tgz",
-      "integrity": "sha512-xYQRLFeFkL4ZfwC7p9VKcarshj3FB2QJMgJPydvOY7J5czJe6xSG5/wM1z63RmAzGbCkKg+dzpq61oeSyWiGBQ==",
-      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
-      "license": "MIT",
-      "dependencies": {
-        "jose": "^4.14.4"
-      },
-      "peerDependencies": {
-        "@supabase/supabase-js": "^2.19.0"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -9719,15 +9691,6 @@
         "jiti": "bin/jiti.js"
       }
     },
-    "node_modules/jose": {
-      "version": "4.15.9",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
-      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
-      }
-    },
     "node_modules/js-file-download": {
       "version": "0.4.12",
       "resolved": "https://registry.npmjs.org/js-file-download/-/js-file-download-0.4.12.tgz",
@@ -12258,12 +12221,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
-      "license": "MIT"
-    },
-    "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
       "license": "MIT"
     },
     "node_modules/set-function-length": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-s3": "^3.901.0",
         "@aws-sdk/s3-request-presigner": "^3.901.0",
         "@supabase/auth-helpers-nextjs": "^0.8.7",
+        "@supabase/ssr": "^0.12.0",
         "@supabase/supabase-js": "^2.75.0",
         "@types/crypto-js": "^4.2.1",
         "@types/leaflet": "^1.9.8",
@@ -3880,77 +3881,99 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.75.0.tgz",
-      "integrity": "sha512-J8TkeqCOMCV4KwGKVoxmEBuDdHRwoInML2vJilthOo7awVCro2SM+tOcpljORwuBQ1vHUtV62Leit+5wlxrNtw==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.110.0.tgz",
+      "integrity": "sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "2.6.15"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.75.0.tgz",
-      "integrity": "sha512-18yk07Moj/xtQ28zkqswxDavXC3vbOwt1hDuYM3/7xPnwwpKnsmPyZ7bQ5th4uqiJzQ135t74La9tuaxBR6e7w==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.110.0.tgz",
+      "integrity": "sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "2.6.15"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
-      "integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=22.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.4.tgz",
+      "integrity": "sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.75.0.tgz",
-      "integrity": "sha512-YfBz4W/z7eYCFyuvHhfjOTTzRrQIvsMG2bVwJAKEVVUqGdzqfvyidXssLBG0Fqlql1zJFgtsPpK1n4meHrI7tg==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.110.0.tgz",
+      "integrity": "sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "2.6.15"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.75.0.tgz",
-      "integrity": "sha512-B4Xxsf2NHd5cEnM6MGswOSPSsZKljkYXpvzKKmNxoUmNQOfB7D8HOa6NwHcUBSlxcjV+vIrYKcYXtavGJqeGrw==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.110.0.tgz",
+      "integrity": "sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "2.6.15",
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "0.4.4",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@supabase/ssr": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.12.0.tgz",
+      "integrity": "sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.2"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.108.0"
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.75.0.tgz",
-      "integrity": "sha512-wpJMYdfFDckDiHQaTpK+Ib14N/O2o0AAWWhguKvmmMurB6Unx17GGmYp5rrrqCTf8S1qq4IfIxTXxS4hzrUySg==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.110.0.tgz",
+      "integrity": "sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "2.6.15"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.75.0",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.75.0.tgz",
-      "integrity": "sha512-8UN/vATSgS2JFuJlMVr51L3eUDz+j1m7Ww63wlvHLKULzCDaVWYzvacCjBTLW/lX/vedI2LBI4Vg+01G9ufsJQ==",
+      "version": "2.110.0",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.110.0.tgz",
+      "integrity": "sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.75.0",
-        "@supabase/functions-js": "2.75.0",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "2.75.0",
-        "@supabase/realtime-js": "2.75.0",
-        "@supabase/storage-js": "2.75.0"
+        "@supabase/auth-js": "2.110.0",
+        "@supabase/functions-js": "2.110.0",
+        "@supabase/postgrest-js": "2.110.0",
+        "@supabase/realtime-js": "2.110.0",
+        "@supabase/storage-js": "2.110.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
@@ -4698,12 +4721,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
-      "integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
-      "license": "MIT"
-    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -4774,15 +4791,6 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -6770,6 +6778,19 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/copy-to-clipboard": {
       "version": "3.3.3",
@@ -8931,6 +8952,15 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/idb": {
@@ -13550,12 +13580,6 @@
       "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
       "license": "MIT"
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/tree-sitter": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/tree-sitter/-/tree-sitter-0.21.1.tgz",
@@ -14050,12 +14074,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/webpack": {
       "version": "5.101.3",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.3.tgz",
@@ -14194,16 +14212,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -14741,6 +14749,7 @@
       "version": "8.20.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
       "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.901.0",
     "@aws-sdk/s3-request-presigner": "^3.901.0",
-    "@supabase/auth-helpers-nextjs": "^0.8.7",
     "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.75.0",
     "@types/crypto-js": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-s3": "^3.901.0",
     "@aws-sdk/s3-request-presigner": "^3.901.0",
     "@supabase/auth-helpers-nextjs": "^0.8.7",
+    "@supabase/ssr": "^0.12.0",
     "@supabase/supabase-js": "^2.75.0",
     "@types/crypto-js": "^4.2.1",
     "@types/leaflet": "^1.9.8",

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,4 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,4 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { NextResponse } from 'next/server';
 import { SITE_URL } from '@/lib/constants';

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,5 +1,6 @@
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createBrowserClient as createSSRBrowserClient } from '@supabase/ssr';
 import { createClient } from '@supabase/supabase-js';
+import { authCookieOptions } from './cookies';
 
 // ==========================================
 // 環境変数チェック
@@ -33,7 +34,11 @@ export const createBrowserClient = () => {
     );
   }
 
-  return createClientComponentClient();
+  // クッキー保存（本番: Domain=.pokefuta.com）で data.pokefuta.com と
+  // セッションを共有する
+  return createSSRBrowserClient(supabaseUrl, supabaseAnonKey, {
+    cookieOptions: authCookieOptions,
+  });
 };
 
 // ==========================================

--- a/src/lib/supabase/cookies.ts
+++ b/src/lib/supabase/cookies.ts
@@ -7,9 +7,12 @@ import type { CookieOptionsWithName } from '@supabase/ssr';
 // 本番ではクッキーを親ドメイン (.pokefuta.com) スコープで発行する。
 // ローカル開発では domain を付けない（localhost に domain 指定を
 // 付けるとブラウザがクッキーを保存しない）。
+// 空文字・空白のみの環境変数は未指定として扱う
+const envCookieDomain = process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN?.trim();
+
 export const authCookieOptions: CookieOptionsWithName = {
   domain:
-    process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN ||
+    envCookieDomain ||
     (process.env.NODE_ENV === 'production' ? '.pokefuta.com' : undefined),
   path: '/',
   sameSite: 'lax',

--- a/src/lib/supabase/cookies.ts
+++ b/src/lib/supabase/cookies.ts
@@ -1,0 +1,17 @@
+import type { CookieOptionsWithName } from '@supabase/ssr';
+
+// ==========================================
+// 認証クッキーの共通オプション
+// ==========================================
+// data.pokefuta.com（GitHub Pages 側）とセッションを共有するため、
+// 本番ではクッキーを親ドメイン (.pokefuta.com) スコープで発行する。
+// ローカル開発では domain を付けない（localhost に domain 指定を
+// 付けるとブラウザがクッキーを保存しない）。
+export const authCookieOptions: CookieOptionsWithName = {
+  domain:
+    process.env.NEXT_PUBLIC_AUTH_COOKIE_DOMAIN ||
+    (process.env.NODE_ENV === 'production' ? '.pokefuta.com' : undefined),
+  path: '/',
+  sameSite: 'lax',
+  secure: process.env.NODE_ENV === 'production',
+};

--- a/src/lib/supabase/route-handler.ts
+++ b/src/lib/supabase/route-handler.ts
@@ -28,9 +28,15 @@ export function createRouteHandlerClient(
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, options)
             );
-          } catch {
-            // クッキーを書けない文脈では無視する
-            // （セッションのリフレッシュは middleware が担う）
+          } catch (error) {
+            // Server Component などクッキーを書けない文脈で呼ばれた場合。
+            // Route Handler で失敗すると Set-Cookie が反映されずログイン
+            // 状態が壊れる手掛かりになるため、握りつぶさずログに残す
+            // （セッションのリフレッシュ自体は middleware が担う）。
+            console.error(
+              `Failed to set auth cookies (${cookiesToSet.map((c) => c.name).join(', ')}):`,
+              error
+            );
           }
         },
       },

--- a/src/lib/supabase/route-handler.ts
+++ b/src/lib/supabase/route-handler.ts
@@ -1,14 +1,39 @@
-import { createRouteHandlerClient as _createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/types/database';
+import { authCookieOptions } from './cookies';
 
-// @supabase/auth-helpers-nextjs returns SupabaseClient<DB, SchemaName, Schema> (3-param style),
-// but the installed supabase-js SupabaseClient class uses 5 params where the 3rd is SchemaName
-// (a string), not Schema (the schema object). When Database["public"] satisfies GenericSchema,
-// the mismatch causes all table types to resolve to `never`. Cast to SupabaseClient<Database>
-// (1-param) which uses correct defaults.
+// @supabase/auth-helpers-nextjs（非推奨）から @supabase/ssr へ移行済み。
+// クッキーは authCookieOptions（本番: Domain=.pokefuta.com）で発行され、
+// data.pokefuta.com とセッションを共有する。
+// 既存呼び出し側との互換のため createRouteHandlerClient({ cookies }) の
+// シグネチャを維持している（引数は未使用）。
 export function createRouteHandlerClient(
-  context: Parameters<typeof _createRouteHandlerClient>[0]
+  _context?: { cookies: typeof cookies }
 ): SupabaseClient<Database> {
-  return _createRouteHandlerClient<Database>(context) as unknown as SupabaseClient<Database>;
+  const cookieStore = cookies();
+
+  return createServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: authCookieOptions,
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // クッキーを書けない文脈では無視する
+            // （セッションのリフレッシュは middleware が担う）
+          }
+        },
+      },
+    }
+  ) as unknown as SupabaseClient<Database>;
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,9 +1,28 @@
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient as createSSRServerClient } from '@supabase/ssr';
 import { cookies } from 'next/headers';
+import { authCookieOptions } from './cookies';
 
 // ==========================================
 // Server Component用クライアント
 // ==========================================
+// Server Component ではクッキーを書けないため setAll は無視する
+// （セッションのリフレッシュは middleware が担う）。
 export const createServerClient = () => {
-  return createServerComponentClient({ cookies });
+  const cookieStore = cookies();
+
+  return createSSRServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieOptions: authCookieOptions,
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll() {
+          // Server Component からは書き込み不可
+        },
+      },
+    }
+  );
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,7 @@
-import { createMiddlewareClient } from '@supabase/auth-helpers-nextjs';
+import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { authCookieOptions } from '@/lib/supabase/cookies';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
@@ -11,7 +12,23 @@ export async function middleware(req: NextRequest) {
   }
 
   try {
-    const supabase = createMiddlewareClient({ req, res });
+    const supabase = createServerClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
+      {
+        cookieOptions: authCookieOptions,
+        cookies: {
+          getAll() {
+            return req.cookies.getAll();
+          },
+          setAll(cookiesToSet) {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              res.cookies.set(name, value, options)
+            );
+          },
+        },
+      }
+    );
 
     // セッション更新
     const {


### PR DESCRIPTION
## 概要
非推奨の @supabase/auth-helpers-nextjs を @supabase/ssr (0.12) に移行し、本番のセッションクッキーを **Domain=.pokefuta.com** で発行。data.pokefuta.com（GitHub Pages）との双方向 SSO の基盤（合流計画 Phase 1）。

## 変更内容
- `src/lib/supabase/cookies.ts` 新規 — 共通クッキーオプション（`NEXT_PUBLIC_AUTH_COOKIE_DOMAIN` で上書き可。本番デフォルト `.pokefuta.com`、ローカルは domain なし）
- `client.ts` / `route-handler.ts` / `server.ts` / `middleware.ts` を @supabase/ssr に書き換え（`createRouteHandlerClient({ cookies })` のシグネチャは互換維持 → 15 の API ルートは変更不要）
- logout / auth callback の直接 import をラッパー経由に統一（auth-helpers の import はゼロに）

## 検証（Playwright、本番 Auth には触れず）
localhost のホスト共有クッキーで SSO 機構を検証：
1. 静的ログインページ描画 + CDN モジュール動作 ✅
2. Supabase Auth 到達（誤クレデンシャルでエラー表示） ✅
3. data側ブラウザクライアントが標準形式クッキーのセッションを解釈 ✅
4. **app側サーバーが同一クッキーでセッション認識**（/api/auth/session → authenticated: true） ✅
5. data側ログアウトの伝播 ✅
6. middleware の保護リダイレクト ✅

`tsc --noEmit` 通過。

## 注意
- クッキー形式・スコープが変わるため、**既存ログインユーザーは再ログインが必要**
- tracker 側 PR（feat/data-login）とセットでマージ推奨（こちらが先）

🤖 Generated with [Claude Code](https://claude.com/claude-code)