### PR TITLE
Backfill app user display names

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -25,6 +25,7 @@ Supabase SQL Editorで `database/migrations/` のSQLを番号順に実行しま�
 19. `021_restrict_app_user_public_id.sql`
 20. `022_upsert_app_user_fn.sql`
 21. `023_add_public_display_names_fn.sql`
+22. `024_backfill_app_user_display_names.sql`
 
 ## 注意
 

--- a/database/migrations/024_backfill_app_user_display_names.sql
+++ b/database/migrations/024_backfill_app_user_display_names.sql
@@ -1,0 +1,23 @@
+-- 既存 app_user.display_name が NULL/空のユーザーを auth.users の公開プロフィール名から補完する。
+-- PR #179/#180 は今後の同期と公開読み取りを直したが、既存の NULL は残るため
+-- 公開フィードで display_name が null のままになる。
+-- email の @ 前は個人情報になり得るため公開表示名には使わない。
+-- 優先順位は src/lib/auth/displayName.ts と揃える。
+
+UPDATE public.app_user au
+SET
+  display_name = COALESCE(
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'display_name'), ''),
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'name'), ''),
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'full_name'), '')
+  ),
+  updated_at = NOW()
+FROM auth.users auth_user
+WHERE au.auth_uid = auth_user.id
+  AND NULLIF(BTRIM(COALESCE(au.display_name, '')), '') IS NULL
+  AND COALESCE(auth_user.is_anonymous, false) = false
+  AND COALESCE(
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'display_name'), ''),
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'name'), ''),
+    NULLIF(BTRIM(auth_user.raw_user_meta_data->>'full_name'), '')
+  ) IS NOT NULL;

--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -3,6 +3,7 @@ import { cookies } from 'next/headers';
 import sharp from 'sharp';
 import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import { getAuthUserDisplayName } from '@/lib/auth/displayName';
 import {
   storage,
   generateDesignManholeStorageKey,
@@ -77,7 +78,7 @@ export async function POST(request: NextRequest) {
       );
     }
     const userId = session.user.id;
-    const displayName = session.user.user_metadata?.display_name as string | undefined;
+    const displayName = getAuthUserDisplayName(session.user);
     await ensureAppUser(supabase, userId, displayName);
 
     const formData = await request.formData();

--- a/src/app/api/image-upload/route.ts
+++ b/src/app/api/image-upload/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import { getAuthUserDisplayName } from '@/lib/auth/displayName';
 import { loadPublicDisplayNameMap } from '@/lib/public-display-names';
 import sharp from 'sharp';
 import { storage, generateStorageKey, deriveSmallKey } from '@/lib/storage';
@@ -152,7 +153,7 @@ export async function POST(request: NextRequest) {
     }
 
     const userId = session.user.id;
-    const displayName = session.user.user_metadata?.display_name;
+    const displayName = getAuthUserDisplayName(session.user);
 
     // ✅ Ensure app_user exists, auto-create if missing
     await ensureAppUser(supabase, userId, displayName);

--- a/src/app/api/visits/[id]/bookmark/route.ts
+++ b/src/app/api/visits/[id]/bookmark/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import { getAuthUserDisplayName } from '@/lib/auth/displayName';
 
 /**
  * @swagger
@@ -84,7 +85,7 @@ export async function POST(
 
     const visitId = params.id;
     const userId = session.user.id;
-    const displayName = session.user.user_metadata?.display_name;
+    const displayName = getAuthUserDisplayName(session.user);
 
     // ✅ Ensure app_user exists, auto-create if missing
     await ensureAppUser(supabase, userId, displayName);

--- a/src/app/api/visits/[id]/comments/route.ts
+++ b/src/app/api/visits/[id]/comments/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import { getAuthUserDisplayName } from '@/lib/auth/displayName';
 import { loadPublicDisplayNameMap } from '@/lib/public-display-names';
 
 /**
@@ -182,7 +183,7 @@ export async function POST(
     const { content } = body;
     const visitId = params.id;
     const userId = session.user.id;
-    const metadataDisplayName = session.user.user_metadata?.display_name;
+    const metadataDisplayName = getAuthUserDisplayName(session.user);
 
     // ✅ Ensure app_user exists, auto-create if missing
     await ensureAppUser(supabase, userId, metadataDisplayName);

--- a/src/app/api/visits/[id]/like/route.ts
+++ b/src/app/api/visits/[id]/like/route.ts
@@ -3,6 +3,7 @@ import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 import { cookies } from 'next/headers';
 import { Database } from '@/types/database';
 import { ensureAppUser } from '@/lib/auth/ensureAppUser';
+import { getAuthUserDisplayName } from '@/lib/auth/displayName';
 
 /**
  * @swagger
@@ -84,7 +85,7 @@ export async function POST(
 
     const visitId = params.id;
     const userId = session.user.id;
-    const displayName = session.user.user_metadata?.display_name;
+    const displayName = getAuthUserDisplayName(session.user);
 
     // ✅ Ensure app_user exists, auto-create if missing
     await ensureAppUser(supabase, userId, displayName);

--- a/src/lib/auth/displayName.ts
+++ b/src/lib/auth/displayName.ts
@@ -1,0 +1,19 @@
+type AuthUserLike = {
+  user_metadata?: Record<string, unknown> | null;
+};
+
+const readMetadataString = (metadata: Record<string, unknown> | null | undefined, key: string) => {
+  const value = metadata?.[key];
+  return typeof value === 'string' ? value.trim() : '';
+};
+
+export function getAuthUserDisplayName(user: AuthUserLike): string | undefined {
+  const metadata = user.user_metadata;
+  // Keep this precedence in sync with database/migrations/024_backfill_app_user_display_names.sql.
+  const displayName =
+    readMetadataString(metadata, 'display_name') ||
+    readMetadataString(metadata, 'name') ||
+    readMetadataString(metadata, 'full_name');
+
+  return displayName || undefined;
+}


### PR DESCRIPTION
## Summary
- Backfill existing `app_user.display_name` values from public auth metadata fields.
- Add a shared auth display-name resolver for future `ensureAppUser` calls.
- Use `display_name -> name -> full_name`; intentionally do **not** use email local-part as a public display name.

## Root Cause
PR #180 fixed the public read/RLS path, but production still had `app_user.display_name = null` for existing users. `get_public_display_names()` was working and returning the actual stored value: null.

PR #179 also only synced `user_metadata.display_name`; Google/auth users often have `name` or `full_name`.

## Privacy Note
Email local-part fallback was considered and removed. Values like `taro.tanaka` can be personally identifying, so this PR only backfills from explicit profile-name metadata fields.

## Validation
- `npm run type-check`
- `npm run build`

## Production Step
Apply `database/migrations/024_backfill_app_user_display_names.sql` in Supabase SQL Editor. This is the part that fixes existing null rows immediately when metadata contains `display_name`, `name`, or `full_name`.
