### PR TITLE
Make nearby manhole photos landscape

### DIFF
--- a/src/app/nearby/page.tsx
+++ b/src/app/nearby/page.tsx
@@ -619,7 +619,7 @@ export default function NearbyPage() {
                           {manhole.visit.photos.slice(0, 3).map((photo: any) => (
                             <div
                               key={photo.id}
-                              className="relative aspect-square overflow-hidden rounded-[6px] bg-white"
+                              className="relative aspect-[4/3] overflow-hidden rounded-[6px] bg-white"
                             >
                               <img
                                 src={photo.url || `/api/image-upload?key=${photo.storage_key}`}


### PR DESCRIPTION
## Summary
- Change visited photo thumbnails on `/nearby` from square to a 4:3 landscape frame.
- Keep the existing object-cover behavior so uploaded photos continue to fill the thumbnail cleanly.

## Impact
This makes manhole photos on the nearby search cards appear wider and less cramped while preserving the existing three-photo row layout.

## Validation
- `npm run type-check`
- `npm run build`

Note: `npm run build` still emits existing Next/Browserslist/Supabase edge-runtime warnings, but completed successfully.
