### PR TITLE
fix: /api/site-stats をforce-dynamic化 — Amplifyで統計がビルド時値に凍結される問題を修正

### DIFF
--- a/src/app/api/site-stats/route.ts
+++ b/src/app/api/site-stats/route.ts
@@ -7,7 +7,15 @@ import { fetchSiteStatsSnapshot } from '@/lib/manhole-snapshot';
  * data.pokefuta.com の静的スナップショット（bake-app-data.yml が日次生成）を
  * そのまま返す。リクエスト毎の Supabase 読み出し（旧実装では auth admin API の
  * 全ユーザー走査まで毎回行っていた）を排除するための構成。
+ *
+ * force-dynamic が無いとこのルートはビルド時に静的プリレンダーされ、
+ * Amplify では ISR 再検証が効かないためデプロイ時点の値で凍結する
+ * （日次 bake が反映されず古い統計を返し続ける）。ルート自体を毎回実行し、
+ * 鮮度は内側の fetch の revalidate（1時間）に任せる。Supabase は読まないので
+ * egress は増えない。
  */
+export const dynamic = 'force-dynamic';
+
 export async function GET() {
   const stats = await fetchSiteStatsSnapshot();
 


### PR DESCRIPTION
## 問題
トップページの「いま **280** 枚の写真が集まっています / 残り **279** 件」が古いまま更新されない。

## 原因調査
| コンポーネント | 状態 |
|---|---|
| bake-app-data.yml (GitHub Action) | ✅ 正常。data.pokefuta.com は 7/17 分 (posts 370) を配信 |
| /api/manholes (本番) | ✅ 最新。request.url 参照で自動的に動的ルート |
| **/api/site-stats (本番)** | ❌ **7/14 (posts 280) で凍結** |

- ルートが `request` を参照しないため Next.js がビルド時に静的プリレンダー
- Amplify は Route Handler の ISR バックグラウンド再検証が効かず、デプロイ時点の値のまま固定
- 本番ヘッダで `x-nextjs-cache: HIT` を確認

## 対応
`export const dynamic = 'force-dynamic'` を追加してルートを毎回実行。鮮度は内側 fetch の `revalidate: 3600`(1時間)に任せる。**Supabase 読み出しは無いので egress は増えない**(既存設計の意図を維持)。

## 検証
- `npm run type-check` ✅
- `npm run build` → ルートが `○`(Static) → `ƒ`(Dynamic) に変化 ✅
- 本番ビルドをローカル起動し `/api/site-stats` が最新スナップショット (posts 370, generated_at 2026-07-17) を返すことを確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)