### PR TITLE
feat: デザインマンホール投稿の個別ページとSEO基盤

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -62,6 +62,13 @@ const nextConfig = {
       '/users/[userId]/prefectures/opengraph-image': [
         './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
       ],
+      // フォントに加えテンプレート一式を含める（pokefuta-ogp-template の
+      // モジュールロード時に template/background を読むため）
+      '/design-manholes/[id]/opengraph-image': [
+        './public/ogp/fonts/NotoSansCJKjp-Bold.otf',
+        './public/ogp/pokefuta_ogp_template.svg',
+        './public/ogp/pokefuta_ogp_background_1200x630.png',
+      ],
     },
   },
   images: {

--- a/package.json
+++ b/package.json
@@ -53,5 +53,8 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "allowScripts": {
+    "sharp@0.32.6": true
   }
 }

--- a/src/app/design-manholes/MapSection.tsx
+++ b/src/app/design-manholes/MapSection.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { DesignManhole } from '@/types/database';
+
+// Leaflet は import 時に window を参照するため、サーバーコンポーネントの
+// ページからは必ずこのラッパー経由（ssr: false）で読み込む
+const DesignManholeMap = dynamic(
+  () => import('@/components/DesignManhole/DesignManholeMap'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-72 w-full items-center justify-center rounded-lg bg-[#EFE5CE] sm:h-96">
+        <span className="text-sm text-[#7B63A8]">地図を読み込み中...</span>
+      </div>
+    ),
+  }
+);
+
+export default function MapSection({ designManholes }: { designManholes: DesignManhole[] }) {
+  return <DesignManholeMap designManholes={designManholes} />;
+}

--- a/src/app/design-manholes/[id]/opengraph-image/route.ts
+++ b/src/app/design-manholes/[id]/opengraph-image/route.ts
@@ -2,6 +2,8 @@ import { renderDesignManholeOgpTemplate, renderOgpFallback } from '@/lib/pokefut
 import { loadDesignManholeForOgp } from '@/lib/design-manhole-ogp';
 
 export const runtime = 'nodejs';
+// hidden 化した投稿のOGPが Data Cache 経由で配信され続けないようにする
+export const fetchCache = 'force-no-store';
 
 function buildFallback(): Promise<Buffer> {
   return renderOgpFallback({

--- a/src/app/design-manholes/[id]/opengraph-image/route.ts
+++ b/src/app/design-manholes/[id]/opengraph-image/route.ts
@@ -1,0 +1,49 @@
+import { renderDesignManholeOgpTemplate, renderOgpFallback } from '@/lib/pokefuta-ogp-template';
+import { loadDesignManholeForOgp } from '@/lib/design-manhole-ogp';
+
+export const runtime = 'nodejs';
+
+function buildFallback(): Promise<Buffer> {
+  return renderOgpFallback({
+    title: 'みんなのデザインマンホール',
+    subtitle: 'ご当地デザインマンホールをみんなで集めよう',
+  });
+}
+
+export async function GET(
+  _request: Request,
+  { params }: { params: { id: string } }
+) {
+  const designManhole = await loadDesignManholeForOgp(params.id, { includeSignedUrl: true });
+
+  if (!designManhole?.signed_url) {
+    return new Response(await buildFallback() as unknown as BodyInit, {
+      headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
+    });
+  }
+
+  try {
+    const imageResponse = await fetch(designManhole.signed_url);
+    if (!imageResponse.ok) throw new Error(`Photo fetch failed: ${imageResponse.status}`);
+
+    const imageBuffer = Buffer.from(await imageResponse.arrayBuffer());
+
+    const png = await renderDesignManholeOgpTemplate({
+      photoBuffer: imageBuffer,
+      title: designManhole.title || 'デザインマンホール',
+      submitterName: designManhole.submitter_name,
+    });
+
+    return new Response(png as unknown as BodyInit, {
+      headers: {
+        'Content-Type': 'image/png',
+        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+      },
+    });
+  } catch (error) {
+    console.error('Failed to render design manhole OGP:', error);
+    return new Response(await buildFallback() as unknown as BodyInit, {
+      headers: { 'Content-Type': 'image/png', 'Cache-Control': 'public, max-age=300' },
+    });
+  }
+}

--- a/src/app/design-manholes/[id]/opengraph-image/route.ts
+++ b/src/app/design-manholes/[id]/opengraph-image/route.ts
@@ -39,7 +39,8 @@ export async function GET(
     return new Response(png as unknown as BodyInit, {
       headers: {
         'Content-Type': 'image/png',
-        'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+        // hidden 化した投稿の写真がCDNに残り続けないよう短めにする（モデレーション優先）
+        'Cache-Control': 'public, max-age=300, stale-while-revalidate=900',
       },
     });
   } catch (error) {

--- a/src/app/design-manholes/[id]/page.tsx
+++ b/src/app/design-manholes/[id]/page.tsx
@@ -1,0 +1,215 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Plus, Share2 } from 'lucide-react';
+import Header from '@/components/Header';
+import BottomNav from '@/components/BottomNav';
+import MapSection from '../MapSection';
+import { loadDesignManholeForOgp } from '@/lib/design-manhole-ogp';
+import { buildXShareUrl, buildLineShareUrl, designManholeShareText } from '@/lib/share';
+import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
+import type { DesignManhole } from '@/types/database';
+
+type Props = {
+  params: { id: string };
+};
+
+export const dynamic = 'force-dynamic';
+
+const NOT_FOUND_METADATA: Metadata = {
+  title: `投稿が見つかりません | ${SITE_NAME}`,
+  robots: { index: false, follow: false },
+};
+
+const displayTitle = (title: string | null) => title || 'デザインマンホール';
+
+const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+};
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const designManhole = await loadDesignManholeForOgp(params.id);
+  if (!designManhole) {
+    return NOT_FOUND_METADATA;
+  }
+
+  const pageUrl = `${SITE_URL}/design-manholes/${designManhole.id}`;
+  const ogImageUrl = `${SITE_URL}/design-manholes/${designManhole.id}/opengraph-image?v=${OGP_IMAGE_VERSION}`;
+  const title = `${displayTitle(designManhole.title)} | みんなのデザインマンホール | ${SITE_NAME}`;
+  const description =
+    designManhole.description ||
+    `${designManhole.submitter_name ? `${designManhole.submitter_name}さんが見つけた` : 'みんなで集める'}ご当地デザインマンホール。ポケふた以外のオンリーワンなマンホールのコレクション。`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: pageUrl },
+    openGraph: {
+      type: 'website',
+      title,
+      description,
+      url: pageUrl,
+      siteName: SITE_NAME,
+      images: [{ url: ogImageUrl, width: 1200, height: 630, alt: title }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title,
+      description,
+      images: [ogImageUrl],
+    },
+  };
+}
+
+export default async function Page({ params }: Props) {
+  const designManhole = await loadDesignManholeForOgp(params.id);
+  if (!designManhole) {
+    notFound();
+  }
+
+  const title = displayTitle(designManhole.title);
+  const pageUrl = `${SITE_URL}/design-manholes/${designManhole.id}`;
+  const photoUrl = `/api/design-manholes/${designManhole.id}/photo`;
+  const shareText = designManholeShareText(designManhole.title);
+  const xShareUrl = buildXShareUrl(shareText, pageUrl, ['デザインマンホール', 'マンホール'], {
+    includeDefaultHashtags: false,
+  });
+  const lineShareUrl = buildLineShareUrl(pageUrl);
+
+  // DetailMap（DesignManholeMap）は一覧APIの公開型を受けるので同じ形に揃える
+  const mapItem: DesignManhole = {
+    id: designManhole.id,
+    title: designManhole.title,
+    description: designManhole.description,
+    submitter_name: designManhole.submitter_name,
+    latitude: designManhole.latitude,
+    longitude: designManhole.longitude,
+    width: designManhole.width,
+    height: designManhole.height,
+    created_at: designManhole.created_at,
+    photo_url: `${photoUrl}?size=small`,
+  };
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'ImageObject',
+        contentUrl: `${SITE_URL}${photoUrl}`,
+        name: title,
+        description: designManhole.description || undefined,
+        creditText: designManhole.submitter_name || undefined,
+        uploadDate: designManhole.created_at,
+        contentLocation: {
+          '@type': 'Place',
+          geo: {
+            '@type': 'GeoCoordinates',
+            latitude: designManhole.latitude,
+            longitude: designManhole.longitude,
+          },
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'みんなのデザインマンホール',
+            item: `${SITE_URL}/design-manholes`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: title,
+            item: pageUrl,
+          },
+        ],
+      },
+    ],
+  };
+
+  return (
+    <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <script
+        type="application/ld+json"
+        // title 等はユーザー入力なので、</script> 挿入によるXSSを防ぐため < をエスケープする
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+      />
+      <Header title="デザインマンホール" showDescriptionLink={false} />
+
+      <main className="mx-auto max-w-3xl px-4 pb-8 pt-5 sm:pt-8">
+        <nav className="text-xs text-[#2A2A2A]/60">
+          <Link href="/design-manholes" className="hover:underline">
+            みんなのデザインマンホール
+          </Link>
+          <span className="mx-1">/</span>
+          <span>{title}</span>
+        </nav>
+
+        <article className="mt-4 overflow-hidden rounded-lg border border-[#7B63A8]/15 bg-white shadow-sm">
+          <div className="bg-[#EFE5CE]">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={photoUrl}
+              alt={title}
+              className="mx-auto max-h-[70vh] w-full object-contain"
+            />
+          </div>
+          <div className="p-4 sm:p-5">
+            <h1 className="text-lg font-bold sm:text-xl">{title}</h1>
+            <p className="mt-1 text-xs text-[#2A2A2A]/50">
+              {designManhole.submitter_name ? `${designManhole.submitter_name} ・ ` : ''}
+              {formatDate(designManhole.created_at)}
+            </p>
+            {designManhole.description && (
+              <p className="mt-3 whitespace-pre-wrap text-sm text-[#2A2A2A]/80">
+                {designManhole.description}
+              </p>
+            )}
+
+            <div className="mt-4 flex flex-wrap items-center gap-2">
+              <a
+                href={xShareUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 rounded-lg bg-[#2A2A2A] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#444444]"
+              >
+                <Share2 className="h-4 w-4" />
+                Xでシェア
+              </a>
+              <a
+                href={lineShareUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 rounded-lg bg-[#06C755] px-4 py-2 text-sm font-bold text-white transition hover:bg-[#05B34C]"
+              >
+                LINEで送る
+              </a>
+            </div>
+          </div>
+        </article>
+
+        <div className="mt-5">
+          <MapSection designManholes={[mapItem]} />
+        </div>
+
+        <div className="mt-6 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-5 text-center">
+          <p className="text-sm text-[#2A2A2A]/70">
+            あなたの街のデザインマンホールも投稿してみませんか？
+          </p>
+          <Link
+            href="/design-manholes/new"
+            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+          >
+            <Plus className="h-4 w-4" />
+            投稿する
+          </Link>
+        </div>
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/app/design-manholes/[id]/page.tsx
+++ b/src/app/design-manholes/[id]/page.tsx
@@ -7,6 +7,7 @@ import BottomNav from '@/components/BottomNav';
 import MapSection from '../MapSection';
 import { loadDesignManholeForOgp } from '@/lib/design-manhole-ogp';
 import { buildXShareUrl, buildLineShareUrl, designManholeShareText } from '@/lib/share';
+import { formatDateJaJst } from '@/lib/date';
 import { OGP_IMAGE_VERSION, SITE_NAME, SITE_URL } from '@/lib/constants';
 import type { DesignManhole } from '@/types/database';
 
@@ -15,6 +16,9 @@ type Props = {
 };
 
 export const dynamic = 'force-dynamic';
+// supabase-js の GET が Data Cache に乗ると hidden 化した投稿のページが
+// 404 にならず残り続けるため無効化（/api/design-manholes と同じ理由）
+export const fetchCache = 'force-no-store';
 
 const NOT_FOUND_METADATA: Metadata = {
   title: `投稿が見つかりません | ${SITE_NAME}`,
@@ -22,11 +26,6 @@ const NOT_FOUND_METADATA: Metadata = {
 };
 
 const displayTitle = (title: string | null) => title || 'デザインマンホール';
-
-const formatDate = (iso: string) => {
-  const d = new Date(iso);
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
-};
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const designManhole = await loadDesignManholeForOgp(params.id);
@@ -161,7 +160,7 @@ export default async function Page({ params }: Props) {
             <h1 className="text-lg font-bold sm:text-xl">{title}</h1>
             <p className="mt-1 text-xs text-[#2A2A2A]/50">
               {designManhole.submitter_name ? `${designManhole.submitter_name} ・ ` : ''}
-              {formatDate(designManhole.created_at)}
+              {formatDateJaJst(designManhole.created_at)}
             </p>
             {designManhole.description && (
               <p className="mt-3 whitespace-pre-wrap text-sm text-[#2A2A2A]/80">

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -5,11 +5,13 @@ import Link from 'next/link';
 import { useDropzone } from 'react-dropzone';
 import exifr from 'exifr';
 import imageCompression from 'browser-image-compression';
-import { AlertCircle, Camera, CheckCircle, Upload } from 'lucide-react';
+import { AlertCircle, Camera, CheckCircle, Share2, Upload } from 'lucide-react';
 import Header from '@/components/Header';
 import BottomNav from '@/components/BottomNav';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { isValidCoordinates } from '@/lib/location';
+import { buildXShareUrl, designManholeShareText } from '@/lib/share';
+import { SITE_URL } from '@/lib/constants';
 
 type GpsSource = 'exif' | null;
 
@@ -33,6 +35,8 @@ export default function DesignManholeNewPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState(false);
+  const [postedId, setPostedId] = useState<string | null>(null);
+  const [postedTitle, setPostedTitle] = useState<string | null>(null);
 
   // ニックネーム初期値はログインユーザーの表示名（ページ自体は middleware が保護）
   useEffect(() => {
@@ -181,6 +185,8 @@ export default function DesignManholeNewPage() {
         throw new Error(data?.error || '投稿に失敗しました。時間をおいて再度お試しください');
       }
 
+      setPostedId(data?.design_manhole?.id ?? null);
+      setPostedTitle(data?.design_manhole?.title ?? null);
       setDone(true);
     } catch (err: any) {
       setError(err?.message || '投稿に失敗しました');
@@ -190,6 +196,16 @@ export default function DesignManholeNewPage() {
   };
 
   if (done) {
+    const postedPageUrl = postedId
+      ? `${SITE_URL}/design-manholes/${postedId}`
+      : `${SITE_URL}/design-manholes`;
+    const shareUrl = buildXShareUrl(
+      `${designManholeShareText(postedTitle)}\nみんなのデザインマンホールに投稿しました！`,
+      postedPageUrl,
+      ['デザインマンホール', 'マンホール'],
+      { includeDefaultHashtags: false }
+    );
+
     return (
       <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
         <Header title="デザインマンホール投稿" showDescriptionLink={false} />
@@ -198,14 +214,33 @@ export default function DesignManholeNewPage() {
           <h1 className="mt-4 text-xl font-bold">投稿ありがとうございます！</h1>
           <p className="mt-2 text-sm text-[#2A2A2A]/70">
             投稿されたデザインマンホールは公開されました。
+            翌日には <a href="https://data.pokefuta.com/gmanhole_map.html" target="_blank" rel="noopener noreferrer" className="text-[#7B63A8] underline hover:opacity-80">キャラマンホールマップ</a> にも掲載されます。
           </p>
-          <div className="mt-6 flex justify-center gap-3">
-            <Link
-              href="/design-manholes"
-              className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
-            >
-              一覧を見る
-            </Link>
+          <a
+            href={shareUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-flex items-center gap-1.5 rounded-lg bg-[#2A2A2A] px-6 py-3 text-sm font-bold text-white transition hover:bg-[#444444]"
+          >
+            <Share2 className="h-4 w-4" />
+            Xでシェアする
+          </a>
+          <div className="mt-4 flex justify-center gap-3">
+            {postedId ? (
+              <Link
+                href={`/design-manholes/${postedId}`}
+                className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+              >
+                自分の投稿ページを見る
+              </Link>
+            ) : (
+              <Link
+                href="/design-manholes"
+                className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+              >
+                一覧を見る
+              </Link>
+            )}
             <button
               type="button"
               onClick={() => window.location.reload()}

--- a/src/app/design-manholes/page.tsx
+++ b/src/app/design-manholes/page.tsx
@@ -5,11 +5,16 @@ import Header from '@/components/Header';
 import BottomNav from '@/components/BottomNav';
 import MapSection from './MapSection';
 import { loadPublishedDesignManholes } from '@/lib/design-manhole-ogp';
+import { formatDateJaJst } from '@/lib/date';
 import { OGP_IMAGE_URL, SITE_NAME, SITE_URL } from '@/lib/constants';
+import type { DesignManhole } from '@/types/database';
 
 // Amplify ではビルド時静的化で内容が凍結する事故があるため（/api/site-stats と同じ）、
 // 常にサーバーレンダリングする。キャッシュは CDN 側に任せる
 export const dynamic = 'force-dynamic';
+// supabase-js の PostgREST GET が Next の Data Cache に乗ると新規投稿が一覧に
+// 反映されず hidden 行も消えない（/api/design-manholes と同じ理由）
+export const fetchCache = 'force-no-store';
 
 const PAGE_URL = `${SITE_URL}/design-manholes`;
 const PAGE_TITLE = `みんなのデザインマンホール | ${SITE_NAME}`;
@@ -34,11 +39,6 @@ export const metadata: Metadata = {
     description: PAGE_DESCRIPTION,
     images: [OGP_IMAGE_URL],
   },
-};
-
-const formatDate = (iso: string) => {
-  const d = new Date(iso);
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
 };
 
 // tracker (data.pokefuta.com/design_manhole.html) の「こんな1枚を待っています」と同じ文言
@@ -78,7 +78,14 @@ function WantedSection() {
 }
 
 export default async function DesignManholesPage() {
-  const designManholes = await loadPublishedDesignManholes(200);
+  let designManholes: DesignManhole[] = [];
+  let loadError = false;
+  try {
+    designManholes = await loadPublishedDesignManholes(200);
+  } catch (error) {
+    console.error('Failed to load design manholes for listing:', error);
+    loadError = true;
+  }
 
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -121,7 +128,11 @@ export default async function DesignManholesPage() {
           </Link>
         </div>
 
-        {designManholes.length === 0 ? (
+        {loadError ? (
+          <p className="mt-5 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
+            一覧の取得に失敗しました。時間をおいて再度お試しください。
+          </p>
+        ) : designManholes.length === 0 ? (
           <div className="mt-5 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-8 text-center">
             <p className="text-sm text-[#2A2A2A]/70">
               まだ投稿がありません。最初の1枚を投稿してみませんか？
@@ -161,7 +172,7 @@ export default async function DesignManholesPage() {
                     </p>
                     <p className="mt-0.5 truncate text-xs text-[#2A2A2A]/50">
                       {dm.submitter_name ? `${dm.submitter_name} ・ ` : ''}
-                      {formatDate(dm.created_at)}
+                      {formatDateJaJst(dm.created_at)}
                     </p>
                   </div>
                 </Link>

--- a/src/app/design-manholes/page.tsx
+++ b/src/app/design-manholes/page.tsx
@@ -1,55 +1,107 @@
-'use client';
-
-import { useEffect, useState } from 'react';
+import type { Metadata } from 'next';
 import Link from 'next/link';
-import dynamic from 'next/dynamic';
 import { Plus } from 'lucide-react';
 import Header from '@/components/Header';
 import BottomNav from '@/components/BottomNav';
-import type { DesignManhole } from '@/types/database';
+import MapSection from './MapSection';
+import { loadPublishedDesignManholes } from '@/lib/design-manhole-ogp';
+import { OGP_IMAGE_URL, SITE_NAME, SITE_URL } from '@/lib/constants';
 
-const DesignManholeMap = dynamic(
-  () => import('@/components/DesignManhole/DesignManholeMap'),
-  {
-    ssr: false,
-    loading: () => (
-      <div className="flex h-72 w-full items-center justify-center rounded-lg bg-[#EFE5CE] sm:h-96">
-        <span className="text-sm text-[#7B63A8]">地図を読み込み中...</span>
-      </div>
-    ),
-  }
-);
+// Amplify ではビルド時静的化で内容が凍結する事故があるため（/api/site-stats と同じ）、
+// 常にサーバーレンダリングする。キャッシュは CDN 側に任せる
+export const dynamic = 'force-dynamic';
+
+const PAGE_URL = `${SITE_URL}/design-manholes`;
+const PAGE_TITLE = `みんなのデザインマンホール | ${SITE_NAME}`;
+const PAGE_DESCRIPTION =
+  'ポケふた以外の、オンリーワンなご当地デザインマンホールのコレクション。街のシンボルや市の花のデザイン蓋、カラーマンホールなど、みんなが見つけた1枚を地図と一覧で紹介。あなたの街の蓋も投稿できます。';
+
+export const metadata: Metadata = {
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  alternates: { canonical: PAGE_URL },
+  openGraph: {
+    type: 'website',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    siteName: SITE_NAME,
+    images: [{ url: OGP_IMAGE_URL, width: 1200, height: 630, alt: PAGE_TITLE }],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    images: [OGP_IMAGE_URL],
+  },
+};
 
 const formatDate = (iso: string) => {
   const d = new Date(iso);
   return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
 };
 
-export default function DesignManholesPage() {
-  const [designManholes, setDesignManholes] = useState<DesignManhole[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+// tracker (data.pokefuta.com/design_manhole.html) の「こんな1枚を待っています」と同じ文言
+const WANTED_EXAMPLES = [
+  { icon: '🏯', title: '街のシンボル・名所デザイン', note: '城・橋・祭りなど、その街ならではの蓋' },
+  { icon: '🌸', title: '市の花・木・鳥デザイン', note: '定番だけど地域ごとに全部違う定番蓋' },
+  { icon: '🎨', title: 'カラーマンホール', note: '色付きの蓋はそれだけでレア。見つけたらぜひ' },
+  { icon: '🚒', title: '消火栓・防火水槽のデザイン蓋', note: 'マンホール以外の丸い鉄蓋も大歓迎' },
+];
 
-  useEffect(() => {
-    const load = async () => {
-      try {
-        const res = await fetch('/api/design-manholes?limit=200');
-        const data = await res.json();
-        if (!res.ok || !data.success) {
-          throw new Error(data?.error || '一覧の取得に失敗しました');
-        }
-        setDesignManholes(data.design_manholes ?? []);
-      } catch (err: any) {
-        setError(err?.message || '一覧の取得に失敗しました');
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, []);
+function WantedSection() {
+  return (
+    <section className="mt-6 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-4 sm:p-5">
+      <h2 className="text-sm font-bold text-[#7B63A8]">こんな1枚を待っています</h2>
+      <ul className="mt-3 grid gap-2.5 sm:grid-cols-2">
+        {WANTED_EXAMPLES.map((example) => (
+          <li key={example.title} className="flex items-start gap-2.5">
+            <span aria-hidden="true" className="text-xl">{example.icon}</span>
+            <span className="text-sm">
+              <b>{example.title}</b>
+              <span className="mt-0.5 block text-xs text-[#2A2A2A]/60">{example.note}</span>
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-4 text-center">
+        <Link
+          href="/design-manholes/new"
+          className="inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+        >
+          <Plus className="h-4 w-4" />
+          投稿する
+        </Link>
+      </div>
+    </section>
+  );
+}
+
+export default async function DesignManholesPage() {
+  const designManholes = await loadPublishedDesignManholes(200);
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    name: 'みんなのデザインマンホール',
+    description: PAGE_DESCRIPTION,
+    url: PAGE_URL,
+    numberOfItems: designManholes.length,
+    itemListElement: designManholes.slice(0, 30).map((dm, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: dm.title || 'デザインマンホール',
+      url: `${PAGE_URL}/${dm.id}`,
+    })),
+  };
 
   return (
     <div className="min-h-screen safe-area-inset bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+      <script
+        type="application/ld+json"
+        // title はユーザー入力なので、</script> 挿入によるXSSを防ぐため < をエスケープする
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd).replace(/</g, '\\u003c') }}
+      />
       <Header title="デザインマンホール" showDescriptionLink={false} />
 
       <main className="mx-auto max-w-5xl px-4 pb-8 pt-5 sm:pt-8">
@@ -69,17 +121,7 @@ export default function DesignManholesPage() {
           </Link>
         </div>
 
-        {error && (
-          <p className="mt-5 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
-            {error}
-          </p>
-        )}
-
-        {loading ? (
-          <div className="mt-5 flex h-72 items-center justify-center rounded-lg bg-[#EFE5CE]">
-            <span className="text-sm text-[#7B63A8]">読み込み中...</span>
-          </div>
-        ) : designManholes.length === 0 ? (
+        {designManholes.length === 0 ? (
           <div className="mt-5 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-8 text-center">
             <p className="text-sm text-[#2A2A2A]/70">
               まだ投稿がありません。最初の1枚を投稿してみませんか？
@@ -94,14 +136,15 @@ export default function DesignManholesPage() {
         ) : (
           <>
             <div className="mt-5">
-              <DesignManholeMap designManholes={designManholes} />
+              <MapSection designManholes={designManholes} />
             </div>
 
             <div className="mt-6 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4">
               {designManholes.map((dm) => (
-                <div
+                <Link
                   key={dm.id}
-                  className="overflow-hidden rounded-lg border border-[#7B63A8]/15 bg-white shadow-sm"
+                  href={`/design-manholes/${dm.id}`}
+                  className="overflow-hidden rounded-lg border border-[#7B63A8]/15 bg-white shadow-sm transition hover:shadow-md"
                 >
                   <div className="aspect-square bg-[#EFE5CE]">
                     {/* eslint-disable-next-line @next/next/no-img-element */}
@@ -121,11 +164,13 @@ export default function DesignManholesPage() {
                       {formatDate(dm.created_at)}
                     </p>
                   </div>
-                </div>
+                </Link>
               ))}
             </div>
           </>
         )}
+
+        <WantedSection />
       </main>
 
       <BottomNav />

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -51,6 +51,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'daily',
       priority: 0.7,
     },
+    {
+      url: `${baseUrl}/design-manholes`,
+      lastModified,
+      changeFrequency: 'daily',
+      priority: 0.8,
+    },
   ];
 
   let dynamicPages: MetadataRoute.Sitemap = [];
@@ -85,5 +91,37 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     console.error('Error fetching manholes for sitemap:', error);
   }
 
-  return [...staticPages, ...dynamicPages];
+  let designManholePages: MetadataRoute.Sitemap = [];
+
+  try {
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+    if (supabaseUrl && supabaseKey && !supabaseUrl.includes('dummy')) {
+      const supabase = createClient<Database>(supabaseUrl, supabaseKey);
+
+      const { data: designManholes, error } = await supabase
+        .from('design_manhole')
+        .select('id, updated_at')
+        .eq('status', 'published')
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        throw error;
+      }
+
+      if (designManholes && designManholes.length > 0) {
+        designManholePages = designManholes.map((dm: { id: string; updated_at: string }) => ({
+          url: `${baseUrl}/design-manholes/${dm.id}`,
+          lastModified: new Date(dm.updated_at),
+          changeFrequency: 'monthly' as const,
+          priority: 0.7,
+        }));
+      }
+    }
+  } catch (error) {
+    console.error('Error fetching design manholes for sitemap:', error);
+  }
+
+  return [...staticPages, ...dynamicPages, ...designManholePages];
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,3 +1,15 @@
+// サーバーコンポーネント用。実行環境のタイムゾーン（本番はUTC）に依らずJSTの日付で表示する
+export const formatDateJaJst = (value: string) => {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '';
+  return new Intl.DateTimeFormat('ja-JP', {
+    timeZone: 'Asia/Tokyo',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }).format(date);
+};
+
 export const formatDateJa = (value: string) => {
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return '';

--- a/src/lib/design-manhole-ogp.ts
+++ b/src/lib/design-manhole-ogp.ts
@@ -1,0 +1,97 @@
+import 'server-only';
+import { createOgpSupabaseClients } from '@/lib/manhole-ogp';
+import { storage } from '@/lib/storage';
+import type { DesignManhole } from '@/types/database';
+
+// storage_key はサーバー内でのみ使い、クライアントへは渡さないこと
+export type DesignManholeForOgp = {
+  id: string;
+  title: string | null;
+  description: string | null;
+  submitter_name: string | null;
+  latitude: number;
+  longitude: number;
+  width: number | null;
+  height: number | null;
+  created_at: string;
+  storage_key: string;
+  signed_url?: string;
+};
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidDesignManholeId(id: string): boolean {
+  return UUID_PATTERN.test(id);
+}
+
+// 一覧ページのSSR用。/api/design-manholes GET と同じ公開カラムのみを返す
+// （exif / storage_key / created_by は絶対に含めない）
+export async function loadPublishedDesignManholes(limit = 200): Promise<DesignManhole[]> {
+  const clients = createOgpSupabaseClients();
+
+  for (const supabase of clients) {
+    const { data, error } = await supabase
+      .from('design_manhole')
+      .select('id, title, description, submitter_name, latitude, longitude, width, height, created_at')
+      .eq('status', 'published')
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    if (error || !data) continue;
+
+    return (data as any[]).map((row) => ({
+      ...row,
+      photo_url: `/api/design-manholes/${row.id}/photo?size=small`,
+    }));
+  }
+
+  return [];
+}
+
+export async function loadDesignManholeForOgp(
+  id: string,
+  options: { includeSignedUrl?: boolean } = {}
+): Promise<DesignManholeForOgp | null> {
+  if (!isValidDesignManholeId(id)) return null;
+
+  const clients = createOgpSupabaseClients();
+
+  for (const supabase of clients) {
+    // hidden 化した投稿は個別ページ・OGPとも 404 にする（photo route と同方針）
+    const { data, error } = await supabase
+      .from('design_manhole')
+      .select('id, title, description, submitter_name, latitude, longitude, width, height, created_at, storage_key')
+      .eq('id', id)
+      .eq('status', 'published')
+      .single();
+
+    if (error || !data) continue;
+
+    const row = data as any;
+    const designManhole: DesignManholeForOgp = {
+      id: row.id,
+      title: row.title ?? null,
+      description: row.description ?? null,
+      submitter_name: row.submitter_name ?? null,
+      latitude: row.latitude,
+      longitude: row.longitude,
+      width: row.width ?? null,
+      height: row.height ?? null,
+      created_at: row.created_at,
+      storage_key: row.storage_key,
+    };
+
+    if (options.includeSignedUrl) {
+      try {
+        const signed = await storage.getSignedUrl(designManhole.storage_key, 3600);
+        designManhole.signed_url = signed.url;
+      } catch {
+        // signed URL failure is non-fatal; caller must check
+      }
+    }
+
+    return designManhole;
+  }
+
+  return null;
+}

--- a/src/lib/design-manhole-ogp.ts
+++ b/src/lib/design-manhole-ogp.ts
@@ -26,8 +26,11 @@ export function isValidDesignManholeId(id: string): boolean {
 
 // 一覧ページのSSR用。/api/design-manholes GET と同じ公開カラムのみを返す
 // （exif / storage_key / created_by は絶対に含めない）
+// 全クライアントで失敗した場合は throw する。空配列を返すと障害時に
+// 「まだ投稿がありません」と誤表示してしまうため、失敗と0件を区別する
 export async function loadPublishedDesignManholes(limit = 200): Promise<DesignManhole[]> {
   const clients = createOgpSupabaseClients();
+  let lastError: unknown = new Error('Supabase client is not configured');
 
   for (const supabase of clients) {
     const { data, error } = await supabase
@@ -37,7 +40,10 @@ export async function loadPublishedDesignManholes(limit = 200): Promise<DesignMa
       .order('created_at', { ascending: false })
       .limit(limit);
 
-    if (error || !data) continue;
+    if (error || !data) {
+      lastError = error ?? lastError;
+      continue;
+    }
 
     return (data as any[]).map((row) => ({
       ...row,
@@ -45,7 +51,7 @@ export async function loadPublishedDesignManholes(limit = 200): Promise<DesignMa
     }));
   }
 
-  return [];
+  throw lastError;
 }
 
 export async function loadDesignManholeForOgp(

--- a/src/lib/manhole-ogp.ts
+++ b/src/lib/manhole-ogp.ts
@@ -18,7 +18,7 @@ export type PhotoForOgp = {
   signed_url?: string;
 };
 
-function createOgpSupabaseClients() {
+export function createOgpSupabaseClients() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
   const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;

--- a/src/lib/pokefuta-ogp-template.ts
+++ b/src/lib/pokefuta-ogp-template.ts
@@ -268,6 +268,87 @@ export async function renderPokefutaOgpTemplate(input: PokefutaOgpTemplateInput)
   return sharp(base).composite(textLayers).png().toBuffer();
 }
 
+// デザインマンホール投稿用OGP。ポケふた用テンプレート（「◯◯のポケふた」等の
+// 文言焼き込み）は流用できないため、写真+テキストの専用レイアウトで合成する
+export async function renderDesignManholeOgpTemplate(input: {
+  photoBuffer: Buffer;
+  title: string;
+  submitterName?: string | null;
+}): Promise<Buffer> {
+  const photoBuffer = await sharp(input.photoBuffer)
+    .resize(470, 470, { fit: 'cover' })
+    .jpeg({ quality: 88 })
+    .toBuffer();
+
+  const baseSvg = `<svg width="${WIDTH}" height="${HEIGHT}" viewBox="0 0 ${WIDTH} ${HEIGHT}" xmlns="http://www.w3.org/2000/svg">
+    <rect width="${WIDTH}" height="${HEIGHT}" fill="#F6EEDC"/>
+    <rect x="40" y="40" width="1120" height="550" rx="28" fill="#FFF8EB" stroke="#7B63A8" stroke-opacity="0.22" stroke-width="4"/>
+    <rect x="76" y="76" width="486" height="486" rx="20" fill="#EFE5CE"/>
+    <rect x="600" y="96" width="420" height="56" rx="28" fill="#7B63A8"/>
+  </svg>`;
+  const base = await sharp(Buffer.from(baseSvg)).png().toBuffer();
+
+  const overlays: sharp.OverlayOptions[] = [
+    { input: photoBuffer, left: 84, top: 84 },
+  ];
+
+  const submitterLine = input.submitterName ? `${truncate(input.submitterName, 16)}さんの投稿` : 'みんなの投稿';
+  const textLayers = await buildTextLayers([
+    {
+      text: 'みんなのデザインマンホール',
+      left: 628,
+      top: textTopFromBaseline(138, 26),
+      width: 370,
+      height: 44,
+      fontSize: 26,
+      color: '#FFFFFF',
+    },
+    {
+      // 長いタイトルは幅520px内で2行に折り返す想定。投稿者行と重ならないよう
+      // 高さを2行分確保し、投稿者行は baseline 390 まで離す
+      text: truncate(input.title, 22),
+      left: 604,
+      top: textTopFromBaseline(235, 52),
+      width: 520,
+      height: 140,
+      fontSize: 52,
+      minFontSize: 36,
+      color: '#4F3828',
+    },
+    {
+      text: submitterLine,
+      left: 606,
+      top: textTopFromBaseline(390, 30),
+      width: 520,
+      height: 52,
+      fontSize: 30,
+      color: '#17614F',
+    },
+    {
+      text: 'ご当地デザインマンホールをみんなで集めよう',
+      left: 606,
+      top: textTopFromBaseline(470, 28),
+      width: 540,
+      height: 50,
+      fontSize: 28,
+      minFontSize: 22,
+      color: '#2F241C',
+    },
+    {
+      text: 'pokefuta.com',
+      left: 900,
+      top: textTopFromBaseline(560, 25),
+      width: 224,
+      height: 44,
+      fontSize: 23,
+      color: '#17614F',
+      align: 'center',
+    },
+  ]);
+
+  return sharp(base).composite([...overlays, ...textLayers]).png().toBuffer();
+}
+
 export async function renderOgpFallback(input: {
   title: string;
   subtitle: string;

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -4,12 +4,26 @@ function normalizeHashtag(tag: string): string {
   return tag.replace(/^#+/, '').trim();
 }
 
-export function buildXShareUrl(text: string, pageUrl: string, hashtags: string[] = []): string {
-  const mergedHashtags = [...hashtags, ...DEFAULT_HASHTAGS]
+export function buildXShareUrl(
+  text: string,
+  pageUrl: string,
+  hashtags: string[] = [],
+  options: { includeDefaultHashtags?: boolean } = {}
+): string {
+  // デザインマンホール等ポケふた以外の文脈では includeDefaultHashtags: false で
+  // 「ポケふた」タグの強制付与を外せる
+  const includeDefaults = options.includeDefaultHashtags ?? true;
+  const mergedHashtags = [...hashtags, ...(includeDefaults ? DEFAULT_HASHTAGS : [])]
     .map(normalizeHashtag)
     .filter(Boolean);
 
   return `https://x.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(pageUrl)}&hashtags=${encodeURIComponent(mergedHashtags.join(','))}`;
+}
+
+export function designManholeShareText(title: string | null): string {
+  return title
+    ? `「${title}」のデザインマンホールを見つけました！`
+    : `素敵なデザインマンホールを見つけました！`;
 }
 
 export function buildLineShareUrl(pageUrl: string): string {


### PR DESCRIPTION
## 目的

みんなのデザインマンホール（/design-manholes）は投稿が9件のみで、ページも完全CSRのためクローラには「読み込み中...」しか見えず、投稿ごとの共有URLも存在しなかった。各投稿に個別URL+OGPを持たせ、共有→流入→投稿のループの起点を作る。

## 変更内容

### 投稿個別ページ `/design-manholes/[id]`（新規）
- SSR + `generateMetadata`（title/canonical/OG/Twitter card）
- JSON-LD: `ImageObject`（GeoCoordinates付き）+ `BreadcrumbList`
- 写真・説明・Leafletミニ地図・X/LINEシェアボタン・投稿CTA
- `status='published'` のみ表示。hidden・不正IDは404 + noindex

### OGP画像 `/design-manholes/[id]/opengraph-image`（新規）
- R2から写真を取得し専用レイアウトで合成（`renderDesignManholeOgpTemplate` 追加）
- 既存ポケふたテンプレートは「◯◯のポケふた」等の文言焼き込みのため流用せず専用レイアウトに
- 写真取得失敗時はフォールバック画像

### 一覧ページのSSR化
- サーバーコンポーネント化（`force-dynamic`。Amplifyのビルド時凍結事故 #188 と同じ轍を踏まないため）
- `metadata` + `ItemList` JSON-LD、カードを個別ページリンクに
- 「こんな1枚を待っています」セクション（data.pokefuta.com の投稿LPと同文言）

### その他
- sitemap.xml: `/design-manholes` + 公開投稿の個別URL
- 投稿完了画面: 「自分の投稿ページを見る」+ Xシェア（`inserted.id` を利用）、翌日キャラマンホールマップ掲載の案内
- `buildXShareUrl`: デフォルトタグ（ポケふた）を外すオプション追加（既存呼び出しは無変更）
- package.json: sharp の allowScripts 許可（ローカルビルド用）

## 検証

- `npm run type-check` / `npm run build` 通過
- ローカルSupabase + `npm start` で実測:
  - 一覧: title/JSON-LD/公開投稿がSSR出力に含まれ、hidden投稿は含まれない
  - 個別: published→200+メタデータ、hidden→404、不正ID→404
  - OGP: 合成レイアウト・フォールバックとも目視確認（タイトル2行折り返し時の重なりも修正済み）
  - sitemap.xml に /design-manholes が出力される
  - XシェアURLのハッシュタグが「デザインマンホール,マンホール」になる（ポケふた無し）

関連: data.pokefuta.com 側で source_url を個別ページに向けるPRを pokefuta-tracker に別途作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)