### PR TITLE
feat: ヘッダーに「図鑑」リンク追加（data.pokefuta.com への導線）

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -119,6 +119,15 @@ export default function Header({
             </Link>
           )}
 
+          <a
+            href="https://data.pokefuta.com/"
+            className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"
+            aria-label="ポケふた図鑑（data.pokefuta.com）"
+            title="ポケふた図鑑（data.pokefuta.com）"
+          >
+            図鑑
+          </a>
+
           {showXLink && (
             <a
               href="https://x.com/pokemonmanhole"

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -152,6 +152,22 @@ function PCTopNav({ active }: PCTopNavProps) {
             </Link>
           );
         })}
+        {/* 図鑑（data.pokefuta.com）への外部リンク。内部Link前提のNAV_ITEMSには混ぜない */}
+        {authLoaded && (
+          <a
+            href="https://data.pokefuta.com/"
+            style={{
+              fontSize: 13.5,
+              fontWeight: 600,
+              color: '#6f6657',
+              padding: '7px 13px',
+              borderRadius: 9,
+              textDecoration: 'none',
+            }}
+          >
+            図鑑
+          </a>
+        )}
       </div>
 
       {/* スペーサー */}

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -152,7 +152,7 @@ function PCTopNav({ active }: PCTopNavProps) {
             </Link>
           );
         })}
-        {/* 図鑑（data.pokefuta.com）への外部リンク。内部Link前提のNAV_ITEMSには混ぜない */}
+        {/* 図鑑（data.pokefuta.com）への外部リンク。内部Link前提の GUEST/AUTH_NAV_ITEMS には混ぜない */}
         {authLoaded && (
           <a
             href="https://data.pokefuta.com/"


### PR DESCRIPTION
## 概要

data.pokefuta.com との薄い相互連携の app 側。data 側の対応 PR: nishiokya/pokefuta-tracker#275（「スタンプ帳」→ /visits リンク追加 + 表示名ロジック統一）。

- `Header.tsx`（上部バー）: X リンクの隣に「図鑑」→ https://data.pokefuta.com/ リンクを追加（同一ブランド内なので同タブ遷移）
- `PCShell.tsx`（PC トップナビ）: ナビリンク列の末尾に「図鑑」外部リンクを追加（NAV_ITEMS 配列は内部 Link 前提のため素の `<a>` で追加）

表示名ロジック（`user_metadata.display_name` 優先・fallback「トレーナー」）は本リポジトリが正のため変更なし。data 側をこれに合わせた。

`BottomNav.tsx`（モバイル下部タブ）はアプリ内タブの意味合いが強いため追加していない。

## 検証

- `npx tsc --noEmit` で変更2ファイルにエラーなし（既存の `@supabase/auth-helpers-nextjs` 型解決エラー等は本 PR と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)