### PR TITLE
fix: 写真一覧APIで他人の訪問note（GPS座標入り）を返さない

### DIFF
--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -665,10 +665,13 @@ export async function GET(request: NextRequest) {
         if (visit && typeof visit === 'object' && !Array.isArray(visit)) {
           const displayName = displayNameByAuthUid.get(visit.user_id) ?? null;
           const publicUserId = publicUserIdByAuthUid.get(visit.user_id) ?? null;
+          // note は非公開メモ（GPS座標・撮影日時等を含む）のため本人の訪問以外には返さない
+          const isOwnVisit = viewerUserId && visit.user_id === viewerUserId;
           return {
             ...img,
             visit: {
               ...visit,
+              note: isOwnVisit ? visit.note : undefined,
               display_name: displayName,
               public_user_id: publicUserId
             }


### PR DESCRIPTION
## 概要
公開スタンプ帳の動作確認中に発見した既存の情報漏れの修正です。

匿名で叩ける `/api/image-upload?manhole_id=…`（写真一覧 GET）の応答に、`visit.note` がすべての公開訪問分そのまま含まれていました。note はアプリが自動記録する非公開メモで、**撮影地点の正確な GPS 座標・撮影日時・カメラ機種**が入っています（本番応答で確認済み）。

`/api/visits` は note を本人以外に返さない設計なので、それに合わせて一覧応答でも本人の訪問のみ note を返し、他人の分はキーごと落とすようにしました。

フロントの利用箇所は `ManholePage.tsx` の `isOwn ? featuredPhoto.visit?.note : undefined` のみで、本人分は従来どおり表示されます。

## 検証
- `npm run type-check` クリーン
- 修正前の本番応答で他人の visit に note（GPS座標）が含まれることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)