### PR TITLE
feat: /upload未ログイン時にfrom=dataを/loginへ引き継ぐ

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -45,6 +45,10 @@ export async function middleware(req: NextRequest) {
       const redirectUrl = new URL('/login', req.url);
       // クエリ（?manhole_id= 等）も保持してログイン後に復元する
       redirectUrl.searchParams.set('redirect', req.nextUrl.pathname + req.nextUrl.search);
+      // data.pokefuta.com からの導線では /login に文脈を引き継ぐ（fromDataSite 案内表示）
+      if (req.nextUrl.searchParams.get('from') === 'data') {
+        redirectUrl.searchParams.set('from', 'data');
+      }
       return NextResponse.redirect(redirectUrl);
     }
 


### PR DESCRIPTION
## 背景

data.pokefuta.com の写真投稿CTA（`/upload?manhole_id=X&from=data`）から来た未ログインユーザーは、middleware で `/login` にリダイレクトされるが、`from=data` が落ちるため既存の fromDataSite 案内バナー（「data.pokefuta.comから来た方へ」共通アカウントの説明）が表示されなかった。

## 変更内容

- `src/middleware.ts`: 未ログインで保護パスに来た際、`from=data` クエリを `/login` へのリダイレクトURLに引き継ぐ。`redirect` パラメータによるログイン後の復元（manhole_id 保持）は従来どおり

tracker側の対応PR: nishiokya/pokefuta-tracker#285

## 検証

- `npx tsc --noEmit` エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)