### PR TITLE
Show poster names on photo overlays

### DIFF
--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -52,7 +52,8 @@ interface Photo {
 
 const getPhotoUserLabel = (photo: Photo) => {
   const name = photo.visit?.display_name;
-  if (name && name.trim().length > 0) return name;
+  const trimmedName = name?.trim();
+  if (trimmedName) return trimmedName;
   const uid = photo.visit?.user_id;
   if (uid && uid.length >= 8) return `ユーザー:${uid.slice(0, 8)}`;
   return '名無しのトレーナー';

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -798,10 +798,8 @@ export default function ManholeDetailPage() {
                 {/* caption — inline styles to prevent global CSS overrides */}
                 {featuredPhoto && (
                   <div style={{ position: 'absolute', left: 0, right: 0, bottom: 0, padding: '26px 13px 44px', background: 'linear-gradient(180deg,transparent,rgba(20,14,5,.62))', color: '#fff', display: 'flex', alignItems: 'center', gap: 8, zIndex: 1 }}>
-                    <span style={{ fontSize: 12.5, fontWeight: 700 }}>
-                      {featuredPhoto.visit?.user_id === currentUserId
-                        ? 'あなたの1枚'
-                        : `@${getPhotoUserLabel(featuredPhoto)}`}
+                    <span style={{ minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontSize: 12.5, fontWeight: 700 }}>
+                      @{getPhotoUserLabel(featuredPhoto)}
                     </span>
                     {featuredPhoto.visit?.shot_at && (
                       <span style={{ marginLeft: 'auto', fontSize: 11, fontFamily: 'Outfit,sans-serif', opacity: 0.9 }}>

--- a/src/app/my-trip/page.tsx
+++ b/src/app/my-trip/page.tsx
@@ -18,6 +18,7 @@ type JourneyVisit = {
   manhole_id: number | null;
   manhole?: Pick<Manhole, 'id' | 'prefecture' | 'municipality' | 'building' | 'title' | 'pokemons' | 'titles' | 'hashtags' | 'title_tags'> & { city?: string } | null;
   shot_at: string;
+  display_name?: string | null;
   photos: Array<{ id: string; thumbnail_url?: string }>;
 };
 
@@ -269,6 +270,7 @@ export default function MyTripPage() {
                           thumbnailUrl={visit.photos?.[0]?.thumbnail_url}
                           title={title}
                           date={dateStr}
+                          posterName={visit.display_name}
                           tags={getManholeTags(visit.manhole, 2)}
                         />
                       );

--- a/src/components/VisitPhotoCard.tsx
+++ b/src/components/VisitPhotoCard.tsx
@@ -16,10 +16,13 @@ export interface VisitPhotoCardProps {
   thumbnailUrl?: string | null;
   title: string;
   date: string;
+  posterName?: string | null;
   tags: string[];
 }
 
-export default function VisitPhotoCard({ manholeId, thumbnailUrl, title, date, tags }: VisitPhotoCardProps) {
+export default function VisitPhotoCard({ manholeId, thumbnailUrl, title, date, posterName, tags }: VisitPhotoCardProps) {
+  const visiblePosterName = posterName?.trim();
+
   return (
     <Link href={`/manhole/${manholeId}`} style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}>
       <div
@@ -71,7 +74,36 @@ export default function VisitPhotoCard({ manholeId, thumbnailUrl, title, date, t
             >
               {title}
             </div>
-            <div style={{ fontFamily: NUM, fontSize: 11, opacity: 0.9, marginTop: 2 }}>{date}</div>
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 6,
+                fontFamily: NUM,
+                fontSize: 11,
+                lineHeight: 1.25,
+                opacity: 0.9,
+                marginTop: 2,
+                minWidth: 0,
+              }}
+            >
+              <span style={{ flexShrink: 0 }}>{date}</span>
+              {visiblePosterName && (
+                <>
+                  <span style={{ flexShrink: 0, opacity: 0.75 }}>/</span>
+                  <span
+                    style={{
+                      minWidth: 0,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                  >
+                    {visiblePosterName}
+                  </span>
+                </>
+              )}
+            </div>
           </div>
         </div>
         {tags.length > 0 && (


### PR DESCRIPTION
## Summary
- show poster names beside dates in the My Trip photo card overlay
- show poster names for the featured manhole photo overlay, including the current user
- keep long poster names truncated so overlay controls and dates keep their space

## Validation
- `git diff --check`
- `npm run type-check` currently fails on pre-existing unrelated TypeScript issues and missing local `@supabase/ssr` resolution; the touched files are not listed in the errors.