### PR TITLE
feat: 公開スタンプ帳ページを刷新 — 写真コラージュOGP・県別セクション・共有/回遊導線

### DIFF
--- a/src/app/users/[userId]/visits/opengraph-image/route.tsx
+++ b/src/app/users/[userId]/visits/opengraph-image/route.tsx
@@ -1,0 +1,334 @@
+import { ImageResponse } from 'next/og';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import sharp from 'sharp';
+import { deriveSmallKey, storage } from '@/lib/storage';
+import { getProgressClient, loadPublicUserPrefectureProgress } from '@/lib/user-prefecture-progress';
+import { PublicVisit, loadPublicUserVisits } from '@/lib/user-public-visits';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const alt = 'ポケふたスタンプ帳';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const PHOTO_COUNT = 3;
+const PHOTO_RENDER_SIZE = 420;
+
+type RouteContext = {
+  params: {
+    userId: string;
+  };
+};
+
+type PhotoKeyRow = {
+  id: string;
+  storage_key: string;
+};
+
+async function loadNotoSansCjk(): Promise<ArrayBuffer | null> {
+  try {
+    const fontPath = join(process.cwd(), 'public/ogp/fonts/NotoSansCJKjp-Bold.otf');
+    const font = await readFile(fontPath);
+    return new Uint8Array(font).buffer;
+  } catch {
+    return null;
+  }
+}
+
+// 最新の公開訪問写真を最大3枚、data URI(JPEG)にして返す。
+// 1枚でも失敗したら写真なしレイアウトに落とすのではなく、取れた分だけ使う。
+async function loadRecentPhotoDataUris(visits: PublicVisit[]): Promise<string[]> {
+  const photoIds = visits
+    .map((visit) => visit.photoIds[0])
+    .filter((id): id is string => Boolean(id))
+    .slice(0, PHOTO_COUNT);
+
+  if (photoIds.length === 0) return [];
+
+  const supabase = getProgressClient();
+  if (!supabase) return [];
+
+  // photoIds は公開訪問由来だが、直接クエリでも is_public を再確認して二重に守る
+  const { data, error } = await supabase
+    .from('photo')
+    .select('id, storage_key, visit:visit_id!inner(is_public)')
+    .in('id', photoIds)
+    .eq('visit.is_public', true);
+
+  if (error || !data) return [];
+
+  const keyById = new Map(
+    (data as unknown as PhotoKeyRow[]).map((row) => [row.id, row.storage_key])
+  );
+
+  const results = await Promise.all(
+    photoIds.map(async (photoId) => {
+      try {
+        const storageKey = keyById.get(photoId);
+        if (!storageKey) return null;
+
+        let key = storageKey;
+        const smallKey = deriveSmallKey(storageKey);
+        if (smallKey && (await storage.exists?.(smallKey))) {
+          key = smallKey;
+        }
+
+        const signed = await storage.getSignedUrl(key, 300);
+        const response = await fetch(signed.url);
+        if (!response.ok) return null;
+
+        const input = Buffer.from(await response.arrayBuffer());
+        const jpeg = await sharp(input)
+          .rotate()
+          .resize(PHOTO_RENDER_SIZE, PHOTO_RENDER_SIZE, { fit: 'cover' })
+          .jpeg({ quality: 72 })
+          .toBuffer();
+
+        return `data:image/jpeg;base64,${jpeg.toString('base64')}`;
+      } catch {
+        return null;
+      }
+    })
+  );
+
+  return results.filter((uri): uri is string => Boolean(uri));
+}
+
+export async function GET(_request: Request, { params }: RouteContext) {
+  try {
+    const [visitsData, progress, fontData] = await Promise.all([
+      loadPublicUserVisits(params.userId),
+      loadPublicUserPrefectureProgress(params.userId).catch(() => null),
+      loadNotoSansCjk(),
+    ]);
+
+    if (!visitsData) {
+      return new Response('Not found', {
+        status: 404,
+        headers: { 'Cache-Control': 'public, max-age=300' },
+      });
+    }
+
+    const photoUris = await loadRecentPhotoDataUris(visitsData.visits).catch(() => []);
+
+    const totalPrefectures = progress?.totalPrefectureCount || 47;
+    const completionRate = progress ? Math.min(progress.completionRate, 100) : null;
+
+    return new ImageResponse(
+      (
+        <div
+          style={{
+            width: '100%',
+            height: '100%',
+            display: 'flex',
+            background: '#F6EEDC',
+            color: '#4F3828',
+            padding: 52,
+            fontFamily: 'NotoSansCJK, sans-serif',
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              position: 'absolute',
+              top: 0, right: 0, bottom: 0, left: 0,
+              backgroundImage: 'linear-gradient(#8C6A4A1A 1px, transparent 1px)',
+              backgroundSize: '32px 32px',
+            }}
+          />
+          <div
+            style={{
+              position: 'absolute',
+              top: 28, right: 28, bottom: 28, left: 28,
+              border: '4px solid rgba(140,106,74,0.18)',
+              borderRadius: 20,
+            }}
+          />
+
+          {/* 左: 名前とスタッツ */}
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'space-between',
+              flex: 1,
+              paddingRight: 36,
+              zIndex: 1,
+            }}
+          >
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 18 }}>
+              <div
+                style={{
+                  display: 'flex',
+                  alignSelf: 'flex-start',
+                  borderRadius: 999,
+                  background: '#F8D9C4',
+                  color: '#B5483C',
+                  padding: '10px 20px',
+                  fontSize: 26,
+                  fontWeight: 800,
+                }}
+              >
+                ポケふたスタンプ帳
+              </div>
+              <div style={{ fontSize: 64, fontWeight: 900, lineHeight: 1.15 }}>
+                {`${visitsData.displayName}のスタンプ帳`}
+              </div>
+            </div>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+              <div style={{ display: 'flex', gap: 20 }}>
+                <OgpStat label="訪問スタンプ" value={`${visitsData.totalVisits}`} />
+                <OgpStat
+                  label="都道府県"
+                  value={`${visitsData.prefectureCount}/${totalPrefectures}`}
+                />
+              </div>
+
+              {completionRate !== null && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      justifyContent: 'space-between',
+                      fontSize: 24,
+                      fontWeight: 800,
+                      color: '#6A4D36',
+                    }}
+                  >
+                    <span>全国達成率</span>
+                    <span style={{ color: '#B5483C' }}>{completionRate.toFixed(1)}%</span>
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      width: '100%',
+                      height: 22,
+                      borderRadius: 999,
+                      background: 'rgba(140,106,74,0.18)',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    <div
+                      style={{
+                        display: 'flex',
+                        width: `${Math.max(completionRate, 1.5)}%`,
+                        height: '100%',
+                        borderRadius: 999,
+                        background: '#B5483C',
+                      }}
+                    />
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* 右: 訪問写真コラージュ or スタンプモチーフ */}
+          <div
+            style={{
+              display: 'flex',
+              width: 400,
+              position: 'relative',
+              zIndex: 1,
+            }}
+          >
+            {photoUris.length > 0 ? (
+              photoUris.map((uri, index) => {
+                const placements = [
+                  { top: 24, left: 60, rotate: '-6deg' },
+                  { top: 180, left: 130, rotate: '5deg' },
+                  { top: 320, left: 40, rotate: '-3deg' },
+                ];
+                const place = placements[index] ?? placements[0];
+                return (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img
+                    key={index}
+                    src={uri}
+                    alt=""
+                    width={230}
+                    height={230}
+                    style={{
+                      position: 'absolute',
+                      top: place.top,
+                      left: place.left,
+                      width: 230,
+                      height: 230,
+                      objectFit: 'cover',
+                      borderRadius: 16,
+                      border: '8px solid #FFF7E5',
+                      boxShadow: '0 14px 30px rgba(95,68,42,0.28)',
+                      transform: `rotate(${place.rotate})`,
+                    }}
+                  />
+                );
+              })
+            ) : (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: 300,
+                  height: 300,
+                  margin: 'auto',
+                  borderRadius: 999,
+                  border: '10px dashed rgba(181,72,60,0.45)',
+                  color: '#B5483C',
+                  fontSize: 40,
+                  fontWeight: 900,
+                  transform: 'rotate(-8deg)',
+                }}
+              >
+                ポケふた旅
+              </div>
+            )}
+          </div>
+        </div>
+      ),
+      {
+        ...size,
+        fonts: fontData
+          ? [
+              {
+                name: 'NotoSansCJK',
+                data: fontData,
+                weight: 700,
+              },
+            ]
+          : [],
+        headers: {
+          'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        },
+      }
+    );
+  } catch (err) {
+    console.error('[OGP] users visits render failed:', err);
+    return new Response('Internal Server Error', {
+      status: 500,
+      headers: { 'Cache-Control': 'public, max-age=60' },
+    });
+  }
+}
+
+function OgpStat({ label, value }: { label: string; value: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        border: '3px solid rgba(140,106,74,0.18)',
+        borderRadius: 16,
+        background: 'rgba(255,247,229,0.92)',
+        padding: '20px 24px',
+      }}
+    >
+      <div style={{ fontSize: 24, fontWeight: 800, color: '#6A4D36' }}>{label}</div>
+      <div style={{ marginTop: 8, fontSize: 52, fontWeight: 900, color: '#B5483C' }}>{value}</div>
+    </div>
+  );
+}

--- a/src/app/users/[userId]/visits/opengraph-image/route.tsx
+++ b/src/app/users/[userId]/visits/opengraph-image/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
 import sharp from 'sharp';
+import { getOgpFontPath } from '@/lib/pokefuta-ogp-template';
 import { deriveSmallKey, storage } from '@/lib/storage';
 import { getProgressClient, loadPublicUserPrefectureProgress } from '@/lib/user-prefecture-progress';
 import { PublicVisit, loadPublicUserVisits } from '@/lib/user-public-visits';
@@ -12,8 +12,16 @@ export const alt = 'ポケふたスタンプ帳';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
-const PHOTO_COUNT = 3;
-const PHOTO_RENDER_SIZE = 420;
+// コラージュの配置スロット。写真は最大この数まで載る
+const PHOTO_PLACEMENTS = [
+  { top: 24, left: 60, rotate: '-6deg' },
+  { top: 180, left: 130, rotate: '5deg' },
+  { top: 320, left: 40, rotate: '-3deg' },
+] as const;
+const PHOTO_COUNT = PHOTO_PLACEMENTS.length;
+// satori は1倍でラスタライズするので描画サイズちょうどでよい
+const PHOTO_RENDER_SIZE = 230;
+const PHOTO_FETCH_TIMEOUT_MS = 4000;
 
 type RouteContext = {
   params: {
@@ -28,8 +36,7 @@ type PhotoKeyRow = {
 
 async function loadNotoSansCjk(): Promise<ArrayBuffer | null> {
   try {
-    const fontPath = join(process.cwd(), 'public/ogp/fonts/NotoSansCJKjp-Bold.otf');
-    const font = await readFile(fontPath);
+    const font = await readFile(getOgpFontPath());
     return new Uint8Array(font).buffer;
   } catch {
     return null;
@@ -56,11 +63,24 @@ async function loadRecentPhotoDataUris(visits: PublicVisit[]): Promise<string[]>
     .in('id', photoIds)
     .eq('visit.is_public', true);
 
-  if (error || !data) return [];
+  if (error || !data) {
+    if (error) console.error('[OGP] users visits photo select failed:', error.message);
+    return [];
+  }
 
   const keyById = new Map(
     (data as unknown as PhotoKeyRow[]).map((row) => [row.id, row.storage_key])
   );
+
+  // 署名は手元で完結する軽い処理なので、exists() の HEAD を打たずに
+  // small を先に取りに行き、無ければ原本にフォールバックする
+  const fetchPhoto = async (key: string): Promise<Response | null> => {
+    const signed = await storage.getSignedUrl(key, 300);
+    const response = await fetch(signed.url, {
+      signal: AbortSignal.timeout(PHOTO_FETCH_TIMEOUT_MS),
+    });
+    return response.ok ? response : null;
+  };
 
   const results = await Promise.all(
     photoIds.map(async (photoId) => {
@@ -68,15 +88,12 @@ async function loadRecentPhotoDataUris(visits: PublicVisit[]): Promise<string[]>
         const storageKey = keyById.get(photoId);
         if (!storageKey) return null;
 
-        let key = storageKey;
         const smallKey = deriveSmallKey(storageKey);
-        if (smallKey && (await storage.exists?.(smallKey))) {
-          key = smallKey;
+        let response = smallKey ? await fetchPhoto(smallKey).catch(() => null) : null;
+        if (!response) {
+          response = await fetchPhoto(storageKey);
         }
-
-        const signed = await storage.getSignedUrl(key, 300);
-        const response = await fetch(signed.url);
-        if (!response.ok) return null;
+        if (!response) return null;
 
         const input = Buffer.from(await response.arrayBuffer());
         const jpeg = await sharp(input)
@@ -110,10 +127,22 @@ export async function GET(_request: Request, { params }: RouteContext) {
       });
     }
 
+    if (!fontData) {
+      // フォントなしで satori に CJK を渡すと描画時に throw して 500 になるだけなので、
+      // 原因がわかる形で早期に落とす
+      console.error('[OGP] users visits: CJK font is missing, cannot render');
+      return new Response('Font unavailable', {
+        status: 500,
+        headers: { 'Cache-Control': 'public, max-age=60' },
+      });
+    }
+
     const photoUris = await loadRecentPhotoDataUris(visitsData.visits).catch(() => []);
 
     const totalPrefectures = progress?.totalPrefectureCount || 47;
     const completionRate = progress ? Math.min(progress.completionRate, 100) : null;
+    // 0% のときに 1.5% 埋まって見えないよう、進捗があるときだけ最小幅を適用
+    const barWidthPercent = completionRate ? Math.max(completionRate, 1.5) : 0;
 
     return new ImageResponse(
       (
@@ -214,7 +243,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
                     <div
                       style={{
                         display: 'flex',
-                        width: `${Math.max(completionRate, 1.5)}%`,
+                        width: `${barWidthPercent}%`,
                         height: '100%',
                         borderRadius: 999,
                         background: '#B5483C',
@@ -237,12 +266,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
           >
             {photoUris.length > 0 ? (
               photoUris.map((uri, index) => {
-                const placements = [
-                  { top: 24, left: 60, rotate: '-6deg' },
-                  { top: 180, left: 130, rotate: '5deg' },
-                  { top: 320, left: 40, rotate: '-3deg' },
-                ];
-                const place = placements[index] ?? placements[0];
+                const place = PHOTO_PLACEMENTS[index];
                 return (
                   // eslint-disable-next-line @next/next/no-img-element
                   <img
@@ -291,15 +315,13 @@ export async function GET(_request: Request, { params }: RouteContext) {
       ),
       {
         ...size,
-        fonts: fontData
-          ? [
-              {
-                name: 'NotoSansCJK',
-                data: fontData,
-                weight: 700,
-              },
-            ]
-          : [],
+        fonts: [
+          {
+            name: 'NotoSansCJK',
+            data: fontData,
+            weight: 700 as const,
+          },
+        ],
         headers: {
           'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
         },

--- a/src/app/users/[userId]/visits/page.tsx
+++ b/src/app/users/[userId]/visits/page.tsx
@@ -1,11 +1,23 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, Camera, MapPin, Stamp } from 'lucide-react';
+import {
+  ArrowLeft,
+  ArrowRight,
+  Camera,
+  Map as MapIcon,
+  MapPin,
+  Search,
+  Sparkles,
+  Stamp,
+} from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
-import { SITE_NAME, SITE_URL } from '@/lib/constants';
+import ShareButtons from '@/components/ShareButtons';
+import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import { formatDateJa } from '@/lib/date';
+import { userVisitsShareText } from '@/lib/share';
+import { loadPublicUserPrefectureProgress } from '@/lib/user-prefecture-progress';
 import { PublicVisit, loadPublicUserVisits } from '@/lib/user-public-visits';
 
 type PageProps = {
@@ -17,6 +29,8 @@ type PageProps = {
 export const dynamic = 'force-dynamic';
 
 const getPageUrl = (userId: string) => `${SITE_URL}/users/${encodeURIComponent(userId)}/visits`;
+const getOgpImageUrl = (userId: string) =>
+  `${getPageUrl(userId)}/opengraph-image?v=${OGP_IMAGE_VERSION}`;
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const data = await loadPublicUserVisits(params.userId);
@@ -28,6 +42,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   }
 
   const pageUrl = getPageUrl(data.userId);
+  const ogpImageUrl = getOgpImageUrl(data.userId);
   const title = `${data.displayName}のスタンプ帳 | ${SITE_NAME}`;
   const description = `${data.displayName}さんが公開している訪問記録${data.totalVisits}件、${data.prefectureCount}都道府県分のポケふたスタンプ帳です。`;
 
@@ -43,22 +58,78 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       url: pageUrl,
       siteName: SITE_NAME,
       type: 'profile',
+      images: [
+        {
+          url: ogpImageUrl,
+          width: 1200,
+          height: 630,
+          alt: `${data.displayName}のポケふたスタンプ帳`,
+        },
+      ],
     },
     twitter: {
-      card: 'summary',
+      card: 'summary_large_image',
       title,
       description,
+      images: [ogpImageUrl],
     },
   };
 }
 
+type PrefectureGroup = {
+  name: string;
+  visits: PublicVisit[];
+};
+
+// 訪問は shot_at 降順で来るので、挿入順 = 直近に訪れた都道府県が先頭になる
+function groupVisitsByPrefecture(visits: PublicVisit[]): PrefectureGroup[] {
+  const groups = new Map<string, PublicVisit[]>();
+  visits.forEach((visit) => {
+    const name = visit.manhole?.prefecture || 'その他';
+    const list = groups.get(name);
+    if (list) {
+      list.push(visit);
+    } else {
+      groups.set(name, [visit]);
+    }
+  });
+  return Array.from(groups.entries()).map(([name, groupVisits]) => ({
+    name,
+    visits: groupVisits,
+  }));
+}
+
 export default async function UserVisitsPage({ params }: PageProps) {
-  const data = await loadPublicUserVisits(params.userId);
+  const [data, progress] = await Promise.all([
+    loadPublicUserVisits(params.userId),
+    loadPublicUserPrefectureProgress(params.userId).catch(() => null),
+  ]);
 
   if (!data) notFound();
 
+  const pageUrl = getPageUrl(data.userId);
+  const shareText = userVisitsShareText(data.displayName, data.totalVisits, data.prefectureCount);
+  const totalPrefectures = progress?.totalPrefectureCount || 47;
+  const completionRate = progress ? Math.min(progress.completionRate, 100) : null;
+  const prefectureGroups = groupVisitsByPrefecture(data.visits);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ProfilePage',
+    name: `${data.displayName}のスタンプ帳`,
+    url: pageUrl,
+    mainEntity: {
+      '@type': 'Person',
+      name: data.displayName,
+    },
+  };
+
   return (
     <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <Header
         title={SITE_NAME}
         actions={
@@ -84,9 +155,37 @@ export default async function UserVisitsPage({ params }: PageProps) {
               公開設定の訪問記録のみを表示しています。
             </p>
 
-            <div className="mt-6 grid gap-3 sm:grid-cols-2">
-              <HeroStat label="訪問数" value={`${data.totalVisits}`} />
-              <HeroStat label="都道府県数" value={`${data.prefectureCount}`} />
+            <div className="mt-6 grid grid-cols-3 gap-2 sm:gap-3">
+              <HeroStat label="訪問スタンプ" value={`${data.totalVisits}`} />
+              <HeroStat label="都道府県" value={`${data.prefectureCount}/${totalPrefectures}`} />
+              {completionRate !== null && (
+                <HeroStat label="全国達成率" value={`${completionRate.toFixed(1)}%`} />
+              )}
+            </div>
+
+            {completionRate !== null && (
+              <div className="mt-4">
+                <div className="h-3 w-full overflow-hidden rounded-full bg-[#8C6A4A]/20">
+                  <div
+                    className="h-full rounded-full bg-[#B5483C] transition-all"
+                    style={{ width: `${Math.max(completionRate, 1.5)}%` }}
+                  />
+                </div>
+                <p className="mt-1.5 text-[11px] font-bold text-[#6A4D36]">
+                  全国のポケふた制覇まであと
+                  {progress ? Math.max(progress.totalManholeCount - progress.visitedManholeCount, 0) : 0}
+                  枚
+                </p>
+              </div>
+            )}
+
+            <div className="mt-6">
+              <ShareButtons
+                label="このスタンプ帳を自慢する"
+                shareText={shareText}
+                shareUrl={pageUrl}
+                hashtags={['ポケふたスタンプ帳']}
+              />
             </div>
           </div>
         </section>
@@ -97,18 +196,79 @@ export default async function UserVisitsPage({ params }: PageProps) {
           </p>
         )}
 
-        <section className="mt-6">
-          {data.visits.length === 0 ? (
+        {prefectureGroups.length > 1 && (
+          <nav aria-label="都道府県で移動" className="mt-6 flex flex-wrap gap-2">
+            {prefectureGroups.map((group) => (
+              <a
+                key={group.name}
+                href={`#pref-${group.name}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-[#8C6A4A]/25 bg-white/70 px-3 py-1.5 text-xs font-bold text-[#4F3828] transition hover:border-[#B5483C]/40 hover:bg-[#F8D9C4] hover:text-[#B5483C]"
+              >
+                <MapPin className="h-3 w-3" />
+                {group.name}
+                <span className="text-[#B5483C]">{group.visits.length}</span>
+              </a>
+            ))}
+          </nav>
+        )}
+
+        {data.visits.length === 0 ? (
+          <section className="mt-6">
             <div className="rounded-[8px] border border-[#8C6A4A]/15 bg-white/70 px-5 py-10 text-center text-sm font-bold text-[#6A4D36]">
               公開中の訪問記録はまだありません。
             </div>
-          ) : (
-            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
-              {data.visits.map((visit) => (
-                <VisitCard key={visit.id} visit={visit} />
-              ))}
-            </div>
-          )}
+          </section>
+        ) : (
+          prefectureGroups.map((group) => (
+            <section key={group.name} id={`pref-${group.name}`} className="mt-8 scroll-mt-20">
+              <div className="mb-3 flex items-baseline justify-between gap-3">
+                <h2 className="flex items-center gap-2 text-lg font-extrabold text-[#4F3828]">
+                  <MapPin className="h-5 w-5 text-[#B5483C]" />
+                  {group.name}
+                </h2>
+                <p className="text-xs font-bold text-[#6A4D36]">{group.visits.length}枚</p>
+              </div>
+              <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4">
+                {group.visits.map((visit) => (
+                  <VisitCard key={visit.id} visit={visit} />
+                ))}
+              </div>
+            </section>
+          ))
+        )}
+
+        <section className="mt-10">
+          <h2 className="mb-3 flex items-center gap-2 text-lg font-extrabold text-[#4F3828]">
+            <Sparkles className="h-5 w-5 text-[#B5483C]" />
+            あなたもポケふた旅へ
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <CtaCard
+              href="/visits"
+              icon={<Stamp className="h-5 w-5" />}
+              title="自分のスタンプ帳を作る"
+              description="無料ではじめて訪問を記録・公開しよう"
+              highlight
+            />
+            <CtaCard
+              href="/nearby"
+              icon={<Search className="h-5 w-5" />}
+              title="近くのポケふたを探す"
+              description="現在地から近い順に見つけられます"
+            />
+            <CtaCard
+              href="/map"
+              icon={<MapIcon className="h-5 w-5" />}
+              title="全国マップで見る"
+              description="都道府県ごとの設置状況をチェック"
+            />
+            <CtaCard
+              href="/popular"
+              icon={<Camera className="h-5 w-5" />}
+              title="人気のポケふた"
+              description="みんなが訪れているポケふたを見る"
+            />
+          </div>
         </section>
       </main>
 
@@ -123,6 +283,41 @@ function HeroStat({ label, value }: { label: string; value: string }) {
       <p className="text-[11px] font-extrabold text-[#6A4D36]">{label}</p>
       <p className="mt-1 font-pixel text-2xl leading-none text-[#B5483C]">{value}</p>
     </div>
+  );
+}
+
+function CtaCard({
+  href,
+  icon,
+  title,
+  description,
+  highlight = false,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  highlight?: boolean;
+}) {
+  return (
+    <Link
+      href={href}
+      className={`group flex flex-col rounded-[8px] border px-4 py-4 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md ${
+        highlight
+          ? 'border-[#B5483C]/35 bg-[#F8D9C4]'
+          : 'border-[#8C6A4A]/20 bg-[#FFF7E5]'
+      }`}
+    >
+      <div className={`flex items-center gap-2 font-extrabold ${highlight ? 'text-[#B5483C]' : 'text-[#4F3828]'}`}>
+        {icon}
+        <span className="text-sm leading-tight">{title}</span>
+      </div>
+      <p className="mt-2 flex-1 text-[11px] font-bold leading-snug text-[#6A4D36]">{description}</p>
+      <span className={`mt-3 inline-flex items-center gap-1 text-[11px] font-extrabold ${highlight ? 'text-[#B5483C]' : 'text-[#8C6A4A]'}`}>
+        ひらく
+        <ArrowRight className="h-3 w-3 transition group-hover:translate-x-0.5" />
+      </span>
+    </Link>
   );
 }
 

--- a/src/app/users/[userId]/visits/page.tsx
+++ b/src/app/users/[userId]/visits/page.tsx
@@ -111,6 +111,11 @@ export default async function UserVisitsPage({ params }: PageProps) {
   const shareText = userVisitsShareText(data.displayName, data.totalVisits, data.prefectureCount);
   const totalPrefectures = progress?.totalPrefectureCount || 47;
   const completionRate = progress ? Math.min(progress.completionRate, 100) : null;
+  // 0% のときに 1.5% 埋まって見えないよう、進捗があるときだけ最小幅を適用
+  const barWidthPercent = completionRate ? Math.max(completionRate, 1.5) : 0;
+  const remainingCount = progress
+    ? Math.max(progress.totalManholeCount - progress.visitedManholeCount, 0)
+    : null;
   const prefectureGroups = groupVisitsByPrefecture(data.visits);
 
   const jsonLd = {
@@ -128,7 +133,8 @@ export default async function UserVisitsPage({ params }: PageProps) {
     <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        // displayName はユーザー入力なので、</script> 挿入によるXSSを防ぐため < をエスケープする
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
       />
       <Header
         title={SITE_NAME}
@@ -168,13 +174,11 @@ export default async function UserVisitsPage({ params }: PageProps) {
                 <div className="h-3 w-full overflow-hidden rounded-full bg-[#8C6A4A]/20">
                   <div
                     className="h-full rounded-full bg-[#B5483C] transition-all"
-                    style={{ width: `${Math.max(completionRate, 1.5)}%` }}
+                    style={{ width: `${barWidthPercent}%` }}
                   />
                 </div>
                 <p className="mt-1.5 text-[11px] font-bold text-[#6A4D36]">
-                  全国のポケふた制覇まであと
-                  {progress ? Math.max(progress.totalManholeCount - progress.visitedManholeCount, 0) : 0}
-                  枚
+                  全国のポケふた制覇まであと{remainingCount}枚
                 </p>
               </div>
             )}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -36,6 +36,14 @@ export function visitsShareText(stampCount: number): string {
   return `ポケふた旅を続けています！\n${stampCount}枚のポケふたを巡りました`;
 }
 
+export function userVisitsShareText(
+  displayName: string,
+  stampCount: number,
+  prefectureCount: number
+): string {
+  return `${displayName}のポケふたスタンプ帳\n${stampCount}枚のスタンプ・${prefectureCount}都道府県を巡りました！`;
+}
+
 export function prefectureProgressShareText(
   completedPrefectureCount: number,
   totalPrefectureCount: number


### PR DESCRIPTION
## 概要

公開スタンプ帳ページ `/users/[userId]/visits` を「他の人に自慢したくなる・自分も投稿したくなる」目玉ページとして刷新します。

## 変更内容

### 1. OGP刷新(summary_large_image化)
- `/users/[userId]/visits/opengraph-image` ルートを新設(1200×630 PNG)
- 最新の公開訪問写真3枚をR2署名URL経由で取得し、sharpで縮小してポラロイド風コラージュを描画
- スタンプ数・都道府県数(X/47)・全国達成率プログレスバーを表示
- 写真取得時に `visit.is_public` を再チェックし、非公開写真は絶対に載らない
- 写真が1枚もないユーザーはスタンプ風モチーフにフォールバック
- ページメタを `twitter:card=summary_large_image` + `og:image` に変更(従来はテキストのみの `summary`)

### 2. ページ本体の強化
- ヒーローに3スタッツ(訪問スタンプ・都道府県/47・全国達成率)+ 制覇プログレスバー +「あと◯枚」
- 「このスタンプ帳を自慢する」共有ボタン(X / LINE / リンクコピー)をヒーロー直下に配置
- 訪問一覧を都道府県別セクションに再編成(直近に訪れた県が先頭)、県チップでアンカージャンプ
- ProfilePage の JSON-LD を追加

### 3. 回遊導線の追加
- ページ下部にCTAカード4枚: 自分のスタンプ帳を作る(強調)/ 近くのポケふたを探す / 全国マップ / 人気のポケふた
- 各訪問カード→ポケふた詳細への既存導線は維持

### 4. その他
- `userVisitsShareText()` を `src/lib/share.ts` に追加

## 動作確認
- `tsc --noEmit` パス
- ローカルdevサーバーで対象ユーザーページ 200 / OGP画像 200 (image/png) を確認
- モバイル(390px)・OGP画像のスクリーンショットで表示確認済み

## 備考
- 既存の `prefectures/opengraph-image` は satori 非対応の `width: 'fit-content'` を使っており、手元環境では500になる(本PRの新ルートでは同パターンを回避済み)。別途要確認。
- デプロイ後にSNSのOGPキャッシュを飛ばす場合は `OGP_IMAGE_VERSION` を更新してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)