### PR TITLE
feat: design-manholes一覧APIに data.pokefuta.com 向けCORSヘッダーを追加

### DIFF
--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -275,6 +275,8 @@ export async function GET(request: NextRequest) {
       {
         headers: {
           'Cache-Control': 'public, s-maxage=300, stale-while-revalidate=3600',
+          // data.pokefuta.com の投稿LPがギャラリー表示に読む（公開カラムのみの一覧なので許可できる）
+          'Access-Control-Allow-Origin': 'https://data.pokefuta.com',
         },
       }
     );


### PR DESCRIPTION
## 概要

data.pokefuta.com の投稿促進LP（nishiokya/pokefuta-tracker#296）に「みんなの投稿」ギャラリーがあり、`GET /api/design-manholes` をクロスオリジンで読みます。現状CORSヘッダーが無いためfetchが失敗し、ギャラリーは非表示のままです。公開一覧のGETレスポンスに `Access-Control-Allow-Origin: https://data.pokefuta.com` を追加します。

## 安全性

- 対象はGET一覧のみ。返すのは公開カラムだけ（`status=published`、`exif` / `storage_key` / `created_by` は含まない）
- 認証Cookie不要のエンドポイントで、`credentials` なしの単純GETなのでプリフライトも発生しない
- 写真エンドポイント（`/photo`）は `<img>` で読むためCORS不要・変更なし

## ペアPR

- LP側（ギャラリー実装済み・fetch失敗時は非表示にフォールバック）: nishiokya/pokefuta-tracker#296

🤖 Generated with [Claude Code](https://claude.com/claude-code)