### PR TITLE
fix: gallery出力を公開写真のみに限定（--include-private時）＋export単体テスト追加

### DIFF
--- a/tools/export_latest_manhole_photos.py
+++ b/tools/export_latest_manhole_photos.py
@@ -157,6 +157,24 @@ def to_gallery_entry(
     }
 
 
+def select_gallery_photos(
+    photos: list[dict[str, Any]],
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Pick gallery photos: public only, newest first, at most `limit` entries.
+
+    The spec (pokefuta-tracker docs/MANHOLE_DETAIL_SPEC.md) requires the
+    gallery to contain only is_public photos even when the export itself
+    runs with --include-private.
+    """
+    public_photos = [
+        photo
+        for photo in photos
+        if normalize_visit(photo.get("visit")).get("is_public")
+    ]
+    return sorted(public_photos, key=photo_sort_date, reverse=True)[:limit]
+
+
 def supabase_get(
     path: str,
     query: dict[str, str],
@@ -340,7 +358,7 @@ def build_payload(
         entry = to_photo_entry(manhole_photos[0], base_url, display_name_by_auth_uid)
         entry["gallery"] = [
             to_gallery_entry(photo, base_url, display_name_by_auth_uid)
-            for photo in manhole_photos[:gallery_limit]
+            for photo in select_gallery_photos(manhole_photos, gallery_limit)
         ]
         photos[str(manhole_id)] = entry
     manhole_comments = fetch_manhole_comments_by_display_name(

--- a/tools/test_export_latest_manhole_photos.py
+++ b/tools/test_export_latest_manhole_photos.py
@@ -1,0 +1,117 @@
+"""Unit tests for export_latest_manhole_photos (network-free).
+
+Run: python3 tools/test_export_latest_manhole_photos.py
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).with_name("export_latest_manhole_photos.py")
+SPEC = importlib.util.spec_from_file_location("export_latest_manhole_photos", MODULE_PATH)
+export = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(export)
+
+
+def _photo(
+    photo_id: str,
+    shot_at: str | None = None,
+    created_at: str = "2026-01-01T00:00:00Z",
+    is_public: bool = True,
+    user_id: str = "user-1",
+) -> dict:
+    return {
+        "id": photo_id,
+        "manhole_id": 1,
+        "storage_key": f"photos/{photo_id}.jpeg",
+        "content_type": "image/jpeg",
+        "created_at": created_at,
+        "visit": {
+            "shot_at": shot_at,
+            "is_public": is_public,
+            "user_id": user_id,
+            "comment": None,
+        },
+    }
+
+
+class SelectGalleryPhotosTest(unittest.TestCase):
+    def test_newest_first_by_shot_at(self):
+        photos = [
+            _photo("old", shot_at="2026-01-01T00:00:00Z"),
+            _photo("new", shot_at="2026-03-01T00:00:00Z"),
+            _photo("mid", shot_at="2026-02-01T00:00:00Z"),
+        ]
+        result = export.select_gallery_photos(photos, 5)
+        self.assertEqual([p["id"] for p in result], ["new", "mid", "old"])
+
+    def test_shot_at_takes_priority_over_created_at(self):
+        photos = [
+            _photo("no-shot", shot_at=None, created_at="2026-05-01T00:00:00Z"),
+            _photo("shot", shot_at="2026-06-01T00:00:00Z", created_at="2026-01-01T00:00:00Z"),
+        ]
+        result = export.select_gallery_photos(photos, 5)
+        self.assertEqual([p["id"] for p in result], ["shot", "no-shot"])
+
+    def test_limit_is_applied(self):
+        photos = [_photo(f"p{i}", shot_at=f"2026-01-0{i}T00:00:00Z") for i in range(1, 8)]
+        result = export.select_gallery_photos(photos, 5)
+        self.assertEqual(len(result), 5)
+        self.assertEqual(result[0]["id"], "p7")
+
+    def test_private_photos_are_excluded(self):
+        photos = [
+            _photo("public", shot_at="2026-01-01T00:00:00Z"),
+            _photo("private", shot_at="2026-02-01T00:00:00Z", is_public=False),
+        ]
+        result = export.select_gallery_photos(photos, 5)
+        self.assertEqual([p["id"] for p in result], ["public"])
+
+    def test_representative_is_first_gallery_entry(self):
+        # The newest public photo (= representative in the default run)
+        # must open the gallery.
+        photos = [
+            _photo("rep", shot_at="2026-03-01T00:00:00Z"),
+            _photo("other", shot_at="2026-01-01T00:00:00Z"),
+        ]
+        newest = sorted(photos, key=export.photo_sort_date, reverse=True)[0]
+        result = export.select_gallery_photos(photos, 5)
+        self.assertEqual(result[0]["id"], newest["id"])
+        self.assertEqual(result[0]["id"], "rep")
+
+    def test_empty_input(self):
+        self.assertEqual(export.select_gallery_photos([], 5), [])
+
+    def test_visit_as_list_is_normalized(self):
+        photo = _photo("listy", shot_at="2026-01-01T00:00:00Z")
+        photo["visit"] = [photo["visit"]]
+        result = export.select_gallery_photos([photo], 5)
+        self.assertEqual([p["id"] for p in result], ["listy"])
+
+
+class ToGalleryEntryTest(unittest.TestCase):
+    def test_fields_and_display_name(self):
+        photo = _photo("abc", shot_at="2026-01-02T03:04:05Z", user_id="uid-9")
+        entry = export.to_gallery_entry(photo, "https://images.example.com", {"uid-9": "tako"})
+        self.assertEqual(
+            entry,
+            {
+                "photo_id": "abc",
+                "url": "https://images.example.com/photos/abc.jpeg",
+                "storage_key": "photos/abc.jpeg",
+                "content_type": "image/jpeg",
+                "created_at": "2026-01-01T00:00:00Z",
+                "shot_at": "2026-01-02T03:04:05Z",
+                "display_name": "tako",
+            },
+        )
+
+    def test_unknown_user_gives_none_display_name(self):
+        photo = _photo("abc", user_id="unknown")
+        entry = export.to_gallery_entry(photo, "https://images.example.com", {})
+        self.assertIsNone(entry["display_name"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要

#162 で追加された `latest-manhole-photos.json` の `gallery` 出力について、仕様（pokefuta-tracker `docs/MANHOLE_DETAIL_SPEC.md`）の「gallery は `is_public = true` の写真のみ」要件を厳密化。

- gallery 選定を純関数 `select_gallery_photos()` に切り出し、`visit.is_public` でフィルタ
- `--include-private` 実行時でも非公開写真が gallery に混入しなくなる（デフォルト実行＝週次ワークフローは従来から public のみなので挙動不変）
- `tools/test_export_latest_manhole_photos.py` 新設（stdlib unittest・ネットワーク不要・9件）

## 検証

- `python3 tools/test_export_latest_manhole_photos.py` → 9件 OK
- 実 Supabase に対して export 実行 → 142件、既存フィールドは現行本番JSONと完全一致（後方互換）、gallery は全件で並び順・5枚上限・代表先頭を確認
- tracker 側 E2E: import（gallery_imported=39, failed=0）→ ページ生成 → マンホール4の詳細HTMLに「みんなの写真」セクション描画を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)