### PR TITLE
Add editable public user profiles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repository guidance
+
+- Treat `app_user` profile data as public only through narrowly scoped `SECURITY DEFINER` functions. Do not grant anonymous table access.
+- Keep `src/types/database.ts` in sync when a database migration adds or changes profile fields.
+- A user may edit only the profile associated with `auth.uid()`; enforce this in the database as well as in the UI.

--- a/database/migrations/025_add_public_user_profiles.sql
+++ b/database/migrations/025_add_public_user_profiles.sql
@@ -1,0 +1,118 @@
+-- 公開スタンプ帳に表示する任意プロフィール項目を追加する。
+-- app_user 自体は公開せず、公開読み取りは get_public_user_info() に限定する。
+
+ALTER TABLE app_user
+  ADD COLUMN IF NOT EXISTS bio text,
+  ADD COLUMN IF NOT EXISTS x_url text,
+  ADD COLUMN IF NOT EXISTS instagram_url text,
+  ADD COLUMN IF NOT EXISTS profile_is_customized boolean NOT NULL DEFAULT false;
+
+ALTER TABLE app_user
+  DROP CONSTRAINT IF EXISTS app_user_display_name_length,
+  DROP CONSTRAINT IF EXISTS app_user_bio_length,
+  DROP CONSTRAINT IF EXISTS app_user_x_url_length,
+  DROP CONSTRAINT IF EXISTS app_user_instagram_url_length;
+
+ALTER TABLE app_user
+  ADD CONSTRAINT app_user_display_name_length
+    CHECK (display_name IS NULL OR char_length(display_name) <= 40),
+  ADD CONSTRAINT app_user_bio_length
+    CHECK (bio IS NULL OR char_length(bio) <= 160),
+  ADD CONSTRAINT app_user_x_url_length
+    CHECK (x_url IS NULL OR char_length(x_url) <= 300),
+  ADD CONSTRAINT app_user_instagram_url_length
+    CHECK (instagram_url IS NULL OR char_length(instagram_url) <= 300);
+
+-- CREATE OR REPLACE では RETURNS TABLE の列を変更できないため、いったん削除する。
+DROP FUNCTION IF EXISTS get_public_user_info(uuid);
+CREATE FUNCTION get_public_user_info(p_user_id uuid)
+RETURNS TABLE (
+  auth_uid uuid,
+  display_name text,
+  bio text,
+  x_url text,
+  instagram_url text
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT au.auth_uid, au.display_name, au.bio, au.x_url, au.instagram_url
+  FROM app_user au
+  WHERE au.id = p_user_id;
+$$;
+
+REVOKE ALL ON FUNCTION get_public_user_info(uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION get_public_user_info(uuid) TO anon, authenticated;
+
+-- auth.uid() から対象行を決め、他ユーザーのプロフィールを更新できないようにする。
+CREATE OR REPLACE FUNCTION update_own_public_profile(
+  p_display_name text,
+  p_bio text,
+  p_x_url text,
+  p_instagram_url text
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_display_name text := nullif(btrim(p_display_name), '');
+  v_bio text := nullif(btrim(p_bio), '');
+  v_x_url text := nullif(btrim(p_x_url), '');
+  v_instagram_url text := nullif(btrim(p_instagram_url), '');
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Authentication required';
+  END IF;
+  IF v_display_name IS NULL THEN
+    RAISE EXCEPTION 'Display name is required';
+  END IF;
+  IF char_length(v_display_name) > 40 OR char_length(COALESCE(v_bio, '')) > 160 THEN
+    RAISE EXCEPTION 'Profile text is too long';
+  END IF;
+  IF v_x_url IS NOT NULL AND v_x_url !~* '^https://(www\.)?(x\.com|twitter\.com)/[^/[:space:]]+/?$' THEN
+    RAISE EXCEPTION 'Invalid X URL';
+  END IF;
+  IF v_instagram_url IS NOT NULL AND v_instagram_url !~* '^https://(www\.)?instagram\.com/[^/[:space:]]+/?$' THEN
+    RAISE EXCEPTION 'Invalid Instagram URL';
+  END IF;
+
+  UPDATE app_user
+  SET display_name = v_display_name,
+      bio = v_bio,
+      x_url = v_x_url,
+      instagram_url = v_instagram_url,
+      profile_is_customized = true,
+      updated_at = now()
+  WHERE auth_uid = auth.uid();
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Profile not found';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION update_own_public_profile(text, text, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION update_own_public_profile(text, text, text, text) TO authenticated;
+
+-- ログインメタデータ由来の名前で、ユーザーが明示的に編集した名前を上書きしない。
+CREATE OR REPLACE FUNCTION upsert_app_user(
+  p_auth_uid uuid,
+  p_display_name text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  INSERT INTO app_user (auth_uid, display_name)
+  VALUES (p_auth_uid, p_display_name)
+  ON CONFLICT (auth_uid) DO UPDATE
+    SET display_name = EXCLUDED.display_name
+    WHERE NOT app_user.profile_is_customized
+      AND p_display_name IS NOT NULL
+      AND app_user.display_name IS DISTINCT FROM EXCLUDED.display_name;
+$$;

--- a/database/migrations/025_add_public_user_profiles.sql
+++ b/database/migrations/025_add_public_user_profiles.sql
@@ -1,5 +1,6 @@
 -- 公開スタンプ帳に表示する任意プロフィール項目を追加する。
 -- app_user 自体は公開せず、公開読み取りは get_public_user_info() に限定する。
+-- 文字数・URL制約を変更するときは src/app/api/user/profile/route.ts も同期する。
 
 ALTER TABLE app_user
   ADD COLUMN IF NOT EXISTS bio text,
@@ -24,6 +25,8 @@ ALTER TABLE app_user
     CHECK (instagram_url IS NULL OR char_length(instagram_url) <= 300);
 
 -- CREATE OR REPLACE では RETURNS TABLE の列を変更できないため、いったん削除する。
+-- auth_uid は公開 visit の絞り込みに既存のサーバーローダーが利用しているため、011 からの返却を維持する。
+-- 将来これを非公開化する場合は、公開 user id から visit/progress を取得する専用 RPC へ置き換える。
 DROP FUNCTION IF EXISTS get_public_user_info(uuid);
 CREATE FUNCTION get_public_user_info(p_user_id uuid)
 RETURNS TABLE (

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -1,19 +1,25 @@
 import { NextResponse } from 'next/server';
 import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
 
+// Keep these limits in sync with database/migrations/025_add_public_user_profiles.sql.
+// The API gives users friendly errors; the database constraints remain the final guard.
 const DISPLAY_NAME_MAX = 40;
 const BIO_MAX = 160;
 const URL_MAX = 300;
 
 type ProfileInput = {
-  displayName?: unknown;
-  bio?: unknown;
-  xUrl?: unknown;
-  instagramUrl?: unknown;
+  displayName: string;
+  bio: string;
+  xUrl: string;
+  instagramUrl: string;
 };
 
-function optionalText(value: unknown) {
-  return typeof value === 'string' ? value.trim() : '';
+function isProfileInput(value: unknown): value is ProfileInput {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const input = value as Record<string, unknown>;
+  return ['displayName', 'bio', 'xUrl', 'instagramUrl'].every(
+    (key) => typeof input[key] === 'string'
+  );
 }
 
 function isSocialUrl(value: string, hosts: string[]) {
@@ -36,22 +42,26 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: 'ログインが必要です。' }, { status: 401 });
   }
 
-  let input: ProfileInput;
+  let input: unknown;
   try {
-    input = await request.json() as ProfileInput;
+    input = await request.json();
   } catch {
     return NextResponse.json({ error: '入力内容を読み取れませんでした。' }, { status: 400 });
   }
 
-  const displayName = optionalText(input.displayName);
-  const bio = optionalText(input.bio);
-  const xUrl = optionalText(input.xUrl);
-  const instagramUrl = optionalText(input.instagramUrl);
+  if (!isProfileInput(input)) {
+    return NextResponse.json({ error: 'プロフィールの全項目を送信してください。' }, { status: 400 });
+  }
 
-  if (!displayName || displayName.length > DISPLAY_NAME_MAX) {
+  const displayName = input.displayName.trim();
+  const bio = input.bio.trim();
+  const xUrl = input.xUrl.trim();
+  const instagramUrl = input.instagramUrl.trim();
+
+  if (!displayName || [...displayName].length > DISPLAY_NAME_MAX) {
     return NextResponse.json({ error: `表示名は1〜${DISPLAY_NAME_MAX}文字で入力してください。` }, { status: 400 });
   }
-  if (bio.length > BIO_MAX) {
+  if ([...bio].length > BIO_MAX) {
     return NextResponse.json({ error: `一言は${BIO_MAX}文字以内で入力してください。` }, { status: 400 });
   }
   if (xUrl.length > URL_MAX || !isSocialUrl(xUrl, ['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com'])) {

--- a/src/app/api/user/profile/route.ts
+++ b/src/app/api/user/profile/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { createRouteHandlerClient } from '@/lib/supabase/route-handler';
+
+const DISPLAY_NAME_MAX = 40;
+const BIO_MAX = 160;
+const URL_MAX = 300;
+
+type ProfileInput = {
+  displayName?: unknown;
+  bio?: unknown;
+  xUrl?: unknown;
+  instagramUrl?: unknown;
+};
+
+function optionalText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function isSocialUrl(value: string, hosts: string[]) {
+  if (!value) return true;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:'
+      && hosts.includes(url.hostname.toLowerCase())
+      && url.pathname.split('/').filter(Boolean).length === 1;
+  } catch {
+    return false;
+  }
+}
+
+export async function PATCH(request: Request) {
+  const supabase = createRouteHandlerClient();
+  const { data: { user }, error: authError } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    return NextResponse.json({ error: 'ログインが必要です。' }, { status: 401 });
+  }
+
+  let input: ProfileInput;
+  try {
+    input = await request.json() as ProfileInput;
+  } catch {
+    return NextResponse.json({ error: '入力内容を読み取れませんでした。' }, { status: 400 });
+  }
+
+  const displayName = optionalText(input.displayName);
+  const bio = optionalText(input.bio);
+  const xUrl = optionalText(input.xUrl);
+  const instagramUrl = optionalText(input.instagramUrl);
+
+  if (!displayName || displayName.length > DISPLAY_NAME_MAX) {
+    return NextResponse.json({ error: `表示名は1〜${DISPLAY_NAME_MAX}文字で入力してください。` }, { status: 400 });
+  }
+  if (bio.length > BIO_MAX) {
+    return NextResponse.json({ error: `一言は${BIO_MAX}文字以内で入力してください。` }, { status: 400 });
+  }
+  if (xUrl.length > URL_MAX || !isSocialUrl(xUrl, ['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com'])) {
+    return NextResponse.json({ error: 'XのプロフィールURLを https://x.com/ユーザー名 の形で入力してください。' }, { status: 400 });
+  }
+  if (instagramUrl.length > URL_MAX || !isSocialUrl(instagramUrl, ['instagram.com', 'www.instagram.com'])) {
+    return NextResponse.json({ error: 'InstagramのプロフィールURLを https://instagram.com/ユーザー名 の形で入力してください。' }, { status: 400 });
+  }
+
+  const { error } = await supabase.rpc('update_own_public_profile', {
+    p_display_name: displayName,
+    p_bio: bio || null,
+    p_x_url: xUrl || null,
+    p_instagram_url: instagramUrl || null,
+  });
+
+  if (error) {
+    console.error('Failed to update public profile:', error);
+    return NextResponse.json({ error: 'プロフィールを保存できませんでした。' }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/src/app/users/[userId]/visits/page.tsx
+++ b/src/app/users/[userId]/visits/page.tsx
@@ -112,6 +112,8 @@ export default async function UserVisitsPage({ params }: PageProps) {
 
   if (!data) notFound();
   const isOwner = authResult.data.user?.id === data.authUid;
+  const xUrl = safeSocialUrl(data.xUrl, ['x.com', 'www.x.com', 'twitter.com', 'www.twitter.com']);
+  const instagramUrl = safeSocialUrl(data.instagramUrl, ['instagram.com', 'www.instagram.com']);
 
   const pageUrl = getPageUrl(data.userId);
   const shareText = userVisitsShareText(data.displayName, data.totalVisits, data.prefectureCount);
@@ -163,20 +165,25 @@ export default async function UserVisitsPage({ params }: PageProps) {
             <h1 className="text-3xl font-extrabold leading-tight tracking-normal text-[#4F3828] sm:text-5xl">
               {data.displayName}のスタンプ帳
             </h1>
-            <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[#6A4D36] sm:text-base">
-              {data.bio || '公開設定の訪問記録のみを表示しています。'}
+            {data.bio && (
+              <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[#6A4D36] sm:text-base">
+                {data.bio}
+              </p>
+            )}
+            <p className={`${data.bio ? 'mt-1' : 'mt-3'} max-w-2xl text-xs font-medium leading-5 text-[#6A4D36]/80 sm:text-sm`}>
+              公開設定の訪問記録のみを表示しています。
             </p>
 
-            {(data.xUrl || data.instagramUrl) && (
+            {(xUrl || instagramUrl) && (
               <div className="mt-4 flex flex-wrap gap-2">
-                {data.xUrl && <SocialLink href={data.xUrl} label="X" icon={<span className="text-sm font-black">X</span>} />}
-                {data.instagramUrl && <SocialLink href={data.instagramUrl} label="Instagram" icon={<Instagram className="h-4 w-4" />} />}
+                {xUrl && <SocialLink href={xUrl} label="X" icon={<span className="text-sm font-black">X</span>} />}
+                {instagramUrl && <SocialLink href={instagramUrl} label="Instagram" icon={<Instagram className="h-4 w-4" />} />}
               </div>
             )}
 
             {isOwner && (
               <PublicProfileEditor
-                displayName={data.displayName}
+                displayName={data.editableDisplayName}
                 bio={data.bio}
                 xUrl={data.xUrl}
                 instagramUrl={data.instagramUrl}
@@ -311,6 +318,16 @@ function SocialLink({ href, label, icon }: { href: string; label: string; icon: 
       <ExternalLink className="h-3 w-3 opacity-60" />
     </a>
   );
+}
+
+function safeSocialUrl(value: string | null, allowedHosts: string[]) {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' && allowedHosts.includes(url.hostname) ? url.toString() : null;
+  } catch {
+    return null;
+  }
 }
 
 function HeroStat({ label, value }: { label: string; value: string }) {

--- a/src/app/users/[userId]/visits/page.tsx
+++ b/src/app/users/[userId]/visits/page.tsx
@@ -1,12 +1,14 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { ArrowLeft, Camera, MapPin, Stamp } from 'lucide-react';
+import { ArrowLeft, Camera, ExternalLink, Instagram, MapPin, Stamp } from 'lucide-react';
 import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
+import PublicProfileEditor from '@/components/users/PublicProfileEditor';
 import { SITE_NAME, SITE_URL } from '@/lib/constants';
 import { formatDateJa } from '@/lib/date';
 import { PublicVisit, loadPublicUserVisits } from '@/lib/user-public-visits';
+import { createServerClient } from '@/lib/supabase/server';
 
 type PageProps = {
   params: {
@@ -53,9 +55,13 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 }
 
 export default async function UserVisitsPage({ params }: PageProps) {
-  const data = await loadPublicUserVisits(params.userId);
+  const [data, authResult] = await Promise.all([
+    loadPublicUserVisits(params.userId),
+    createServerClient().auth.getUser(),
+  ]);
 
   if (!data) notFound();
+  const isOwner = authResult.data.user?.id === data.authUid;
 
   return (
     <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
@@ -81,8 +87,24 @@ export default async function UserVisitsPage({ params }: PageProps) {
               {data.displayName}のスタンプ帳
             </h1>
             <p className="mt-3 max-w-2xl text-sm font-bold leading-6 text-[#6A4D36] sm:text-base">
-              公開設定の訪問記録のみを表示しています。
+              {data.bio || '公開設定の訪問記録のみを表示しています。'}
             </p>
+
+            {(data.xUrl || data.instagramUrl) && (
+              <div className="mt-4 flex flex-wrap gap-2">
+                {data.xUrl && <SocialLink href={data.xUrl} label="X" icon={<span className="text-sm font-black">X</span>} />}
+                {data.instagramUrl && <SocialLink href={data.instagramUrl} label="Instagram" icon={<Instagram className="h-4 w-4" />} />}
+              </div>
+            )}
+
+            {isOwner && (
+              <PublicProfileEditor
+                displayName={data.displayName}
+                bio={data.bio}
+                xUrl={data.xUrl}
+                instagramUrl={data.instagramUrl}
+              />
+            )}
 
             <div className="mt-6 grid gap-3 sm:grid-cols-2">
               <HeroStat label="訪問数" value={`${data.totalVisits}`} />
@@ -114,6 +136,16 @@ export default async function UserVisitsPage({ params }: PageProps) {
 
       <BottomNav />
     </div>
+  );
+}
+
+function SocialLink({ href, label, icon }: { href: string; label: string; icon: React.ReactNode }) {
+  return (
+    <a href={href} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 rounded-full border border-[#8C6A4A]/25 bg-white/75 px-3 py-1.5 text-xs font-extrabold text-[#4F3828] transition hover:bg-white">
+      {icon}
+      {label}
+      <ExternalLink className="h-3 w-3 opacity-60" />
+    </a>
   );
 }
 

--- a/src/components/users/PublicProfileEditor.tsx
+++ b/src/components/users/PublicProfileEditor.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+import { Check, Loader2, Pencil, X } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+type Props = {
+  displayName: string;
+  bio: string | null;
+  xUrl: string | null;
+  instagramUrl: string | null;
+};
+
+export default function PublicProfileEditor({ displayName, bio, xUrl, instagramUrl }: Props) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSaving(true);
+    setError('');
+    setSaved(false);
+
+    const form = new FormData(event.currentTarget);
+    let response: Response;
+    try {
+      response = await fetch('/api/user/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          displayName: form.get('displayName'),
+          bio: form.get('bio'),
+          xUrl: form.get('xUrl'),
+          instagramUrl: form.get('instagramUrl'),
+        }),
+      });
+    } catch {
+      setSaving(false);
+      setError('通信に失敗しました。時間をおいてもう一度お試しください。');
+      return;
+    }
+    const result = await response.json().catch(() => ({}));
+    setSaving(false);
+
+    if (!response.ok) {
+      setError(result.error || 'プロフィールを保存できませんでした。');
+      return;
+    }
+
+    setSaved(true);
+    setOpen(false);
+    router.refresh();
+  }
+
+  if (!open) {
+    return (
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={() => { setOpen(true); setSaved(false); }}
+          className="inline-flex items-center gap-2 rounded-full border border-[#8C6A4A]/30 bg-white/75 px-3 py-1.5 text-xs font-extrabold text-[#4F3828] transition hover:bg-white"
+        >
+          <Pencil className="h-3.5 w-3.5" />
+          プロフィールを編集
+        </button>
+        {saved && <span className="inline-flex items-center gap-1 text-xs font-bold text-[#39715A]"><Check className="h-3.5 w-3.5" />保存しました</span>}
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-5 rounded-[8px] border border-[#8C6A4A]/20 bg-white/80 p-4" aria-label="公開プロフィール編集">
+      <div className="flex items-center justify-between">
+        <h2 className="font-extrabold text-[#4F3828]">公開プロフィール</h2>
+        <button type="button" onClick={() => setOpen(false)} className="rounded-full p-1.5 text-[#6A4D36] hover:bg-[#F6EEDC]" aria-label="編集を閉じる">
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+      <div className="mt-3 grid gap-3">
+        <Field label="表示名" name="displayName" defaultValue={displayName} maxLength={40} required />
+        <label className="grid gap-1 text-xs font-bold text-[#6A4D36]">
+          一言
+          <textarea name="bio" defaultValue={bio || ''} maxLength={160} rows={3} placeholder="ポケふた巡りについて一言" className="resize-none rounded-[7px] border border-[#8C6A4A]/25 bg-white px-3 py-2 text-sm font-medium text-[#2A2A2A] outline-none focus:border-[#B5483C]" />
+        </label>
+        <Field label="X URL" name="xUrl" type="url" defaultValue={xUrl || ''} maxLength={300} placeholder="https://x.com/username" inputMode="url" />
+        <Field label="Instagram URL" name="instagramUrl" type="url" defaultValue={instagramUrl || ''} maxLength={300} placeholder="https://instagram.com/username" inputMode="url" />
+      </div>
+      {error && <p role="alert" className="mt-3 text-xs font-bold text-[#B5483C]">{error}</p>}
+      <button type="submit" disabled={saving} className="mt-4 inline-flex items-center gap-2 rounded-full bg-[#B5483C] px-4 py-2 text-xs font-extrabold text-white transition hover:bg-[#963C33] disabled:opacity-60">
+        {saving && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+        {saving ? '保存中…' : '保存する'}
+      </button>
+    </form>
+  );
+}
+
+function Field({ label, ...props }: React.InputHTMLAttributes<HTMLInputElement> & { label: string }) {
+  return (
+    <label className="grid gap-1 text-xs font-bold text-[#6A4D36]">
+      {label}
+      <input {...props} className="rounded-[7px] border border-[#8C6A4A]/25 bg-white px-3 py-2 text-sm font-medium text-[#2A2A2A] outline-none focus:border-[#B5483C]" />
+    </label>
+  );
+}

--- a/src/lib/user-prefecture-progress.ts
+++ b/src/lib/user-prefecture-progress.ts
@@ -61,6 +61,9 @@ type VisitProgressRow = {
 export type AppUserProgressRow = {
   auth_uid: string;
   display_name: string | null;
+  bio?: string | null;
+  x_url?: string | null;
+  instagram_url?: string | null;
 };
 
 export const FALLBACK_DISPLAY_NAME = 'トレーナー';

--- a/src/lib/user-public-visits.ts
+++ b/src/lib/user-public-visits.ts
@@ -28,6 +28,7 @@ export type PublicUserVisits = {
   userId: string;
   authUid: string;
   displayName: string;
+  editableDisplayName: string;
   bio: string | null;
   xUrl: string | null;
   instagramUrl: string | null;
@@ -194,6 +195,7 @@ async function loadPublicUserVisitsImpl(userId: string): Promise<PublicUserVisit
     userId: trimmedUserId,
     authUid: appUserRow.auth_uid,
     displayName,
+    editableDisplayName: appUserRow.display_name || '',
     bio: appUserRow.bio || null,
     xUrl: appUserRow.x_url || null,
     instagramUrl: appUserRow.instagram_url || null,

--- a/src/lib/user-public-visits.ts
+++ b/src/lib/user-public-visits.ts
@@ -26,7 +26,11 @@ export type PublicVisit = {
 
 export type PublicUserVisits = {
   userId: string;
+  authUid: string;
   displayName: string;
+  bio: string | null;
+  xUrl: string | null;
+  instagramUrl: string | null;
   totalVisits: number;
   prefectureCount: number;
   visits: PublicVisit[];
@@ -188,7 +192,11 @@ async function loadPublicUserVisitsImpl(userId: string): Promise<PublicUserVisit
 
   return {
     userId: trimmedUserId,
+    authUid: appUserRow.auth_uid,
     displayName,
+    bio: appUserRow.bio || null,
+    xUrl: appUserRow.x_url || null,
+    instagramUrl: appUserRow.instagram_url || null,
     totalVisits,
     prefectureCount: prefectureSet.size,
     visits: publicVisits,

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -27,6 +27,10 @@ export interface Database {
           auth_uid: string;
           display_name: string | null;
           avatar_url: string | null;
+          bio: string | null;
+          x_url: string | null;
+          instagram_url: string | null;
+          profile_is_customized: boolean;
           created_at: string;
           updated_at: string;
           all_prefectures_completed_at: string | null;
@@ -37,12 +41,20 @@ export interface Database {
           auth_uid: string;
           display_name?: string | null;
           avatar_url?: string | null;
+          bio?: string | null;
+          x_url?: string | null;
+          instagram_url?: string | null;
+          profile_is_customized?: boolean;
           all_prefectures_completed_at?: string | null;
           all_prefectures_outdated_at?: string | null;
         };
         Update: {
           display_name?: string | null;
           avatar_url?: string | null;
+          bio?: string | null;
+          x_url?: string | null;
+          instagram_url?: string | null;
+          profile_is_customized?: boolean;
           all_prefectures_completed_at?: string | null;
           all_prefectures_outdated_at?: string | null;
         };
@@ -658,6 +670,25 @@ export interface Database {
           auth_uid: string;
           display_name: string | null;
         }[];
+      };
+      get_public_user_info: {
+        Args: { p_user_id: string };
+        Returns: {
+          auth_uid: string;
+          display_name: string | null;
+          bio: string | null;
+          x_url: string | null;
+          instagram_url: string | null;
+        }[];
+      };
+      update_own_public_profile: {
+        Args: {
+          p_display_name: string;
+          p_bio: string | null;
+          p_x_url: string | null;
+          p_instagram_url: string | null;
+        };
+        Returns: undefined;
       };
     };
   };


### PR DESCRIPTION
## What changed

- add editable public profile fields for display name, bio, X URL, and Instagram URL
- show the public profile on `/users/[userId]/visits`
- expose the edit form only to the signed-in profile owner
- add an authenticated profile update API and database function scoped to `auth.uid()`
- keep manually edited display names from being overwritten by login metadata
- document the profile-data security rules in `AGENTS.md`

## Why

Users need a small public profile attached to their shared stamp book, while preserving the existing privacy boundary around `app_user`.

## Validation

- `npm run type-check`
- `npm run build`
- `git diff --check`
- logged-out browser smoke check: edit controls hidden and no horizontal overflow
- unauthenticated profile update returns `401`

## Notes

- apply `database/migrations/025_add_public_user_profiles.sql` before enabling profile saves
- `npm run lint` currently opens Next.js's interactive ESLint setup because this repository has no ESLint configuration
