### PR TITLE
トップ写真のメタ表示を明確化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,14 @@ type FeedVisit = {
   display_name?: string | null;
 };
 
+const formatFeedDate = (value: string) =>
+  new Intl.DateTimeFormat('ja-JP', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    timeZone: 'Asia/Tokyo',
+  }).format(new Date(value));
+
 export default function HomePage() {
   const [loading, setLoading] = useState(true);
   const [feed, setFeed] = useState<FeedVisit[]>([]);
@@ -307,7 +315,7 @@ export default function HomePage() {
                       locationLabel,
                       `撮影 ${formatDateJa(visit.shot_at)}`,
                       posterLabel,
-                      `コメント ${commentCount}`,
+                      commentCount > 0 ? `口コミ ${commentCount}件` : null,
                     ].filter(Boolean).join('、');
                     const cardContent = (
                       <>
@@ -327,26 +335,30 @@ export default function HomePage() {
 
                         {currentPage === 1 && index < 3 && (
                           <span className="absolute left-2 top-2 rounded-[6px] bg-[#7B63A8] px-2 py-1 text-xs font-extrabold text-white shadow-sm">
-                            NEW
+                            新着投稿
                           </span>
                         )}
                         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/85 via-black/55 to-transparent p-3 pt-14 text-white sm:p-4 sm:pt-20">
                           <div className="line-clamp-1 text-sm font-extrabold sm:text-base">
                             {locationLabel || 'ポケふた'}
                           </div>
-                          <div className="mt-1 text-sm font-semibold">{formatDateJa(visit.shot_at)}</div>
+                          <div className="mt-1 text-sm font-semibold text-white/90">
+                            {formatFeedDate(visit.shot_at)}撮影
+                          </div>
                           {posterLabel && (
                             <div className="mt-1 flex min-w-0 items-center gap-1 text-xs font-semibold text-white/85">
                               <UserRound className="h-3.5 w-3.5 shrink-0" />
                               <span className="truncate">{posterLabel}</span>
                             </div>
                           )}
-                          <div className="mt-3 flex items-center gap-4 text-sm font-semibold">
-                            <span className="inline-flex items-center gap-1">
-                              <MessageCircle className="h-4 w-4" />
-                              {commentCount}
-                            </span>
-                          </div>
+                          {commentCount > 0 && (
+                            <div className="mt-3 flex items-center gap-4 text-xs font-semibold text-white/85">
+                              <span className="inline-flex items-center gap-1">
+                                <MessageCircle className="h-4 w-4" />
+                                口コミ {commentCount}件
+                              </span>
+                            </div>
+                          )}
                         </div>
                       </>
                     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,7 +19,7 @@ import BottomNav from '@/components/BottomNav';
 import Header from '@/components/Header';
 import PCShell from '@/components/PCShell';
 import { createBrowserClient } from '@/lib/supabase/client';
-import { formatDateJa } from '@/lib/date';
+import { formatDateJa, formatDateJaJst } from '@/lib/date';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 
 type FeedVisit = {
@@ -38,14 +38,6 @@ type FeedVisit = {
   manhole_comments_count?: number;
   display_name?: string | null;
 };
-
-const formatFeedDate = (value: string) =>
-  new Intl.DateTimeFormat('ja-JP', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    timeZone: 'Asia/Tokyo',
-  }).format(new Date(value));
 
 export default function HomePage() {
   const [loading, setLoading] = useState(true);
@@ -343,7 +335,7 @@ export default function HomePage() {
                             {locationLabel || 'ポケふた'}
                           </div>
                           <div className="mt-1 text-sm font-semibold text-white/90">
-                            {formatFeedDate(visit.shot_at)}撮影
+                            {formatDateJaJst(visit.shot_at)}撮影
                           </div>
                           {posterLabel && (
                             <div className="mt-1 flex min-w-0 items-center gap-1 text-xs font-semibold text-white/85">


### PR DESCRIPTION
## 概要
- トップページの `NEW` を「新着投稿」に変更
- 撮影日を `2026年7月7日撮影` の形式で表示
- コメント0件の数値表示を非表示化
- コメントがある場合は「口コミ n件」と意味を明示
- 読み上げラベルからも0件情報を除外

## 背景
写真オーバーレイの `NEW` と裸の数値 `0` は意味が伝わりにくく、利用者にとって情報価値が低い状態でした。主情報である設置場所を保ちつつ、補助情報の意味と優先順位を明確にします。

## 影響
トップページの写真カード表示だけが変わります。API・DB・投稿データには変更ありません。

## 検証
- `npx tsc --noEmit`
- `git diff --check`
- Claude CLIレビューを2回実行したものの、CLIが本文を返さず結果を取得できませんでした
- ローカルLLMレビューはユーザー指示により省略