### PR TITLE
feat: PCヘッダーにデザインマンホール一覧へのリンクを常時表示

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -119,17 +119,15 @@ export default function Header({
             </Link>
           )}
 
-          {/* デザインマンホールは自分用機能なのでログイン時のみ導線を出す（URL直アクセスは可） */}
-          {user && (
-            <Link
-              href="/design-manholes"
-              className="flex h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:text-sm"
-              aria-label="デザインマンホール（ポケふた以外の投稿）"
-              title="デザインマンホール（ポケふた以外の投稿）"
-            >
-              デザイン蓋
-            </Link>
-          )}
+          {/* PCでは常に導線を出す。スマフォはログイン時のみ（自分用機能・URL直アクセスは可） */}
+          <Link
+            href="/design-manholes"
+            className={`${user ? 'flex' : 'hidden'} h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:flex sm:text-sm`}
+            aria-label="デザインマンホール（ポケふた以外の投稿）"
+            title="デザインマンホール（ポケふた以外の投稿）"
+          >
+            デザイン蓋
+          </Link>
 
           <a
             href="https://data.pokefuta.com/"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -119,7 +119,7 @@ export default function Header({
             </Link>
           )}
 
-          {/* PCでは常に導線を出す。スマフォはログイン時のみ（自分用機能・URL直アクセスは可） */}
+          {/* SPではログイン時のみ。PCの常時導線は PCShell 側で出す（URL直アクセスは可） */}
           <Link
             href="/design-manholes"
             className={`${user ? 'flex' : 'hidden'} h-10 flex-shrink-0 items-center justify-center rounded-full px-2.5 text-xs font-bold text-[#2A2A2A] transition hover:bg-[#7B63A8]/10 sm:flex sm:text-sm`}

--- a/src/components/PCShell.tsx
+++ b/src/components/PCShell.tsx
@@ -168,6 +168,22 @@ function PCTopNav({ active }: PCTopNavProps) {
             図鑑
           </a>
         )}
+        {authLoaded && (
+          <Link
+            href="/design-manholes"
+            style={{
+              fontSize: 13.5,
+              fontWeight: 600,
+              color: pathname === '/design-manholes' || pathname.startsWith('/design-manholes/') ? '#2c2a26' : '#6f6657',
+              padding: '7px 13px',
+              borderRadius: 9,
+              background: pathname === '/design-manholes' || pathname.startsWith('/design-manholes/') ? '#e9dfc7' : 'transparent',
+              textDecoration: 'none',
+            }}
+          >
+            デザイン蓋
+          </Link>
+        )}
       </div>
 
       {/* スペーサー */}


### PR DESCRIPTION
## 概要
PCのヘッダーに `/design-manholes`（デザインマンホール一覧）へのリンクを常時表示するようにしました。

## 変更内容
- **PC（sm以上）**: ログイン有無に関わらず「デザイン蓋」リンクを常時表示
- **スマフォ**: 従来通りログイン時のみ表示（自分用機能・URL直アクセスは可）

既存はログイン時のみ両デバイスで表示していたのを、レスポンシブなクラス切り替え（`${user ? 'flex' : 'hidden'} ... sm:flex`）で「PC常時／スマフォはログイン時のみ」に調整しています。

🤖 Generated with [Claude Code](https://claude.com/claude-code)