### PR TITLE
perf: トップページ高速化 — サムネイル配信とAPIキャッシュ

### DIFF
--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -3,7 +3,8 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
-import { storage, generateStorageKey } from '@/lib/storage';
+import sharp from 'sharp';
+import { storage, generateStorageKey, deriveSmallKey } from '@/lib/storage';
 import { calculateDistance, isValidCoordinates, MAX_DISTANCE_KM, extractCoordinatesFromWKB } from '@/lib/location';
 
 /**
@@ -296,6 +297,25 @@ export async function POST(request: NextRequest) {
       contentType: file.type,
       cacheControl: 'public, max-age=31536000, immutable',
     });
+
+    // Generate the small variant used by feed thumbnails (/api/photo?size=small).
+    // 失敗しても読み側がオリジナルへフォールバックするため、アップロード自体は成功させる。
+    const smallKey = deriveSmallKey(storageKey);
+    if (smallKey) {
+      try {
+        const smallBuffer = await sharp(Buffer.from(arrayBuffer))
+          .rotate()
+          .resize(400, 400, { fit: 'inside', withoutEnlargement: true })
+          .webp({ quality: 70 })
+          .toBuffer();
+        await storage.put(smallKey, smallBuffer, {
+          contentType: 'image/webp',
+          cacheControl: 'public, max-age=31536000, immutable',
+        });
+      } catch (thumbError) {
+        console.error(`Thumbnail generation failed for ${storageKey}:`, thumbError);
+      }
+    }
 
     // Get signed URL for the uploaded file
     const signedUrl = await storage.getSignedUrl(storageKey, 3600); // 1 hour

--- a/src/app/api/photo/[id]/route.ts
+++ b/src/app/api/photo/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
-import { storage } from '@/lib/storage';
+import { storage, deriveSmallKey } from '@/lib/storage';
 
 /**
  * @swagger
@@ -113,14 +113,30 @@ export async function GET(
     // Determine which storage key to use based on size
     let storageKey = photo.storage_key;
 
-    // For now, we don't have separate thumbnails, so just use the main image
-    // TODO: Generate and store thumbnails
+    if (size === 'small') {
+      const smallKey = deriveSmallKey(photo.storage_key);
+      // Small variant may not exist for photos uploaded before the thumbnail
+      // pipeline (or if generation failed) — fall back to the original.
+      if (smallKey && (await storage.exists?.(smallKey))) {
+        storageKey = smallKey;
+      }
+    }
 
     // Get signed URL from storage provider
     const signedUrl = await storage.getSignedUrl(storageKey, 3600); // 1 hour expiry
 
+    // Cache the redirect so browsers reuse the same signed URL (which lets the
+    // immutable R2 object hit the browser cache). max-age must stay well below
+    // the signed URL TTL (3600s) so a cached Location never points at an
+    // expired URL. Private photos must not enter shared caches.
+    const cacheControl = visit?.is_public === true
+      ? 'public, max-age=1800, stale-while-revalidate=600'
+      : 'private, max-age=600';
+
     // Redirect to the signed URL
-    return NextResponse.redirect(signedUrl.url);
+    return NextResponse.redirect(signedUrl.url, {
+      headers: { 'Cache-Control': cacheControl },
+    });
 
   } catch (error: any) {
     console.error('Error fetching photo:', error);

--- a/src/app/api/visits/route.ts
+++ b/src/app/api/visits/route.ts
@@ -231,35 +231,47 @@ export async function GET(request: NextRequest) {
       )
     );
 
-    // いいね数とユーザーのいいね状態を取得
-    const { data: likes } = await supabase
-      .from('visit_like')
-      .select('visit_id, user_id')
-      .in('visit_id', visitIds);
+    const uniqueUserIds = Array.from(
+      new Set((visits || []).map((visit: any) => visit.user_id).filter(Boolean))
+    );
 
-    // 訪問記録へのコメント数を取得
-    const { data: commentCounts } = await supabase
-      .from('visit_comment')
-      .select('visit_id')
-      .in('visit_id', visitIds);
-
-    // マンホール共有コメント数を取得
-    const { data: manholeCommentCounts } = manholeIds.length > 0
-      ? await supabase
-        .from('manhole_comment')
-        .select('manhole_id')
-        .in('manhole_id', manholeIds)
-        .is('parent_comment_id', null)
-      : { data: [] as any[] };
-
-    // ユーザーのブックマーク状態を取得
-    const { data: bookmarks } = viewerUserId
-      ? await supabase
-        .from('visit_bookmark')
+    // いいね数・コメント数・ブックマーク状態・投稿者表示名は互いに独立なので並列取得
+    const [
+      { data: likes },
+      { data: commentCounts },
+      { data: manholeCommentCounts },
+      { data: bookmarks },
+      { data: appUsers },
+    ] = await Promise.all([
+      supabase
+        .from('visit_like')
+        .select('visit_id, user_id')
+        .in('visit_id', visitIds),
+      supabase
+        .from('visit_comment')
         .select('visit_id')
-        .eq('user_id', viewerUserId)
-        .in('visit_id', visitIds)
-      : { data: [] as any[] };
+        .in('visit_id', visitIds),
+      manholeIds.length > 0
+        ? supabase
+          .from('manhole_comment')
+          .select('manhole_id')
+          .in('manhole_id', manholeIds)
+          .is('parent_comment_id', null)
+        : Promise.resolve({ data: [] as any[] }),
+      viewerUserId
+        ? supabase
+          .from('visit_bookmark')
+          .select('visit_id')
+          .eq('user_id', viewerUserId)
+          .in('visit_id', visitIds)
+        : Promise.resolve({ data: [] as any[] }),
+      uniqueUserIds.length > 0
+        ? supabase
+          .from('app_user')
+          .select('auth_uid, display_name')
+          .in('auth_uid', uniqueUserIds)
+        : Promise.resolve({ data: [] as any[] }),
+    ]);
 
     // 各訪問記録のいいね数・コメント数・状態を集計
     const likesMap = new Map<string, { count: number; isLiked: boolean }>();
@@ -341,17 +353,10 @@ export async function GET(request: NextRequest) {
     });
 
     // Enrich with poster display_name
-    const uniqueUserIds = Array.from(new Set(processedVisits.map((v: any) => v.user_id).filter(Boolean)));
     const displayNameMap = new Map<string, string | null>();
-    if (uniqueUserIds.length > 0) {
-      const { data: appUsers } = await supabase
-        .from('app_user')
-        .select('auth_uid, display_name')
-        .in('auth_uid', uniqueUserIds);
-      (appUsers || []).forEach((u: any) => {
-        if (u?.auth_uid) displayNameMap.set(u.auth_uid, u.display_name ?? null);
-      });
-    }
+    (appUsers || []).forEach((u: any) => {
+      if (u?.auth_uid) displayNameMap.set(u.auth_uid, u.display_name ?? null);
+    });
     const enrichedVisits = processedVisits.map((v: any) => ({
       ...v,
       display_name: displayNameMap.get(v.user_id) ?? null,
@@ -406,6 +411,15 @@ export async function GET(request: NextRequest) {
         offset,
         total: filteredVisits.length
       }
+    }, {
+      headers: {
+        // 匿名レスポンスは全員同一(is_liked/is_bookmarked 常に false)なので
+        // CDN で共有キャッシュさせ、Lambda 起動ごと削減する。
+        // ログイン時はユーザー固有のためキャッシュ禁止。
+        'Cache-Control': viewerUserId
+          ? 'private, no-store'
+          : 'public, s-maxage=60, stale-while-revalidate=300',
+      },
     });
 
   } catch (error: any) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -309,7 +309,8 @@ export default function HomePage() {
                             src={photo.thumbnail_url}
                             alt=""
                             className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
-                            loading="lazy"
+                            loading={currentPage === 1 && index < 4 ? 'eager' : 'lazy'}
+                            fetchPriority={currentPage === 1 && index < 4 ? 'high' : undefined}
                           />
                         ) : (
                           <div className="flex h-full w-full items-center justify-center bg-[#FFF8EB] text-[#7B63A8]">

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -36,6 +36,19 @@ export function generateStorageKey(type: 'original' | 'thumb', size?: number): s
   return `photos/original/${year}/${month}/${uuid}.jpg`;
 }
 
+// Derive the small-variant key from an original storage key.
+// photos/original/YYYY/MM/{uuid}.jpg -> photos/small/YYYY/MM/{uuid}.webp
+// Deterministic so the read path can re-derive it without a DB column.
+// Returns null for keys that don't follow the original-photo layout.
+export function deriveSmallKey(storageKey: string): string | null {
+  if (!storageKey.includes('/original/')) {
+    return null;
+  }
+  return storageKey
+    .replace('/original/', '/small/')
+    .replace(/\.[^./]+$/, '.webp');
+}
+
 export function generateContextImageStorageKey(manholeId: number, contentType?: string): string {
   const date = new Date();
   const year = date.getFullYear();

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -41,11 +41,11 @@ export function generateStorageKey(type: 'original' | 'thumb', size?: number): s
 // Deterministic so the read path can re-derive it without a DB column.
 // Returns null for keys that don't follow the original-photo layout.
 export function deriveSmallKey(storageKey: string): string | null {
-  if (!storageKey.includes('/original/')) {
+  if (!storageKey.startsWith('photos/original/')) {
     return null;
   }
   return storageKey
-    .replace('/original/', '/small/')
+    .replace('photos/original/', 'photos/small/')
     .replace(/\.[^./]+$/, '.webp');
 }
 

--- a/tools/backfill-thumbnails.js
+++ b/tools/backfill-thumbnails.js
@@ -77,13 +77,20 @@ const s3 = new S3Client({
 const args = process.argv.slice(2);
 const DRY_RUN = args.includes('--dry-run');
 const limitIdx = args.indexOf('--limit');
-const LIMIT = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 0;
+let LIMIT = 0;
+if (limitIdx !== -1) {
+  LIMIT = parseInt(args[limitIdx + 1], 10);
+  if (!Number.isInteger(LIMIT) || LIMIT <= 0) {
+    console.error('--limit requires a positive integer (e.g. --limit 10)');
+    process.exit(1);
+  }
+}
 const CONCURRENCY = 5;
 
 // Must match deriveSmallKey in src/lib/storage/index.ts
 function deriveSmallKey(storageKey) {
-  if (!storageKey.includes('/original/')) return null;
-  return storageKey.replace('/original/', '/small/').replace(/\.[^./]+$/, '.webp');
+  if (!storageKey.startsWith('photos/original/')) return null;
+  return storageKey.replace('photos/original/', 'photos/small/').replace(/\.[^./]+$/, '.webp');
 }
 
 // --- supabase REST (avoid extra deps) -----------------------------------
@@ -178,8 +185,9 @@ async function main() {
     if (rows.length === 0) break;
 
     for (let i = 0; i < rows.length; i += CONCURRENCY) {
-      const batch = rows.slice(i, i + CONCURRENCY)
-        .filter(() => !LIMIT || processed < LIMIT)
+      const remaining = LIMIT ? LIMIT - processed : Infinity;
+      if (remaining <= 0) break;
+      const batch = rows.slice(i, i + Math.min(CONCURRENCY, remaining))
         .map((photo) => {
           processed++;
           return processPhoto(photo, counters, failures);

--- a/tools/backfill-thumbnails.js
+++ b/tools/backfill-thumbnails.js
@@ -192,6 +192,9 @@ async function main() {
     }
 
     if (LIMIT && processed >= LIMIT) break;
+    // 最終ページ(満杯未満)で終了。ちょうど総数で割り切れる場合に
+    // 次ページを要求すると Supabase REST が 416 を返すため。
+    if (rows.length < pageSize || offset + rows.length >= total) break;
     offset += pageSize;
   }
 

--- a/tools/backfill-thumbnails.js
+++ b/tools/backfill-thumbnails.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Backfill small thumbnail variants for existing photos.
+ *
+ * photo テーブルの storage_key (photos/original/YYYY/MM/{uuid}.jpg) から
+ * photos/small/YYYY/MM/{uuid}.webp を生成して R2 に保存する。
+ * /api/photo/[id]?size=small が読む派生キーと同じ規則
+ * (src/lib/storage/index.ts の deriveSmallKey と一致させること)。
+ *
+ * 既に小変種が存在する写真はスキップするので再実行安全。
+ *
+ * Usage:
+ *   node tools/backfill-thumbnails.js --dry-run
+ *   node tools/backfill-thumbnails.js --limit 10
+ *   node tools/backfill-thumbnails.js
+ *
+ * Requires .env.local with:
+ *   NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY,
+ *   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT, R2_BUCKET
+ */
+
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+const {
+  S3Client,
+  GetObjectCommand,
+  PutObjectCommand,
+  HeadObjectCommand,
+} = require('@aws-sdk/client-s3');
+
+// --- env ---------------------------------------------------------------
+
+function loadEnvLocal() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  if (!fs.existsSync(envPath)) return;
+  for (const line of fs.readFileSync(envPath, 'utf-8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || !trimmed.includes('=')) continue;
+    const idx = trimmed.indexOf('=');
+    const key = trimmed.slice(0, idx).trim();
+    const value = trimmed.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+    if (key && !(key in process.env)) process.env[key] = value;
+  }
+}
+
+loadEnvLocal();
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const R2_BUCKET = process.env.R2_BUCKET || 'image';
+
+for (const [name, value] of Object.entries({
+  NEXT_PUBLIC_SUPABASE_URL: SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY: SERVICE_ROLE_KEY,
+  R2_ACCESS_KEY_ID: process.env.R2_ACCESS_KEY_ID,
+  R2_SECRET_ACCESS_KEY: process.env.R2_SECRET_ACCESS_KEY,
+  R2_ENDPOINT: process.env.R2_ENDPOINT,
+})) {
+  if (!value) {
+    console.error(`Missing required env: ${name}`);
+    process.exit(1);
+  }
+}
+
+const s3 = new S3Client({
+  region: 'auto',
+  endpoint: process.env.R2_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.R2_ACCESS_KEY_ID,
+    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
+  },
+});
+
+// --- args --------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const DRY_RUN = args.includes('--dry-run');
+const limitIdx = args.indexOf('--limit');
+const LIMIT = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 0;
+const CONCURRENCY = 5;
+
+// Must match deriveSmallKey in src/lib/storage/index.ts
+function deriveSmallKey(storageKey) {
+  if (!storageKey.includes('/original/')) return null;
+  return storageKey.replace('/original/', '/small/').replace(/\.[^./]+$/, '.webp');
+}
+
+// --- supabase REST (avoid extra deps) -----------------------------------
+
+async function fetchPhotoPage(offset, pageSize) {
+  const url = `${SUPABASE_URL}/rest/v1/photo?select=id,storage_key&order=created_at.asc&offset=${offset}&limit=${pageSize}`;
+  const res = await fetch(url, {
+    headers: {
+      apikey: SERVICE_ROLE_KEY,
+      Authorization: `Bearer ${SERVICE_ROLE_KEY}`,
+      Prefer: 'count=exact',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Supabase REST error ${res.status}: ${await res.text()}`);
+  }
+  const total = parseInt((res.headers.get('content-range') || '').split('/')[1] || '0', 10);
+  return { rows: await res.json(), total };
+}
+
+// --- R2 helpers ----------------------------------------------------------
+
+async function objectExists(key) {
+  try {
+    await s3.send(new HeadObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+    return true;
+  } catch (err) {
+    if (err?.$metadata?.httpStatusCode === 404 || err?.name === 'NotFound') return false;
+    throw err;
+  }
+}
+
+async function getObjectBuffer(key) {
+  const res = await s3.send(new GetObjectCommand({ Bucket: R2_BUCKET, Key: key }));
+  const chunks = [];
+  for await (const chunk of res.Body) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+// --- main ----------------------------------------------------------------
+
+async function processPhoto(photo, counters, failures) {
+  const smallKey = deriveSmallKey(photo.storage_key);
+  if (!smallKey) {
+    counters.skippedKey++;
+    return;
+  }
+  try {
+    if (await objectExists(smallKey)) {
+      counters.alreadyExists++;
+      return;
+    }
+    if (DRY_RUN) {
+      counters.wouldGenerate++;
+      console.log(`[dry-run] would generate ${smallKey}`);
+      return;
+    }
+    const original = await getObjectBuffer(photo.storage_key);
+    const small = await sharp(original)
+      .rotate()
+      .resize(400, 400, { fit: 'inside', withoutEnlargement: true })
+      .webp({ quality: 70 })
+      .toBuffer();
+    await s3.send(new PutObjectCommand({
+      Bucket: R2_BUCKET,
+      Key: smallKey,
+      Body: small,
+      ContentType: 'image/webp',
+      CacheControl: 'public, max-age=31536000, immutable',
+    }));
+    counters.generated++;
+  } catch (err) {
+    counters.failed++;
+    failures.push({ id: photo.id, storage_key: photo.storage_key, error: err.message });
+  }
+}
+
+async function main() {
+  const pageSize = 500;
+  const counters = { generated: 0, alreadyExists: 0, wouldGenerate: 0, skippedKey: 0, failed: 0 };
+  const failures = [];
+  let offset = 0;
+  let processed = 0;
+  let total = null;
+
+  while (true) {
+    const { rows, total: totalCount } = await fetchPhotoPage(offset, pageSize);
+    if (total === null) {
+      total = totalCount;
+      console.log(`photo total: ${total}${DRY_RUN ? ' (dry-run)' : ''}${LIMIT ? ` limit=${LIMIT}` : ''}`);
+    }
+    if (rows.length === 0) break;
+
+    for (let i = 0; i < rows.length; i += CONCURRENCY) {
+      const batch = rows.slice(i, i + CONCURRENCY)
+        .filter(() => !LIMIT || processed < LIMIT)
+        .map((photo) => {
+          processed++;
+          return processPhoto(photo, counters, failures);
+        });
+      if (batch.length === 0) break;
+      await Promise.all(batch);
+      if (processed % 50 === 0) {
+        console.log(`progress: ${processed}/${LIMIT || total} generated=${counters.generated} exists=${counters.alreadyExists} failed=${counters.failed}`);
+      }
+    }
+
+    if (LIMIT && processed >= LIMIT) break;
+    offset += pageSize;
+  }
+
+  console.log('\nsummary:', counters);
+  if (failures.length > 0) {
+    console.log('\nfailures:');
+    for (const f of failures) console.log(`  ${f.id} ${f.storage_key}: ${f.error}`);
+  }
+  process.exit(failures.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## 概要

トップページの表示が遅い問題の対策。最大の要因は「サムネイル未実装のため、フィード24枚が毎回オリジナル約1MBずつ（計約24MB）配信されていた」こと。

## 変更内容

### Phase A: クイックウィン
- `/api/visits`: いいね・コメント数・ブックマーク・表示名の5クエリを `Promise.all` で並列化（5往復→1往復分の時間に）
- 匿名 `/api/visits` レスポンスに `Cache-Control: public, s-maxage=60, stale-while-revalidate=300` を付与（匿名は is_liked/is_bookmarked が常に false で全員同一のためCDN共有キャッシュ可。ログイン時は `private, no-store`）
- トップページ先頭4枚を `loading="eager"` + `fetchPriority="high"` に

### Phase B: サムネイルパイプライン
- `deriveSmallKey()` 追加: `photos/original/YYYY/MM/{uuid}.jpg` → `photos/small/YYYY/MM/{uuid}.webp` の決定的導出（DBスキーマ変更なし）
- アップロード時に sharp で 400px webp(q70) の小変種を生成しR2へ保存。生成失敗は非致命（ログのみ）
- `/api/photo/[id]?size=small` が小変種へリダイレクト。**小変種が無い写真はオリジナルへフォールバック**（既存写真は壊れない）
- リダイレクトに Cache-Control 付与: 公開写真 `public, max-age=1800, stale-while-revalidate=600`（署名URL TTL 3600s の半分以下に抑え、期限切れURLがキャッシュされないようにする）、非公開写真 `private, max-age=600`
- `tools/backfill-thumbnails.js`: 既存写真（213件）の小変種を一括生成。冪等（存在チェックでスキップ）、`--dry-run` / `--limit N` 対応

## 検証（ローカル本番ビルドで実測）

- 小変種 **33KB** vs オリジナル **1.3MB**（約1/40）→ トップページ画像転送 約24MB→1MB弱の見込み
- 小変種の無い写真がオリジナルにフォールバックすることを確認
- 匿名 `/api/visits` / `/api/photo` の Cache-Control が想定値で返ることを確認
- `tsc --noEmit`・`next build` 通過、バックフィル5件実運転成功

## デプロイ後の手順

1. `node tools/backfill-thumbnails.js` を全件実行（再実行安全）
2. 本番で `/api/visits` に2回 curl し CloudFront の `Age`/`X-Cache` ヒットを確認（ヒットしない場合のみインメモリキャッシュを追加検討）

🤖 Generated with [Claude Code](https://claude.com/claude-code)