### PR TITLE
refactor: design_manhole を既存投稿と同じ anon+RLS ポリシー方式に統一

### DIFF
--- a/database/migrations/019_design_manhole_rls_policies.sql
+++ b/database/migrations/019_design_manhole_rls_policies.sql
@@ -1,0 +1,64 @@
+-- ============================================================
+-- 019: design_manhole を既存 visit/photo と同じ RLS ポリシー方式に統一
+-- ============================================================
+-- 018 の「ポリシーゼロ + service role 経由」から、
+-- 「anon キー + ユーザーセッション + RLS ポリシー」（既存投稿と同じ仕組み）へ変更。
+-- service role キー（Amplify 未整備で本番障害の原因になった）への依存を撤廃する。
+--
+-- 直接 PostgREST を叩く経路も開くため、API 側にしかなかった検証を
+-- DB の CHECK 制約・ポリシー条件・列権限で担保する。
+
+-- ------------------------------------------------------------
+-- 1) 業務制約を DB レベルへ（どの経路の書き込みにも効く）
+-- ------------------------------------------------------------
+ALTER TABLE public.design_manhole DROP CONSTRAINT IF EXISTS design_manhole_japan_bounds;
+ALTER TABLE public.design_manhole ADD CONSTRAINT design_manhole_japan_bounds
+  CHECK (latitude BETWEEN 20 AND 46 AND longitude BETWEEN 122 AND 154);
+
+ALTER TABLE public.design_manhole DROP CONSTRAINT IF EXISTS design_manhole_title_length;
+ALTER TABLE public.design_manhole ADD CONSTRAINT design_manhole_title_length
+  CHECK (title IS NULL OR char_length(title) <= 100);
+
+ALTER TABLE public.design_manhole DROP CONSTRAINT IF EXISTS design_manhole_description_length;
+ALTER TABLE public.design_manhole ADD CONSTRAINT design_manhole_description_length
+  CHECK (description IS NULL OR char_length(description) <= 1000);
+
+ALTER TABLE public.design_manhole DROP CONSTRAINT IF EXISTS design_manhole_submitter_name_length;
+ALTER TABLE public.design_manhole ADD CONSTRAINT design_manhole_submitter_name_length
+  CHECK (submitter_name IS NULL OR char_length(submitter_name) <= 50);
+
+-- 他プレフィックス（訪問写真 photos/original/ 等）のキーを指す行を作らせない
+-- ＝ 写真配信 API を踏み台にした非公開画像の漏洩を DB で遮断
+ALTER TABLE public.design_manhole DROP CONSTRAINT IF EXISTS design_manhole_storage_key_prefix;
+ALTER TABLE public.design_manhole ADD CONSTRAINT design_manhole_storage_key_prefix
+  CHECK (storage_key LIKE 'photos/design/original/%');
+
+-- ------------------------------------------------------------
+-- 2) RLS ポリシー（既存テーブルと同じ命名規約）
+-- ------------------------------------------------------------
+-- 読み: 公開行は誰でも。投稿者本人は自分の hidden 行も見える
+DROP POLICY IF EXISTS design_manhole_public_select ON public.design_manhole;
+CREATE POLICY design_manhole_public_select ON public.design_manhole
+  FOR SELECT TO anon, authenticated
+  USING (status = 'published' OR created_by = auth.uid());
+
+-- 書き: ログインユーザーが自分名義の published 行のみ insert 可能
+DROP POLICY IF EXISTS design_manhole_users_insert_own ON public.design_manhole;
+CREATE POLICY design_manhole_users_insert_own ON public.design_manhole
+  FOR INSERT TO authenticated
+  WITH CHECK (created_by = auth.uid() AND status = 'published');
+
+-- UPDATE / DELETE ポリシーは意図的に作らない:
+--   - 投稿者が hidden 化（モデレーション）を巻き戻せないようにする
+--   - 編集・削除が必要になったら管理者（Dashboard / service role）が行う
+
+-- ------------------------------------------------------------
+-- 3) 列権限: exif（端末機種・ソフトウェア情報を含む）は直接読ませない
+-- ------------------------------------------------------------
+REVOKE SELECT ON public.design_manhole FROM anon, authenticated;
+GRANT SELECT (
+  id, title, description, submitter_name,
+  latitude, longitude,
+  storage_provider, storage_key, content_type, file_size, width, height,
+  status, created_by, created_at, updated_at
+) ON public.design_manhole TO anon, authenticated;

--- a/src/app/api/design-manholes/[id]/photo/route.ts
+++ b/src/app/api/design-manholes/[id]/photo/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { supabaseAdmin } from '@/lib/supabase/client';
+import { cookies } from 'next/headers';
+import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { storage, deriveDesignSmallKey } from '@/lib/storage';
 
 export const dynamic = 'force-dynamic';
@@ -31,18 +32,13 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    if (!supabaseAdmin) {
-      return NextResponse.json(
-        { success: false, error: 'サーバー設定エラーが発生しました' },
-        { status: 500 }
-      );
-    }
+    const supabase = createRouteHandlerClient({ cookies });
 
     const { searchParams } = new URL(request.url);
     const size = searchParams.get('size');
 
     // hidden にした投稿は写真も 404 にする（status フィルタが本体）
-    const { data: row, error } = await supabaseAdmin
+    const { data: row, error } = await supabase
       .from('design_manhole')
       .select('id, storage_key')
       .eq('id', params.id)

--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -2,7 +2,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import sharp from 'sharp';
 import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
-import { supabaseAdmin } from '@/lib/supabase/client';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
 import {
   storage,
@@ -68,14 +67,6 @@ export async function POST(request: NextRequest) {
   let uploadedStorageKey: string | null = null;
 
   try {
-    if (!supabaseAdmin) {
-      console.error('supabaseAdmin is not configured (SUPABASE_SERVICE_ROLE_KEY missing)');
-      return NextResponse.json(
-        { success: false, error: 'サーバー設定エラーが発生しました' },
-        { status: 500 }
-      );
-    }
-
     // 1. 認証（image-upload と同じ cookie セッション方式）
     const supabase = createRouteHandlerClient({ cookies });
     const { data: { session } } = await supabase.auth.getSession();
@@ -190,8 +181,9 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 6. DB 挿入（失敗時はアップロード済みオブジェクトを掃除）
-    const { data: inserted, error: insertError } = await supabaseAdmin
+    // 6. DB 挿入（ユーザーセッションで実行。RLS が created_by = auth.uid() を担保。
+    //    失敗時はアップロード済みオブジェクトを掃除）
+    const { data: inserted, error: insertError } = await supabase
       .from('design_manhole')
       .insert({
         title,
@@ -253,12 +245,7 @@ export async function POST(request: NextRequest) {
  */
 export async function GET(request: NextRequest) {
   try {
-    if (!supabaseAdmin) {
-      return NextResponse.json(
-        { success: false, error: 'サーバー設定エラーが発生しました' },
-        { status: 500 }
-      );
-    }
+    const supabase = createRouteHandlerClient({ cookies });
 
     const { searchParams } = new URL(request.url);
     const limitParam = parseInt(searchParams.get('limit') ?? '', 10);
@@ -267,7 +254,7 @@ export async function GET(request: NextRequest) {
       : 100;
 
     // 公開カラムのみ返す（exif / storage_key / created_by は絶対に含めない）
-    const { data, error } = await supabaseAdmin
+    const { data, error } = await supabase
       .from('design_manhole')
       .select('id, title, description, submitter_name, latitude, longitude, width, height, created_at')
       .eq('status', 'published')


### PR DESCRIPTION
## 背景

デザインマンホール投稿（#168）は service role キー（supabaseAdmin）経由の設計だったが、Amplify の `SUPABASE_SERVICE_ROLE_KEY` が無効値で**本番の投稿・一覧が 500** になっていた（service role を実際に使う初の機能だったため今まで未発覚）。

既存のポケふた投稿（visit/photo）と同じ「anon キー + ユーザーセッション + RLS ポリシー」方式に統一し、service role への依存を撤廃する。**マージすれば Amplify の環境変数を触らずに本番が直る。**

## 変更内容

### コード（`/api/photo/[id]` と同じ作りに）
- POST insert: ユーザーセッション（`createRouteHandlerClient`）で実行。RLS が `created_by = auth.uid()` を担保
- GET 一覧 / 写真配信: 同じく anon+cookie クライアントへ切り替え
- `supabaseAdmin` 参照を全廃

### DB — migration 019（**適用済み**）
直接 PostgREST を叩く経路が開くため、API 側にしかなかった検証を DB へ移設:
- **CHECK 制約**: 日本 bbox（lat 20–46 / lng 122–154）、title≤100・description≤1000・submitter_name≤50、**storage_key は `photos/design/original/%` 限定**（他人の訪問写真キーを指す行を作らせない = 写真配信APIを踏み台にした漏洩の遮断）
- **INSERT ポリシー**: authenticated が自分名義 + published のみ
- **SELECT ポリシー**: published は誰でも / 本人は自分の hidden も可視
- **UPDATE/DELETE ポリシーなし**（投稿者が hidden 化を巻き戻せない。モデレーションは Dashboard 専権）
- **列権限**: `exif`（端末機種・ソフト情報）は anon/authenticated から直接読み不可

## テスト（全パス・テストデータは全削除済み）

- RLS 直接アクセス検証 13/13: 自分名義 insert 可 / 他人名義・hidden・他プレフィックスキー・国外座標・101文字 拒否 / 投稿者 UPDATE/DELETE 不可 / anon の exif 列拒否・INSERT 拒否 / hidden 行の可視性
- API E2E 14/14: 投稿→一覧→写真配信(307→webp)→hidden で一覧・写真とも404
- `npm run type-check` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)