### PR TITLE
chore: /activity-check の結果を Obsidian に記録し、skill の古い記述を修正

### DIFF
--- a/.claude/commands/activity-check.md
+++ b/.claude/commands/activity-check.md
@@ -5,6 +5,10 @@ Steps:
 2. Check if dev server is running: `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/api/site-stats`
    - If not 200, report "Dev server not running at localhost:3000" and stop.
 3. Fetch stats: `curl -s http://localhost:3000/api/site-stats`
+   - This route proxies the daily snapshot from data.pokefuta.com through Next.js's
+     fetch cache (revalidate 1h). On a freshly started dev server the FIRST request
+     can serve a stale on-disk entry from `.next/cache/fetch-cache` while it
+     revalidates in the background. Always fetch twice and use the second response.
 4. Parse and display the result as a human-readable health report in this format:
 
 ```
@@ -29,8 +33,19 @@ Steps:
   Posts last 30 days : {posts_last_30d}
 
 [Health]
-  API response source : {source}  (rpc = healthy, admin = RPC degraded, unavailable = DB unreachable)
+  API response source : {source}  (baked = healthy, unavailable = snapshot fetch failed)
+  Snapshot generated  : {generated_at} (relative)
 ```
+
+5. Record the snapshot into Obsidian (always, on every invocation):
+   `curl -s http://localhost:3000/api/site-stats | tools/log-site-stats-to-obsidian.sh`
+   - Appends one row to `~/note/dev/pokefuta/log/pokefuta site-stats 推移.md`
+     (created on first run). Override the path with `POKEFUTA_STATS_NOTE` if needed.
+   - Keyed by the snapshot's `generated_at`, so re-running on the same daily bake
+     overwrites that row instead of adding a duplicate.
+   - Mention in one line whether the note was written, e.g.
+     "Obsidian に記録: pokefuta site-stats 推移.md (snapshot 2026-08-05 06:49)".
+   - If the script fails, report it but still show the report above.
 
 Notes:
 - Use `jq` to parse JSON if available, otherwise parse manually.
@@ -39,6 +54,7 @@ Notes:
 - If `latest_photo_at` is null, show "no photos yet".
 - Flag any anomalies:
   - `posts_last_7d == 0` → "No new photos this week"
-  - `source == "unavailable"` → "WARNING: DB unreachable"
-  - `source == "admin"` → "NOTE: RPC function unavailable, using admin fallback"
+  - `source == "unavailable"` (503) → "WARNING: snapshot fetch failed"
+  - `generated_at` older than ~48h → "NOTE: daily bake may have stopped" (check the
+    bake job in the pokefuta-tracker repo, which publishes data.pokefuta.com)
 - Keep the report concise and scannable.

--- a/.claude/commands/dev-server.md
+++ b/.claude/commands/dev-server.md
@@ -7,7 +7,7 @@ Steps:
 
 2. If not running, start the server in the background:
    Use the Bash tool with `run_in_background: true` to run: `npm run dev`
-   Working directory: /Users/nishiokya/git/pokefuta
+   Working directory: the repository root (do not hardcode an absolute path — use the current project directory)
 
 3. Wait for the server to become ready by polling:
    Retry `curl -s -o /dev/null -w "%{http_code}" http://localhost:3000` up to 15 times with 2-second intervals until it returns 200.

--- a/tools/log-site-stats-to-obsidian.sh
+++ b/tools/log-site-stats-to-obsidian.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# /activity-check の site-stats JSON を Obsidian の推移ノートに1行記録する。
+#
+#   curl -s http://localhost:3000/api/site-stats | tools/log-site-stats-to-obsidian.sh
+#
+# スナップショットの generated_at をキーにしているので、同じスナップショットで
+# 何度実行しても行は増えない（既存行を上書きする）。
+set -euo pipefail
+
+NOTE="${POKEFUTA_STATS_NOTE:-$HOME/note/dev/pokefuta/log/pokefuta site-stats 推移.md}"
+
+json=$(cat)
+if ! printf '%s' "$json" | jq -e '.generated_at' >/dev/null 2>&1; then
+  echo "site-stats JSON が不正（generated_at なし）のため記録しませんでした" >&2
+  exit 1
+fi
+
+jst() {
+  if [ -z "$1" ] || [ "$1" = "null" ]; then
+    echo "-"
+  else
+    TZ=Asia/Tokyo date -d "$1" '+%Y-%m-%d %H:%M' 2>/dev/null || echo "-"
+  fi
+}
+
+IFS=$'\t' read -r generated latest_photo auth active users posts pub priv comments manholes mwp p7 p30 source <<<"$(
+  printf '%s' "$json" | jq -r '[
+    .generated_at,
+    (.latest_photo_at // "null"),
+    .auth_users, .active_users_7d, .users, .posts,
+    (.public_posts // "N/A"), (.private_posts // "N/A"), (.manhole_comments // "N/A"),
+    .manholes, .manholes_with_photos,
+    .posts_last_7d, .posts_last_30d, .source
+  ] | @tsv'
+)"
+
+gen_jst=$(jst "$generated")
+photo_jst=$(jst "$latest_photo")
+now=$(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M')
+row="| ${now} | ${gen_jst} | ${auth} | ${active} | ${users} | ${posts} | ${pub} | ${priv} | ${comments} | ${mwp} / ${manholes} | ${p7} | ${p30} | ${photo_jst} | ${source} |"
+
+mkdir -p "$(dirname "$NOTE")"
+if [ ! -f "$NOTE" ]; then
+  cat > "$NOTE" <<'EOF'
+---
+type: metrics
+tags: [pokefuta, site-stats, activity-check]
+---
+
+# pokefuta site-stats 推移
+
+`/activity-check`（Claude Code）実行のたびに1行記録される。
+値は data.pokefuta.com の日次スナップショット（`baked`）で、ライブDBではない。
+行のキーは snapshot 生成時刻なので、同じスナップショットを何度取っても行は増えない。
+
+| 記録(JST) | snapshot(JST) | auth | 7dアクティブ | 書込ユーザー | 写真 | 公開 | 非公開 | コメント | 写真ありマンホール | 7d投稿 | 30d投稿 | 最新投稿(JST) | source |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+EOF
+fi
+
+tmp=$(mktemp)
+awk -F'|' -v key="$gen_jst" -v row="$row" '
+  {
+    if ($0 ~ /^\|/ && NF > 3) {
+      g = $3
+      gsub(/^[ \t]+|[ \t]+$/, "", g)
+      if (g == key) { print row; found = 1; next }
+    }
+    print
+  }
+  END { if (!found) print row }
+' "$NOTE" > "$tmp"
+mv "$tmp" "$NOTE"
+
+echo "記録しました: ${NOTE} (snapshot ${gen_jst})"


### PR DESCRIPTION
## 概要
`/activity-check`（Claude Code の slash command）を実行するたびに、site-stats のスナップショットを Obsidian の推移ノートに1行記録するようにした。あわせて、実装と乖離していた skill の記述を修正した。

## 変更内容

### `tools/log-site-stats-to-obsidian.sh`（新規）
- `/api/site-stats` の JSON を stdin で受け取り、`~/note/dev/pokefuta/log/pokefuta site-stats 推移.md` にテーブル1行を追記する。
- 行のキーはスナップショットの `generated_at`。同じ日次 bake に対して何度実行しても行は重複せず上書きされる。
- 出力先は `POKEFUTA_STATS_NOTE` で上書き可能。ノートが無ければ frontmatter 込みで新規作成する。

### `.claude/commands/activity-check.md`
- 上記スクリプトを呼ぶ手順5を追加。
- `source` の説明を実装に合わせて修正。`route.ts` が返すのは `baked` と `unavailable`(503) のみで、`rpc` / `admin` は旧実装（リクエスト毎に Supabase を読んでいた頃）の残骸だった。
- `force-dynamic` + 内側 fetch の `revalidate: 1h` という構成上、dev server 起動直後の初回リクエストは `.next/cache/fetch-cache` の stale を返しうるため、2回取得して2回目を使う旨を明記。
- `generated_at` が48時間より古い場合に日次 bake の停止を疑うチェックを追加。

### `.claude/commands/dev-server.md`
- 作業ディレクトリに旧環境の絶対パス `/Users/nishiokya/git/pokefuta` がハードコードされていたのを解消。

## テスト
- スクリプトを2回連続で実行し、行が重複せず上書きされることを確認済み。
- アプリのコードには変更なし（`.claude/` と `tools/` のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)