### PR TITLE
feat: デザインマンホール投稿機能 — ポケふた以外のデザイン蓋を収集（要ログイン）

### DIFF
--- a/database/migrations/018_add_design_manhole.sql
+++ b/database/migrations/018_add_design_manhole.sql
@@ -1,0 +1,52 @@
+-- ============================================================
+-- 018: デザインマンホール（ポケふた以外のご当地デザインマンホール）投稿テーブル
+-- ============================================================
+-- 投稿にはログイン必須（API Route がセッションを検証）。閲覧は誰でも可。
+-- 全アクセスは API Route (service role) 経由。anon/authenticated キーからは触れない。
+-- モデレーション: Supabase Dashboard の Table Editor で status を 'hidden' に変更する
+-- （一覧 API と写真配信 API の両方から消える）。
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.design_manhole (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  title TEXT,                              -- 任意（例: 「○○市 花柄マンホール」）
+  description TEXT,
+  submitter_name TEXT,                     -- 任意の表示名（デフォルトはログインユーザーの表示名）
+
+  latitude DOUBLE PRECISION NOT NULL,
+  longitude DOUBLE PRECISION NOT NULL,
+
+  storage_provider TEXT NOT NULL DEFAULT 'r2',
+  storage_key TEXT NOT NULL UNIQUE,        -- photos/design/original/YYYY/MM/{uuid}.{ext}
+  content_type TEXT NOT NULL,
+  file_size INTEGER,
+  width INTEGER,
+  height INTEGER,
+  exif JSONB,                              -- exifr の GPS/整合性フィールド（詐称検知用・非公開）
+
+  status TEXT NOT NULL DEFAULT 'published'
+    CHECK (status IN ('published', 'hidden')),
+
+  created_by UUID NOT NULL,                -- auth.users.id（visit.user_id と同じ流儀）
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_design_manhole_status_created
+  ON public.design_manhole (status, created_at DESC);
+
+-- ユーザー単位のモデレーション・調査用
+CREATE INDEX IF NOT EXISTS idx_design_manhole_created_by
+  ON public.design_manhole (created_by, created_at DESC);
+
+-- updated_at 自動更新（015 で定義済みの関数を再利用）
+DROP TRIGGER IF EXISTS set_design_manhole_updated_at ON public.design_manhole;
+CREATE TRIGGER set_design_manhole_updated_at
+  BEFORE UPDATE ON public.design_manhole
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS: 有効化のみ・ポリシーなし = anon/authenticated キーからは一切アクセス不可。
+-- service role (API Route の supabaseAdmin) は RLS をバイパスする。
+ALTER TABLE public.design_manhole ENABLE ROW LEVEL SECURITY;

--- a/src/app/api/design-manholes/[id]/photo/route.ts
+++ b/src/app/api/design-manholes/[id]/photo/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabase/client';
+import { storage, deriveDesignSmallKey } from '@/lib/storage';
+
+export const dynamic = 'force-dynamic';
+// supabase-js の PostgREST GET が Next の Data Cache に乗ると
+// hidden 化した行の写真が配信され続けるため、fetch キャッシュを無効化する
+export const fetchCache = 'force-no-store';
+
+/**
+ * @swagger
+ * /api/design-manholes/{id}/photo:
+ *   get:
+ *     summary: デザインマンホールの写真を取得
+ *     tags: [design-manholes]
+ *     description: 公開中(published)の投稿のみ。写真のsigned URLにリダイレクトします。
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema: { type: string, format: uuid }
+ *       - in: query
+ *         name: size
+ *         schema: { type: string, enum: [small] }
+ *     responses:
+ *       307: { description: Signed URLにリダイレクト }
+ *       404: { description: 見つかりません }
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { id: string } }
+) {
+  try {
+    if (!supabaseAdmin) {
+      return NextResponse.json(
+        { success: false, error: 'サーバー設定エラーが発生しました' },
+        { status: 500 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const size = searchParams.get('size');
+
+    // hidden にした投稿は写真も 404 にする（status フィルタが本体）
+    const { data: row, error } = await supabaseAdmin
+      .from('design_manhole')
+      .select('id, storage_key')
+      .eq('id', params.id)
+      .eq('status', 'published')
+      .single();
+
+    if (error || !row) {
+      return NextResponse.json(
+        { success: false, error: 'Not found' },
+        { status: 404 }
+      );
+    }
+
+    let storageKey = row.storage_key as string;
+    if (size === 'small') {
+      const smallKey = deriveDesignSmallKey(storageKey);
+      // サムネイル生成に失敗している投稿は original にフォールバック
+      if (smallKey && (await storage.exists?.(smallKey))) {
+        storageKey = smallKey;
+      }
+    }
+
+    const signedUrl = await storage.getSignedUrl(storageKey, 3600);
+
+    // max-age は signed URL TTL(3600s) より十分短くする（/api/photo/[id] と同じ理屈）
+    return NextResponse.redirect(signedUrl.url, {
+      headers: {
+        'Cache-Control': 'public, max-age=1800, stale-while-revalidate=600',
+      },
+    });
+  } catch (error: any) {
+    console.error('Design manhole photo error:', error);
+    return NextResponse.json(
+      { success: false, error: 'Failed to fetch photo' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -1,0 +1,301 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import sharp from 'sharp';
+import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
+import { supabaseAdmin } from '@/lib/supabase/client';
+import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import {
+  storage,
+  generateDesignManholeStorageKey,
+  deriveDesignSmallKey,
+} from '@/lib/storage';
+import { isValidCoordinates } from '@/lib/location';
+
+export const dynamic = 'force-dynamic';
+// supabase-js の PostgREST GET が Next の Data Cache に乗るのを防ぐ
+// （一覧から hidden 行が消えない事故の予防。CDN 側キャッシュは Cache-Control で制御）
+export const fetchCache = 'force-no-store';
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+// HEIC はクライアント側で browser-image-compression が JPEG に変換して送る前提。
+// sharp(0.32) が HEIC をデコードできないためサーバーでは受けない。
+const ALLOWED_CONTENT_TYPES = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+// デザインマンホールは日本のご当地文化なので日本近辺に限定（離島含むゆるめの矩形）
+const JAPAN_BOUNDS = { latMin: 20, latMax: 46, lngMin: 122, lngMax: 154 };
+
+const MAX_TITLE_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 1000;
+const MAX_SUBMITTER_NAME_LENGTH = 50;
+
+function optionalText(value: FormDataEntryValue | null, maxLength: number): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.slice(0, maxLength);
+}
+
+/**
+ * @swagger
+ * /api/design-manholes:
+ *   post:
+ *     summary: デザインマンホールを投稿
+ *     tags: [design-manholes]
+ *     description: ポケふた以外のデザインマンホールを写真+位置情報付きで投稿します。要ログイン。
+ *     security:
+ *       - cookieAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         multipart/form-data:
+ *           schema:
+ *             type: object
+ *             required: [file, lat, lng]
+ *             properties:
+ *               file: { type: string, format: binary }
+ *               lat: { type: number }
+ *               lng: { type: number }
+ *               title: { type: string, maxLength: 100 }
+ *               description: { type: string, maxLength: 1000 }
+ *               submitterName: { type: string, maxLength: 50 }
+ *               exif: { type: string, description: JSON string }
+ *     responses:
+ *       201: { description: 投稿成功 }
+ *       400: { description: バリデーションエラー }
+ *       401: { description: 認証が必要 }
+ */
+export async function POST(request: NextRequest) {
+  let uploadedStorageKey: string | null = null;
+
+  try {
+    if (!supabaseAdmin) {
+      console.error('supabaseAdmin is not configured (SUPABASE_SERVICE_ROLE_KEY missing)');
+      return NextResponse.json(
+        { success: false, error: 'サーバー設定エラーが発生しました' },
+        { status: 500 }
+      );
+    }
+
+    // 1. 認証（image-upload と同じ cookie セッション方式）
+    const supabase = createRouteHandlerClient({ cookies });
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.user) {
+      return NextResponse.json(
+        { success: false, error: 'ログインが必要です' },
+        { status: 401 }
+      );
+    }
+    const userId = session.user.id;
+    const displayName = session.user.user_metadata?.display_name as string | undefined;
+    await ensureAppUser(supabase, userId, displayName);
+
+    const formData = await request.formData();
+
+    // 2. ファイル検証
+    const file = formData.get('file');
+    if (!(file instanceof File)) {
+      return NextResponse.json(
+        { success: false, error: '写真を選択してください' },
+        { status: 400 }
+      );
+    }
+    if (!ALLOWED_CONTENT_TYPES.has(file.type)) {
+      return NextResponse.json(
+        { success: false, error: 'JPEG/PNG/WebP形式の画像のみ投稿できます' },
+        { status: 400 }
+      );
+    }
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      return NextResponse.json(
+        { success: false, error: `画像サイズが大きすぎます（最大${MAX_FILE_SIZE_BYTES / 1024 / 1024}MB）` },
+        { status: 400 }
+      );
+    }
+
+    // 3. 座標検証
+    const lat = parseFloat(String(formData.get('lat') ?? ''));
+    const lng = parseFloat(String(formData.get('lng') ?? ''));
+    if (!isValidCoordinates(lat, lng)) {
+      return NextResponse.json(
+        { success: false, error: '位置情報を指定してください' },
+        { status: 400 }
+      );
+    }
+    if (
+      lat < JAPAN_BOUNDS.latMin || lat > JAPAN_BOUNDS.latMax ||
+      lng < JAPAN_BOUNDS.lngMin || lng > JAPAN_BOUNDS.lngMax
+    ) {
+      return NextResponse.json(
+        { success: false, error: '日本国内の位置を指定してください' },
+        { status: 400 }
+      );
+    }
+
+    // 4. テキスト項目（すべて任意・長さ上限で切り詰め）
+    const title = optionalText(formData.get('title'), MAX_TITLE_LENGTH);
+    const description = optionalText(formData.get('description'), MAX_DESCRIPTION_LENGTH);
+    const submitterName =
+      optionalText(formData.get('submitterName'), MAX_SUBMITTER_NAME_LENGTH) ??
+      (displayName ? displayName.slice(0, MAX_SUBMITTER_NAME_LENGTH) : null);
+
+    let exif: Record<string, any> | null = null;
+    const exifRaw = formData.get('exif');
+    if (typeof exifRaw === 'string' && exifRaw) {
+      try {
+        const parsed = JSON.parse(exifRaw);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          exif = parsed;
+        }
+      } catch {
+        // EXIF は補助情報なので不正な JSON は黙って捨てる
+      }
+    }
+
+    // 5. R2 アップロード + サムネイル生成
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = Buffer.from(arrayBuffer);
+    const storageKey = generateDesignManholeStorageKey(file.type);
+    uploadedStorageKey = storageKey;
+
+    await storage.put(storageKey, buffer, {
+      contentType: file.type,
+      cacheControl: 'public, max-age=31536000, immutable',
+    });
+
+    let width: number | null = null;
+    let height: number | null = null;
+    try {
+      const metadata = await sharp(buffer).metadata();
+      width = metadata.width ?? null;
+      height = metadata.height ?? null;
+    } catch {
+      // 寸法取得失敗は非致命
+    }
+
+    const smallKey = deriveDesignSmallKey(storageKey);
+    if (smallKey) {
+      try {
+        const thumbnail = await sharp(buffer)
+          .rotate()
+          .resize(400, 400, { fit: 'inside', withoutEnlargement: true })
+          .webp({ quality: 70 })
+          .toBuffer();
+        await storage.put(smallKey, thumbnail, {
+          contentType: 'image/webp',
+          cacheControl: 'public, max-age=31536000, immutable',
+        });
+      } catch (thumbError) {
+        // サムネイル失敗は非致命（配信側が original にフォールバック）
+        console.error('Design manhole thumbnail generation failed:', thumbError);
+      }
+    }
+
+    // 6. DB 挿入（失敗時はアップロード済みオブジェクトを掃除）
+    const { data: inserted, error: insertError } = await supabaseAdmin
+      .from('design_manhole')
+      .insert({
+        title,
+        description,
+        submitter_name: submitterName,
+        latitude: lat,
+        longitude: lng,
+        storage_provider: process.env.STORAGE_PROVIDER || 'r2',
+        storage_key: storageKey,
+        content_type: file.type,
+        file_size: file.size,
+        width,
+        height,
+        exif,
+        created_by: userId,
+      })
+      .select('id, title, latitude, longitude, created_at')
+      .single();
+
+    if (insertError || !inserted) {
+      throw new Error(insertError?.message || 'Failed to insert design manhole');
+    }
+
+    return NextResponse.json(
+      { success: true, design_manhole: inserted },
+      { status: 201 }
+    );
+  } catch (error: any) {
+    if (uploadedStorageKey && storage.delete) {
+      try {
+        await storage.delete(uploadedStorageKey);
+        const smallKey = deriveDesignSmallKey(uploadedStorageKey);
+        if (smallKey) await storage.delete(smallKey);
+      } catch (cleanupError) {
+        console.error('Failed to cleanup design manhole upload after error:', cleanupError);
+      }
+    }
+
+    console.error('Design manhole submission error:', error);
+    return NextResponse.json(
+      { success: false, error: '投稿に失敗しました。時間をおいて再度お試しください' },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * @swagger
+ * /api/design-manholes:
+ *   get:
+ *     summary: 公開中のデザインマンホール一覧
+ *     tags: [design-manholes]
+ *     parameters:
+ *       - in: query
+ *         name: limit
+ *         schema: { type: integer, maximum: 200, default: 100 }
+ *     responses:
+ *       200: { description: 一覧 }
+ */
+export async function GET(request: NextRequest) {
+  try {
+    if (!supabaseAdmin) {
+      return NextResponse.json(
+        { success: false, error: 'サーバー設定エラーが発生しました' },
+        { status: 500 }
+      );
+    }
+
+    const { searchParams } = new URL(request.url);
+    const limitParam = parseInt(searchParams.get('limit') ?? '', 10);
+    const limit = Number.isInteger(limitParam) && limitParam > 0
+      ? Math.min(limitParam, 200)
+      : 100;
+
+    // 公開カラムのみ返す（exif / storage_key / created_by は絶対に含めない）
+    const { data, error } = await supabaseAdmin
+      .from('design_manhole')
+      .select('id, title, description, submitter_name, latitude, longitude, width, height, created_at')
+      .eq('status', 'published')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    const designManholes = (data ?? []).map((row: any) => ({
+      ...row,
+      photo_url: `/api/design-manholes/${row.id}/photo?size=small`,
+    }));
+
+    return NextResponse.json(
+      { success: true, design_manholes: designManholes },
+      {
+        headers: {
+          'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+        },
+      }
+    );
+  } catch (error: any) {
+    console.error('Design manhole list error:', error);
+    return NextResponse.json(
+      { success: false, error: '一覧の取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -1,0 +1,338 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { useDropzone } from 'react-dropzone';
+import exifr from 'exifr';
+import imageCompression from 'browser-image-compression';
+import { Camera, CheckCircle, MapPin } from 'lucide-react';
+import Header from '@/components/Header';
+import BottomNav from '@/components/BottomNav';
+import { createBrowserClient } from '@/lib/supabase/client';
+import { isValidCoordinates } from '@/lib/location';
+
+const LocationPickerMap = dynamic(
+  () => import('@/components/DesignManhole/LocationPickerMap'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-72 w-full items-center justify-center rounded-lg bg-[#EFE5CE] sm:h-80">
+        <span className="text-sm text-[#7B63A8]">地図を読み込み中...</span>
+      </div>
+    ),
+  }
+);
+
+type GpsSource = 'exif' | 'manual' | null;
+
+export default function DesignManholeNewPage() {
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [lat, setLat] = useState<number | null>(null);
+  const [lng, setLng] = useState<number | null>(null);
+  const [gpsSource, setGpsSource] = useState<GpsSource>(null);
+  const [exifPayload, setExifPayload] = useState<Record<string, any> | null>(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [submitterName, setSubmitterName] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+
+  // ニックネーム初期値はログインユーザーの表示名（ページ自体は middleware が保護）
+  useEffect(() => {
+    let cancelled = false;
+    try {
+      const supabase = createBrowserClient();
+      supabase.auth.getSession().then(({ data: { session } }) => {
+        if (cancelled || !session?.user) return;
+        const displayName =
+          session.user.user_metadata?.display_name ||
+          session.user.email?.split('@')[0] ||
+          '';
+        setSubmitterName((prev) => prev || displayName);
+      });
+    } catch (e) {
+      console.error('Supabase initialization error:', e);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onDrop = useCallback(async (acceptedFiles: File[]) => {
+    const selected = acceptedFiles[0];
+    if (!selected) return;
+
+    setFile(selected);
+    setError(null);
+    setPreviewUrl((prev) => {
+      if (prev) URL.revokeObjectURL(prev);
+      return URL.createObjectURL(selected);
+    });
+
+    // EXIF は圧縮前のオリジナルから読む（圧縮でGPSが失われるため）
+    try {
+      const raw = await exifr.parse(selected, {
+        gps: true, tiff: true, exif: true, xmp: false, icc: false, iptc: false,
+      });
+      if (isValidCoordinates(raw?.latitude, raw?.longitude)) {
+        setLat(raw.latitude);
+        setLng(raw.longitude);
+        setGpsSource('exif');
+      }
+      if (raw) {
+        setExifPayload({
+          DateTimeOriginal: raw.DateTimeOriginal ?? null,
+          GPSDateStamp: raw.GPSDateStamp ?? null,
+          GPSProcessingMethod: raw.GPSProcessingMethod ?? null,
+          GPSHPositioningError: raw.GPSHPositioningError ?? null,
+          Make: raw.Make ?? null,
+          Model: raw.Model ?? null,
+          Software: raw.Software ?? null,
+        });
+      } else {
+        setExifPayload(null);
+      }
+    } catch {
+      setExifPayload(null);
+    }
+  }, []);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: { 'image/*': [] },
+    maxFiles: 1,
+    multiple: false,
+  });
+
+  const handleLocationChange = useCallback((newLat: number, newLng: number) => {
+    setLat(newLat);
+    setLng(newLng);
+    setGpsSource((prev) => (prev === 'exif' ? prev : 'manual'));
+  }, []);
+
+  const canSubmit = !!file && lat != null && lng != null && !submitting;
+
+  const handleSubmit = async () => {
+    if (!file || lat == null || lng == null) return;
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      let uploadFile: File;
+      try {
+        // HEIC もここで JPEG に変換される（canvas デコード）
+        uploadFile = await imageCompression(file, {
+          maxSizeMB: 2,
+          maxWidthOrHeight: 2048,
+          useWebWorker: true,
+        });
+      } catch {
+        throw new Error('この画像形式は変換できませんでした。JPEG画像でお試しください');
+      }
+
+      const formData = new FormData();
+      formData.append('file', uploadFile, file.name);
+      formData.append('lat', String(lat));
+      formData.append('lng', String(lng));
+      if (title.trim()) formData.append('title', title.trim());
+      if (description.trim()) formData.append('description', description.trim());
+      if (submitterName.trim()) formData.append('submitterName', submitterName.trim());
+      if (exifPayload) formData.append('exif', JSON.stringify(exifPayload));
+
+      const res = await fetch('/api/design-manholes', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = await res.json().catch(() => null);
+
+      if (res.status === 401) {
+        throw new Error('セッションが切れました。ログインし直してください');
+      }
+      if (!res.ok) {
+        throw new Error(data?.error || '投稿に失敗しました。時間をおいて再度お試しください');
+      }
+
+      setDone(true);
+    } catch (err: any) {
+      setError(err?.message || '投稿に失敗しました');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (done) {
+    return (
+      <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+        <Header title="デザインマンホール投稿" showDescriptionLink={false} />
+        <main className="mx-auto max-w-2xl px-4 pb-8 pt-10 text-center">
+          <CheckCircle className="mx-auto h-14 w-14 text-[#4C9A57]" />
+          <h1 className="mt-4 text-xl font-bold">投稿ありがとうございます！</h1>
+          <p className="mt-2 text-sm text-[#2A2A2A]/70">
+            投稿されたデザインマンホールは公開されました。
+          </p>
+          <div className="mt-6 flex justify-center gap-3">
+            <Link
+              href="/design-manholes"
+              className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+            >
+              一覧を見る
+            </Link>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="rounded-lg border border-[#7B63A8] px-5 py-2.5 text-sm font-bold text-[#7B63A8] transition hover:bg-[#7B63A8]/10"
+            >
+              続けて投稿する
+            </button>
+          </div>
+        </main>
+        <BottomNav />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <Header title="デザインマンホール投稿" showDescriptionLink={false} />
+
+      <main className="mx-auto max-w-2xl px-4 pb-8 pt-5 sm:pt-8">
+        <p className="rounded-lg border border-[#7B63A8]/15 bg-white/70 p-3 text-sm leading-relaxed text-[#2A2A2A]/80">
+          ポケふた以外の「オンリーワンなデザインマンホール」を見つけたら教えてください。
+          写真1枚と位置情報が必須です。
+        </p>
+
+        {/* 写真 */}
+        <section className="mt-6">
+          <h2 className="flex items-center gap-1.5 text-sm font-bold">
+            <Camera className="h-4 w-4 text-[#7B63A8]" />
+            写真 <span className="text-[#B5483C]">*</span>
+          </h2>
+          <div
+            {...getRootProps()}
+            className={`mt-2 cursor-pointer rounded-lg border-2 border-dashed p-6 text-center transition ${
+              isDragActive
+                ? 'border-[#7B63A8] bg-[#7B63A8]/10'
+                : 'border-[#7B63A8]/30 bg-white/60 hover:bg-white'
+            }`}
+          >
+            <input {...getInputProps()} />
+            {previewUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={previewUrl}
+                alt="投稿する写真のプレビュー"
+                className="mx-auto max-h-64 rounded-lg object-contain"
+              />
+            ) : (
+              <p className="text-sm text-[#2A2A2A]/60">
+                タップして写真を選択（またはドラッグ&ドロップ）
+              </p>
+            )}
+          </div>
+          {file && gpsSource === 'exif' && (
+            <p className="mt-2 text-xs text-[#4C9A57]">
+              写真から位置情報を取得しました。地図で微調整できます。
+            </p>
+          )}
+          {file && gpsSource !== 'exif' && (
+            <p className="mt-2 text-xs text-[#B5483C]">
+              写真に位置情報がありません。地図で場所を指定するか、現在地を使ってください。
+            </p>
+          )}
+        </section>
+
+        {/* 位置 */}
+        <section className="mt-6">
+          <h2 className="flex items-center gap-1.5 text-sm font-bold">
+            <MapPin className="h-4 w-4 text-[#7B63A8]" />
+            位置 <span className="text-[#B5483C]">*</span>
+          </h2>
+          <p className="mt-1 text-xs text-[#2A2A2A]/60">
+            地図をタップしてピンを置き、ドラッグで微調整できます。
+          </p>
+          <div className="mt-2">
+            <LocationPickerMap lat={lat} lng={lng} onChange={handleLocationChange} />
+          </div>
+          {lat != null && lng != null && (
+            <p className="mt-1.5 text-xs text-[#2A2A2A]/60">
+              緯度 {lat.toFixed(6)} / 経度 {lng.toFixed(6)}
+            </p>
+          )}
+        </section>
+
+        {/* 任意項目 */}
+        <section className="mt-6 space-y-4">
+          <div>
+            <label htmlFor="dm-title" className="text-sm font-bold">
+              タイトル <span className="text-xs font-normal text-[#2A2A2A]/50">（任意）</span>
+            </label>
+            <input
+              id="dm-title"
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={100}
+              placeholder="例: ○○市の花柄マンホール"
+              className="mt-1.5 w-full rounded-lg border border-[#7B63A8]/20 bg-white px-3 py-2.5 text-sm focus:border-[#7B63A8] focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="dm-description" className="text-sm font-bold">
+              説明 <span className="text-xs font-normal text-[#2A2A2A]/50">（任意）</span>
+            </label>
+            <textarea
+              id="dm-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              maxLength={1000}
+              rows={3}
+              placeholder="デザインの由来や見つけた場所のメモなど"
+              className="mt-1.5 w-full rounded-lg border border-[#7B63A8]/20 bg-white px-3 py-2.5 text-sm focus:border-[#7B63A8] focus:outline-none"
+            />
+          </div>
+          <div>
+            <label htmlFor="dm-name" className="text-sm font-bold">
+              表示名 <span className="text-xs font-normal text-[#2A2A2A]/50">（任意）</span>
+            </label>
+            <input
+              id="dm-name"
+              type="text"
+              value={submitterName}
+              onChange={(e) => setSubmitterName(e.target.value)}
+              maxLength={50}
+              placeholder="投稿者名として表示されます"
+              className="mt-1.5 w-full rounded-lg border border-[#7B63A8]/20 bg-white px-3 py-2.5 text-sm focus:border-[#7B63A8] focus:outline-none"
+            />
+          </div>
+        </section>
+
+        {/* 送信 */}
+        <section className="mt-6">
+          {error && (
+            <p className="mb-3 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="w-full rounded-lg bg-[#7B63A8] py-3 text-sm font-bold text-white transition hover:bg-[#6A5299] disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {submitting ? '投稿中...' : '投稿する'}
+          </button>
+          <p className="mt-2 text-center text-xs text-[#2A2A2A]/50">
+            投稿された写真と位置情報はすぐに公開されます。
+          </p>
+        </section>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -45,14 +45,20 @@ export default function DesignManholeNewPage() {
     let cancelled = false;
     try {
       const supabase = createBrowserClient();
-      supabase.auth.getSession().then(({ data: { session } }) => {
-        if (cancelled || !session?.user) return;
-        const displayName =
-          session.user.user_metadata?.display_name ||
-          session.user.email?.split('@')[0] ||
-          '';
-        setSubmitterName((prev) => prev || displayName);
-      });
+      supabase.auth
+        .getSession()
+        .then(({ data: { session } }) => {
+          if (cancelled || !session?.user) return;
+          const displayName =
+            session.user.user_metadata?.display_name ||
+            session.user.email?.split('@')[0] ||
+            '';
+          setSubmitterName((prev) => prev || displayName);
+        })
+        .catch((e) => {
+          // 表示名プレフィルは補助機能なので失敗しても投稿は続行できる
+          console.error('Failed to get session for display name:', e);
+        });
     } catch (e) {
       console.error('Supabase initialization error:', e);
     }
@@ -81,6 +87,16 @@ export default function DesignManholeNewPage() {
         setLat(raw.latitude);
         setLng(raw.longitude);
         setGpsSource('exif');
+      } else {
+        // 前の写真のEXIF座標を引きずらない（手動で置いたピンは維持する）
+        setGpsSource((prev) => {
+          if (prev === 'exif') {
+            setLat(null);
+            setLng(null);
+            return null;
+          }
+          return prev;
+        });
       }
       if (raw) {
         setExifPayload({
@@ -97,12 +113,27 @@ export default function DesignManholeNewPage() {
       }
     } catch {
       setExifPayload(null);
+      setGpsSource((prev) => {
+        if (prev === 'exif') {
+          setLat(null);
+          setLng(null);
+          return null;
+        }
+        return prev;
+      });
     }
   }, []);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
-    accept: { 'image/*': [] },
+    // サーバーが受けるのは JPEG/PNG/WebP。HEIC/HEIF は送信前に JPEG へ変換するので許可
+    accept: {
+      'image/jpeg': ['.jpg', '.jpeg'],
+      'image/png': ['.png'],
+      'image/webp': ['.webp'],
+      'image/heic': ['.heic'],
+      'image/heif': ['.heif'],
+    },
     maxFiles: 1,
     multiple: false,
   });

--- a/src/app/design-manholes/page.tsx
+++ b/src/app/design-manholes/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import dynamic from 'next/dynamic';
+import { Plus } from 'lucide-react';
+import Header from '@/components/Header';
+import BottomNav from '@/components/BottomNav';
+import type { DesignManhole } from '@/types/database';
+
+const DesignManholeMap = dynamic(
+  () => import('@/components/DesignManhole/DesignManholeMap'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-72 w-full items-center justify-center rounded-lg bg-[#EFE5CE] sm:h-96">
+        <span className="text-sm text-[#7B63A8]">地図を読み込み中...</span>
+      </div>
+    ),
+  }
+);
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+};
+
+export default function DesignManholesPage() {
+  const [designManholes, setDesignManholes] = useState<DesignManhole[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await fetch('/api/design-manholes?limit=200');
+        const data = await res.json();
+        if (!res.ok || !data.success) {
+          throw new Error(data?.error || '一覧の取得に失敗しました');
+        }
+        setDesignManholes(data.design_manholes ?? []);
+      } catch (err: any) {
+        setError(err?.message || '一覧の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  return (
+    <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <Header title="デザインマンホール" showDescriptionLink={false} />
+
+      <main className="mx-auto max-w-5xl px-4 pb-8 pt-5 sm:pt-8">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h1 className="text-lg font-bold sm:text-xl">みんなのデザインマンホール</h1>
+            <p className="mt-1 text-sm text-[#2A2A2A]/70">
+              ポケふた以外の、オンリーワンなデザインマンホールのコレクション
+            </p>
+          </div>
+          <Link
+            href="/design-manholes/new"
+            className="flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
+          >
+            <Plus className="h-4 w-4" />
+            投稿する
+          </Link>
+        </div>
+
+        {error && (
+          <p className="mt-5 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
+            {error}
+          </p>
+        )}
+
+        {loading ? (
+          <div className="mt-5 flex h-72 items-center justify-center rounded-lg bg-[#EFE5CE]">
+            <span className="text-sm text-[#7B63A8]">読み込み中...</span>
+          </div>
+        ) : designManholes.length === 0 ? (
+          <div className="mt-5 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-8 text-center">
+            <p className="text-sm text-[#2A2A2A]/70">
+              まだ投稿がありません。最初の1枚を投稿してみませんか？
+            </p>
+            <Link
+              href="/design-manholes/new"
+              className="mt-4 inline-block rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+            >
+              投稿する
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="mt-5">
+              <DesignManholeMap designManholes={designManholes} />
+            </div>
+
+            <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
+              {designManholes.map((dm) => (
+                <div
+                  key={dm.id}
+                  className="overflow-hidden rounded-lg border border-[#7B63A8]/15 bg-white shadow-sm"
+                >
+                  <div className="aspect-square bg-[#EFE5CE]">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={dm.photo_url}
+                      alt={dm.title || 'デザインマンホール'}
+                      className="h-full w-full object-cover"
+                      loading="lazy"
+                    />
+                  </div>
+                  <div className="p-2.5">
+                    <p className="truncate text-sm font-bold">
+                      {dm.title || 'デザインマンホール'}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-[#2A2A2A]/50">
+                      {dm.submitter_name ? `${dm.submitter_name} ・ ` : ''}
+                      {formatDate(dm.created_at)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/components/DesignManhole/DesignManholeMap.tsx
+++ b/src/components/DesignManhole/DesignManholeMap.tsx
@@ -4,14 +4,9 @@ import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import type { DesignManhole } from '@/types/database';
+import { applyLeafletDefaultIcon } from '@/components/Map/leafletDefaultIcon';
 
-// Fix for default markers in Leaflet
-delete (L.Icon.Default.prototype as any)._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-});
+applyLeafletDefaultIcon();
 
 const DEFAULT_CENTER = {
   lat: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LAT || '36.0'),

--- a/src/components/DesignManhole/DesignManholeMap.tsx
+++ b/src/components/DesignManhole/DesignManholeMap.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import type { DesignManhole } from '@/types/database';
+
+// Fix for default markers in Leaflet
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+});
+
+const DEFAULT_CENTER = {
+  lat: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LAT || '36.0'),
+  lng: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LNG || '138.0'),
+};
+
+interface DesignManholeMapProps {
+  designManholes: DesignManhole[];
+}
+
+// 一覧ページ用の表示専用マップ（投稿のマーカー + サムネイル popup）
+export default function DesignManholeMap({ designManholes }: DesignManholeMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markersLayerRef = useRef<L.LayerGroup | null>(null);
+
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+
+    const map = L.map(mapRef.current, {
+      center: [DEFAULT_CENTER.lat, DEFAULT_CENTER.lng],
+      zoom: 5,
+      zoomControl: true,
+      attributionControl: true,
+    });
+    mapInstanceRef.current = map;
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors',
+    }).addTo(map);
+
+    markersLayerRef.current = L.layerGroup().addTo(map);
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markersLayerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    const layer = markersLayerRef.current;
+    if (!map || !layer) return;
+
+    layer.clearLayers();
+
+    if (designManholes.length === 0) return;
+
+    const escapeHtml = (text: string) =>
+      text.replace(/[&<>"']/g, (c) => ({
+        '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+      }[c] as string));
+
+    designManholes.forEach((dm) => {
+      const title = escapeHtml(dm.title || 'デザインマンホール');
+      const marker = L.marker([dm.latitude, dm.longitude]);
+      marker.bindPopup(
+        `<div style="text-align:center;min-width:120px;">
+          <img src="${dm.photo_url}" alt="${title}" style="max-width:150px;max-height:150px;border-radius:8px;" loading="lazy" />
+          <div style="margin-top:4px;font-weight:bold;font-size:12px;">${title}</div>
+        </div>`
+      );
+      marker.addTo(layer);
+    });
+
+    const bounds = L.latLngBounds(designManholes.map((dm) => [dm.latitude, dm.longitude]));
+    map.fitBounds(bounds, { padding: [40, 40], maxZoom: 12 });
+  }, [designManholes]);
+
+  return <div ref={mapRef} className="h-72 w-full rounded-lg border border-[#7B63A8]/20 sm:h-96" />;
+}

--- a/src/components/DesignManhole/LocationPickerMap.tsx
+++ b/src/components/DesignManhole/LocationPickerMap.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+
+// Fix for default markers in Leaflet
+delete (L.Icon.Default.prototype as any)._getIconUrl;
+L.Icon.Default.mergeOptions({
+  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+});
+
+const DEFAULT_CENTER = {
+  lat: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LAT || '36.0'),
+  lng: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LNG || '138.0'),
+};
+const ZOOM_NO_PIN = 5;
+const ZOOM_WITH_PIN = 16;
+
+interface LocationPickerMapProps {
+  lat: number | null;
+  lng: number | null;
+  onChange: (lat: number, lng: number) => void;
+}
+
+// 投稿フォーム用の位置ピッカー。クリックでピン設置、ドラッグで微調整、
+// 「現在地を使う」ボタンで geolocation。controlled: 親の lat/lng に追従する。
+export default function LocationPickerMap({ lat, lng, onChange }: LocationPickerMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<L.Map | null>(null);
+  const markerRef = useRef<L.Marker | null>(null);
+  // Leaflet イベントハンドラから最新の onChange を呼ぶための ref
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (!mapRef.current || mapInstanceRef.current) return;
+
+    const hasPin = lat != null && lng != null;
+    const map = L.map(mapRef.current, {
+      center: hasPin ? [lat!, lng!] : [DEFAULT_CENTER.lat, DEFAULT_CENTER.lng],
+      zoom: hasPin ? ZOOM_WITH_PIN : ZOOM_NO_PIN,
+      zoomControl: true,
+      attributionControl: true,
+    });
+    mapInstanceRef.current = map;
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '© OpenStreetMap contributors',
+    }).addTo(map);
+
+    map.on('click', (e: L.LeafletMouseEvent) => {
+      onChangeRef.current(e.latlng.lat, e.latlng.lng);
+    });
+
+    return () => {
+      map.remove();
+      mapInstanceRef.current = null;
+      markerRef.current = null;
+    };
+    // 初期化は一度だけ。初期座標は親からの props 反映 effect が引き受ける
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 親からの座標変更（EXIF抽出・現在地・クリック）をマーカーに反映
+  useEffect(() => {
+    const map = mapInstanceRef.current;
+    if (!map) return;
+
+    if (lat == null || lng == null) {
+      if (markerRef.current) {
+        markerRef.current.remove();
+        markerRef.current = null;
+      }
+      return;
+    }
+
+    if (!markerRef.current) {
+      const marker = L.marker([lat, lng], { draggable: true }).addTo(map);
+      marker.on('dragend', () => {
+        const pos = marker.getLatLng();
+        onChangeRef.current(pos.lat, pos.lng);
+      });
+      markerRef.current = marker;
+      map.setView([lat, lng], ZOOM_WITH_PIN, { animate: true });
+    } else {
+      const current = markerRef.current.getLatLng();
+      // ドラッグ由来の onChange が返ってきたときに setView し直さない
+      if (Math.abs(current.lat - lat) > 1e-9 || Math.abs(current.lng - lng) > 1e-9) {
+        markerRef.current.setLatLng([lat, lng]);
+        map.setView([lat, lng], Math.max(map.getZoom(), ZOOM_WITH_PIN), { animate: true });
+      }
+    }
+  }, [lat, lng]);
+
+  const handleUseCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      alert('お使いのブラウザは位置情報に対応していません');
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        onChangeRef.current(position.coords.latitude, position.coords.longitude);
+      },
+      () => {
+        alert('現在地を取得できませんでした。位置情報の利用を許可してください');
+      },
+      { enableHighAccuracy: true, timeout: 10000 }
+    );
+  };
+
+  return (
+    <div className="relative">
+      <div ref={mapRef} className="h-72 w-full rounded-lg border border-[#7B63A8]/20 sm:h-80" />
+      <button
+        type="button"
+        onClick={handleUseCurrentLocation}
+        className="absolute right-2 top-2 z-[1000] rounded-lg bg-white px-3 py-2 text-xs font-bold text-[#2A2A2A] shadow-md transition hover:bg-[#7B63A8]/10"
+      >
+        現在地を使う
+      </button>
+    </div>
+  );
+}

--- a/src/components/DesignManhole/LocationPickerMap.tsx
+++ b/src/components/DesignManhole/LocationPickerMap.tsx
@@ -3,14 +3,9 @@
 import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
+import { applyLeafletDefaultIcon } from '@/components/Map/leafletDefaultIcon';
 
-// Fix for default markers in Leaflet
-delete (L.Icon.Default.prototype as any)._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-});
+applyLeafletDefaultIcon();
 
 const DEFAULT_CENTER = {
   lat: parseFloat(process.env.NEXT_PUBLIC_MAP_DEFAULT_CENTER_LAT || '36.0'),

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -119,14 +119,17 @@ export default function Header({
             </Link>
           )}
 
-          <Link
-            href="/design-manholes"
-            className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"
-            aria-label="デザインマンホール（ポケふた以外の投稿）"
-            title="デザインマンホール（ポケふた以外の投稿）"
-          >
-            デザイン蓋
-          </Link>
+          {/* デザインマンホールは自分用機能なのでログイン時のみ導線を出す（URL直アクセスは可） */}
+          {user && (
+            <Link
+              href="/design-manholes"
+              className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"
+              aria-label="デザインマンホール（ポケふた以外の投稿）"
+              title="デザインマンホール（ポケふた以外の投稿）"
+            >
+              デザイン蓋
+            </Link>
+          )}
 
           <a
             href="https://data.pokefuta.com/"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -119,6 +119,15 @@ export default function Header({
             </Link>
           )}
 
+          <Link
+            href="/design-manholes"
+            className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"
+            aria-label="デザインマンホール（ポケふた以外の投稿）"
+            title="デザインマンホール（ポケふた以外の投稿）"
+          >
+            デザイン蓋
+          </Link>
+
           <a
             href="https://data.pokefuta.com/"
             className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"

--- a/src/components/Map/MapComponent.tsx
+++ b/src/components/Map/MapComponent.tsx
@@ -4,14 +4,9 @@ import { useEffect, useRef } from 'react';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
 import { Manhole } from '@/types/database';
+import { applyLeafletDefaultIcon } from '@/components/Map/leafletDefaultIcon';
 
-// Fix for default markers in Leaflet
-delete (L.Icon.Default.prototype as any)._getIconUrl;
-L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
-  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
-});
+applyLeafletDefaultIcon();
 
 interface MapComponentProps {
   center: { lat: number; lng: number };

--- a/src/components/Map/leafletDefaultIcon.ts
+++ b/src/components/Map/leafletDefaultIcon.ts
@@ -1,0 +1,17 @@
+import L from 'leaflet';
+
+// Fix for default markers in Leaflet
+// （バンドラ経由だとデフォルトアイコンのURL解決が壊れるため CDN を明示する。
+//   Map系コンポーネントは import 時にこれを一度だけ呼ぶ）
+let applied = false;
+
+export function applyLeafletDefaultIcon() {
+  if (applied) return;
+  applied = true;
+  delete (L.Icon.Default.prototype as any)._getIconUrl;
+  L.Icon.Default.mergeOptions({
+    iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon-2x.png',
+    iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-icon.png',
+    shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.4/images/marker-shadow.png',
+  });
+}

--- a/src/lib/storage/index.ts
+++ b/src/lib/storage/index.ts
@@ -59,6 +59,29 @@ export function generateContextImageStorageKey(manholeId: number, contentType?: 
   return `photos/context/original/${year}/${month}/manholes/${manholeId}/${uuid}.${extension}`;
 }
 
+// デザインマンホール投稿写真用キー。visit 写真の photos/original/ とは
+// プレフィックスを分け、モデレーション・一括削除をしやすくする。
+export function generateDesignManholeStorageKey(contentType?: string): string {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const uuid = crypto.randomUUID();
+  const extension = contentTypeToExtension(contentType);
+
+  return `photos/design/original/${year}/${month}/${uuid}.${extension}`;
+}
+
+// photos/design/original/YYYY/MM/{uuid}.{ext} -> photos/design/small/YYYY/MM/{uuid}.webp
+// deriveSmallKey と同じ規約（決定的・DBカラム不要）。対象外のキーは null。
+export function deriveDesignSmallKey(storageKey: string): string | null {
+  if (!storageKey.startsWith('photos/design/original/')) {
+    return null;
+  }
+  return storageKey
+    .replace('photos/design/original/', 'photos/design/small/')
+    .replace(/\.[^./]+$/, '.webp');
+}
+
 function contentTypeToExtension(contentType?: string): string {
   switch (contentType) {
     case 'image/png':

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -38,7 +38,7 @@ export async function middleware(req: NextRequest) {
     // 認証が必要なページへのアクセス
     // upload ページは認証必須
     // visits ページはプレビューモードがあるため未認証でもアクセス可能
-    const protectedPaths = ['/upload'];
+    const protectedPaths = ['/upload', '/design-manholes/new'];
     const isProtectedPath = protectedPaths.some(path => req.nextUrl.pathname.startsWith(path));
 
     if (!session && isProtectedPath) {
@@ -60,5 +60,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/upload/:path*'],
+  matcher: ['/upload/:path*', '/design-manholes/new'],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -60,5 +60,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/upload/:path*', '/design-manholes/new'],
+  matcher: ['/upload/:path*', '/design-manholes/new/:path*'],
 };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -324,6 +324,51 @@ export interface Database {
         };
         Relationships: [];
       };
+      design_manhole: {
+        Row: {
+          id: string;
+          title: string | null;
+          description: string | null;
+          submitter_name: string | null;
+          latitude: number;
+          longitude: number;
+          storage_provider: string;
+          storage_key: string;
+          content_type: string;
+          file_size: number | null;
+          width: number | null;
+          height: number | null;
+          exif: Record<string, any> | null;
+          status: 'published' | 'hidden';
+          created_by: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          title?: string | null;
+          description?: string | null;
+          submitter_name?: string | null;
+          latitude: number;
+          longitude: number;
+          storage_provider?: string;
+          storage_key: string;
+          content_type: string;
+          file_size?: number | null;
+          width?: number | null;
+          height?: number | null;
+          exif?: Record<string, any> | null;
+          status?: 'published' | 'hidden';
+          created_by: string;
+        };
+        Update: {
+          title?: string | null;
+          description?: string | null;
+          status?: 'published' | 'hidden';
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       shared_link: {
         Row: {
           id: string;
@@ -614,6 +659,20 @@ export interface Weather {
   temperature?: number;
   humidity?: number;
   description?: string;
+}
+
+// デザインマンホール一覧 API (/api/design-manholes GET) が返す公開データ
+export interface DesignManhole {
+  id: string;
+  title: string | null;
+  description: string | null;
+  submitter_name: string | null;
+  latitude: number;
+  longitude: number;
+  width: number | null;
+  height: number | null;
+  created_at: string;
+  photo_url: string;
 }
 
 export interface ExifData {


### PR DESCRIPTION
## 概要

ポケふた以外の「オンリーワンなデザインマンホール」の緯度経度を収集するための投稿機能。投稿は要ログイン、閲覧は誰でも可。

## 変更内容

### 新規ページ
- `/design-manholes/new` — 投稿フォーム（middleware で保護、未ログインは /login へリダイレクト）
  - 写真1枚 + 位置情報が必須。EXIF GPS 自動抽出 → なければ地図タップ/ピンドラッグ/現在地ボタン
  - 表示名はログインユーザーの display_name を自動プレフィル
  - HEIC は browser-image-compression が JPEG 変換（EXIF は変換前に読むので GPS は失われない）
- `/design-manholes` — 一覧（マーカー地図 + カードグリッド）。ヘッダーに「デザイン蓋」リンク追加

### API
- `POST /api/design-manholes` — cookie セッション認証 + ensureAppUser。座標は日本バウンディングボックスで検証。insert 失敗時は R2 オブジェクトを掃除（context-images と同パターン）
- `GET /api/design-manholes` — published のみ・公開カラムのみ返す（created_by/exif/storage_key は非公開）
- `GET /api/design-manholes/[id]/photo` — 署名URLへ307（/api/photo/[id] と同パターン）。hidden 行は404

### DB / ストレージ
- migration `018_add_design_manhole.sql` — **適用済み**。RLS 有効・ポリシーなし（全アクセス service role 経由）
- 画像は `photos/design/original|small/` プレフィックス（visit 写真と分離、専用の deriveDesignSmallKey）

### モデレーション（v1）
- 即時公開。荒れたら Supabase Table Editor で `status='hidden'` → 一覧・写真とも即404

## 注意点（レビューポイント）

`dynamic='force-dynamic'` だけでは Route Handler 内の supabase-js GET が Next の Data Cache に乗り、**hidden 化が反映されないバグ**になる。`fetchCache='force-no-store'` を両ルートに追加して解消（E2Eで検出・修正確認済み）。supabaseAdmin を使う既存の GET ルートにも同じ罠がある可能性あり。

## テスト

- `npm run type-check` 通過
- フルE2E 14/14 パス（使い捨てテストユーザーで投稿→一覧→写真配信→hidden→404、テストデータは全削除済み）
- 認証ゲート: 未ログインページアクセス→307 /login、未ログインPOST→401

🤖 Generated with [Claude Code](https://claude.com/claude-code)