### PR TITLE
Fix GA4 page views and attribution pollution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Keep `src/types/database.ts` in sync when a database migration adds or changes profile fields.
 - A user may edit only the profile associated with `auth.uid()`; enforce this in the database as well as in the UI.
 - GA4 は `pokefuta.com` / `www.pokefuta.com` だけで送信する。`localhost`、プレビューURL、開発端末名からは送らない。
-- ページ表示は標準の `page_view` を使い、OAuthコードなどを含むクエリ文字列は `page_location` に送らない。
+- ページ表示は標準の `page_view` を1回だけ送る。`page_location` は `code`・token・OAuthエラーを除去し、`from=data`など安全な計測情報は残す。
+- `data.pokefuta.com` からの遷移はクロスドメインリンカーを正とし、内部UTMは付けない。`from=data` を `source_app=tracker` と `p_data_referral` で計測する。
 - イベント発生箇所は `surface` で表す。GA4の流入元予約語 `source` をカスタムイベント引数に使わない。
 - エラーイベントは `p_api_error` / `p_auth_error` / `p_app_error` を使う。旧キーイベント名 `error_event` / `auth_error` は送信しない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,7 @@
 - Treat `app_user` profile data as public only through narrowly scoped `SECURITY DEFINER` functions. Do not grant anonymous table access.
 - Keep `src/types/database.ts` in sync when a database migration adds or changes profile fields.
 - A user may edit only the profile associated with `auth.uid()`; enforce this in the database as well as in the UI.
+- GA4 は `pokefuta.com` / `www.pokefuta.com` だけで送信する。`localhost`、プレビューURL、開発端末名からは送らない。
+- ページ表示は標準の `page_view` を使い、OAuthコードなどを含むクエリ文字列は `page_location` に送らない。
+- イベント発生箇所は `surface` で表す。GA4の流入元予約語 `source` をカスタムイベント引数に使わない。
+- エラーイベントは `p_api_error` / `p_auth_error` / `p_app_error` を使う。旧キーイベント名 `error_event` / `auth_error` は送信しない。

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "postbuild": "node tools/copy-ogp-assets-to-build.js",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit && node tools/check-public-display-name-source.js",
+    "type-check": "tsc --noEmit && node tools/check-public-display-name-source.js && node tools/check-ga4-contract.js",
+    "verify:analytics": "node tools/check-ga4-contract.js",
     "verify:ogp-linux": "node tools/verify-ogp-linux.js",
     "capture": "node tools/capture/capture.js"
   },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,9 @@
 import type { Metadata, Viewport } from 'next';
-import Script from 'next/script';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import DevDebugPanel from '@/components/DevDebugPanel';
 import ApiErrorAnalytics from '@/components/ApiErrorAnalytics';
+import GoogleAnalytics from '@/components/GoogleAnalytics';
 
 import { SITE_NAME, SITE_URL, OGP_IMAGE_URL } from '@/lib/constants';
 
@@ -68,35 +68,13 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <head>
-        {/* Google Analytics 4 - 環境変数がある場合のみ読み込み */}
-        {gaId && (
-          <>
-            <Script
-              src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-              strategy="afterInteractive"
-            />
-            <Script
-              id="google-analytics"
-              strategy="afterInteractive"
-              dangerouslySetInnerHTML={{
-                __html: `
-                  window.dataLayer = window.dataLayer || [];
-                  function gtag(){dataLayer.push(arguments);}
-                  gtag('js', new Date());
-                  gtag('config', ${JSON.stringify(gaId)}, { send_page_view: false });
-                `,
-              }}
-            />
-          </>
-        )}
-        {/* End Google Analytics 4 */}
-
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
         <meta name="apple-mobile-web-app-title" content="ポケふた" />
       </head>
       <body className={`${inter.className} antialiased`}>
+        {gaId && <GoogleAnalytics measurementId={gaId} />}
         <div id="app" className="min-h-screen bg-[#F6EEDC]">
           <ApiErrorAnalytics />
           {children}

--- a/src/app/manhole/[id]/ManholePage.tsx
+++ b/src/app/manhole/[id]/ManholePage.tsx
@@ -410,7 +410,7 @@ export default function ManholeDetailPage() {
       trackVisitVisibilityChange({
         manhole_id: manhole?.id,
         is_public: nextIsPublic,
-        source: 'manhole_detail',
+        surface: 'manhole_detail',
       });
       showVisibilityToast(nextIsPublic ? '公開しました' : '非公開にしました');
     } else {

--- a/src/app/my-trip/page.tsx
+++ b/src/app/my-trip/page.tsx
@@ -133,7 +133,7 @@ export default function MyTripPage() {
     const ok = await updateVisitVisibility(visitId, nextIsPublic);
 
     if (ok) {
-      trackVisitVisibilityChange({ is_public: nextIsPublic, source: 'my_trip' });
+      trackVisitVisibilityChange({ is_public: nextIsPublic, surface: 'my_trip' });
       showVisibilityToast(nextIsPublic ? '公開しました' : '非公開にしました');
     } else {
       setLocal(!nextIsPublic);

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -46,32 +46,40 @@ export default function GoogleAnalytics({ measurementId }: { measurementId: stri
     const fromData = new URLSearchParams(window.location.search).get('from') === 'data';
     let titleFrame = 0;
     let sendFrame = 0;
+    let timer = 0;
 
-    // App Router の metadata 更新後に title を取得する。
-    titleFrame = window.requestAnimationFrame(() => {
-      sendFrame = window.requestAnimationFrame(() => {
-        window.gtag!('set', { page_location: pageLocation });
-        window.gtag!('event', 'page_view', {
-          page_path: pathname,
-          page_location: pageLocation,
-          page_title: document.title,
-          site_type: 'photo',
-          source_app: fromData ? 'tracker' : undefined,
-        });
-
-        if (fromData && !dataReferralTracked.current) {
-          dataReferralTracked.current = true;
-          window.gtag!('event', 'p_data_referral', {
-            source_app: 'tracker',
-            destination_path: pathname,
-          });
-        }
+    const send = () => {
+      window.gtag!('set', { page_location: pageLocation });
+      window.gtag!('event', 'page_view', {
+        page_path: pathname,
+        page_location: pageLocation,
+        page_title: document.title,
+        site_type: 'photo',
+        source_app: fromData ? 'tracker' : undefined,
       });
-    });
+
+      if (fromData && !dataReferralTracked.current) {
+        dataReferralTracked.current = true;
+        window.gtag!('event', 'p_data_referral', {
+          source_app: 'tracker',
+          destination_path: pathname,
+        });
+      }
+    };
+
+    if (document.visibilityState === 'hidden') {
+      timer = window.setTimeout(send, 0);
+    } else {
+      // App Router の metadata 更新後に title を取得する。
+      titleFrame = window.requestAnimationFrame(() => {
+        sendFrame = window.requestAnimationFrame(send);
+      });
+    }
 
     return () => {
       window.cancelAnimationFrame(titleFrame);
       window.cancelAnimationFrame(sendFrame);
+      window.clearTimeout(timer);
     };
   }, [enabled, pathname, ready]);
 
@@ -81,29 +89,31 @@ export default function GoogleAnalytics({ measurementId }: { measurementId: stri
     <>
       <Script id="google-analytics-bootstrap" strategy="afterInteractive">
         {`
-          window.dataLayer = window.dataLayer || [];
-          window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
-          window.gtag('js', new Date());
-          var analyticsUrl = new URL(window.location.href);
-          ${JSON.stringify(SENSITIVE_QUERY_KEYS)}.forEach(function(key) {
-            analyticsUrl.searchParams.delete(key);
-          });
-          var analyticsQuery = analyticsUrl.searchParams.toString();
-          var analyticsPageLocation = analyticsUrl.origin + analyticsUrl.pathname +
-            (analyticsQuery ? '?' + analyticsQuery : '');
-          window.gtag('set', 'linker', {
-            domains: ['pokefuta.com', 'data.pokefuta.com'],
-            accept_incoming: true
-          });
-          var analyticsGlobalParams = { page_location: analyticsPageLocation };
-          if (analyticsUrl.searchParams.get('from') === 'data') {
-            analyticsGlobalParams.source_app = 'tracker';
-          }
-          window.gtag('set', analyticsGlobalParams);
-          window.gtag('config', ${JSON.stringify(measurementId)}, {
-            send_page_view: false,
-            page_location: analyticsPageLocation
-          });
+          (function() {
+            window.dataLayer = window.dataLayer || [];
+            window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
+            window.gtag('js', new Date());
+            var analyticsUrl = new URL(window.location.href);
+            ${JSON.stringify(SENSITIVE_QUERY_KEYS)}.forEach(function(key) {
+              analyticsUrl.searchParams.delete(key);
+            });
+            var analyticsQuery = analyticsUrl.searchParams.toString();
+            var analyticsPageLocation = analyticsUrl.origin + analyticsUrl.pathname +
+              (analyticsQuery ? '?' + analyticsQuery : '');
+            window.gtag('set', 'linker', {
+              domains: ['pokefuta.com', 'data.pokefuta.com'],
+              accept_incoming: true
+            });
+            var analyticsGlobalParams = { page_location: analyticsPageLocation };
+            if (analyticsUrl.searchParams.get('from') === 'data') {
+              analyticsGlobalParams.source_app = 'tracker';
+            }
+            window.gtag('set', analyticsGlobalParams);
+            window.gtag('config', ${JSON.stringify(measurementId)}, {
+              send_page_view: false,
+              page_location: analyticsPageLocation
+            });
+          })();
         `}
       </Script>
       <Script

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -2,13 +2,34 @@
 
 import Script from 'next/script';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { isProductionAnalyticsHost } from '@/lib/analytics/gtag';
+
+const SENSITIVE_QUERY_KEYS = [
+  'code',
+  'token',
+  'access_token',
+  'refresh_token',
+  'error',
+  'error_description',
+];
+
+export function buildAnalyticsPageLocation(
+  origin: string,
+  pathname: string,
+  search: string
+): string {
+  const params = new URLSearchParams(search);
+  SENSITIVE_QUERY_KEYS.forEach((key) => params.delete(key));
+  const query = params.toString();
+  return `${origin}${pathname}${query ? `?${query}` : ''}`;
+}
 
 export default function GoogleAnalytics({ measurementId }: { measurementId: string }) {
   const pathname = usePathname();
   const [enabled, setEnabled] = useState(false);
   const [ready, setReady] = useState(false);
+  const dataReferralTracked = useRef(false);
 
   useEffect(() => {
     setEnabled(isProductionAnalyticsHost(window.location.hostname));
@@ -17,13 +38,41 @@ export default function GoogleAnalytics({ measurementId }: { measurementId: stri
   useEffect(() => {
     if (!enabled || !ready || typeof window.gtag !== 'function') return;
 
-    // OAuth code やエラー詳細などのクエリ文字列を GA に送らない。
-    window.gtag('event', 'page_view', {
-      page_path: pathname,
-      page_location: `${window.location.origin}${pathname}`,
-      page_title: document.title,
-      site_type: 'photo',
+    const pageLocation = buildAnalyticsPageLocation(
+      window.location.origin,
+      pathname,
+      window.location.search
+    );
+    const fromData = new URLSearchParams(window.location.search).get('from') === 'data';
+    let titleFrame = 0;
+    let sendFrame = 0;
+
+    // App Router の metadata 更新後に title を取得する。
+    titleFrame = window.requestAnimationFrame(() => {
+      sendFrame = window.requestAnimationFrame(() => {
+        window.gtag!('set', { page_location: pageLocation });
+        window.gtag!('event', 'page_view', {
+          page_path: pathname,
+          page_location: pageLocation,
+          page_title: document.title,
+          site_type: 'photo',
+          source_app: fromData ? 'tracker' : undefined,
+        });
+
+        if (fromData && !dataReferralTracked.current) {
+          dataReferralTracked.current = true;
+          window.gtag!('event', 'p_data_referral', {
+            source_app: 'tracker',
+            destination_path: pathname,
+          });
+        }
+      });
     });
+
+    return () => {
+      window.cancelAnimationFrame(titleFrame);
+      window.cancelAnimationFrame(sendFrame);
+    };
   }, [enabled, pathname, ready]);
 
   if (!enabled) return null;
@@ -35,13 +84,25 @@ export default function GoogleAnalytics({ measurementId }: { measurementId: stri
           window.dataLayer = window.dataLayer || [];
           window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
           window.gtag('js', new Date());
+          var analyticsUrl = new URL(window.location.href);
+          ${JSON.stringify(SENSITIVE_QUERY_KEYS)}.forEach(function(key) {
+            analyticsUrl.searchParams.delete(key);
+          });
+          var analyticsQuery = analyticsUrl.searchParams.toString();
+          var analyticsPageLocation = analyticsUrl.origin + analyticsUrl.pathname +
+            (analyticsQuery ? '?' + analyticsQuery : '');
           window.gtag('set', 'linker', {
             domains: ['pokefuta.com', 'data.pokefuta.com'],
             accept_incoming: true
           });
+          var analyticsGlobalParams = { page_location: analyticsPageLocation };
+          if (analyticsUrl.searchParams.get('from') === 'data') {
+            analyticsGlobalParams.source_app = 'tracker';
+          }
+          window.gtag('set', analyticsGlobalParams);
           window.gtag('config', ${JSON.stringify(measurementId)}, {
             send_page_view: false,
-            anonymize_ip: true
+            page_location: analyticsPageLocation
           });
         `}
       </Script>

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import Script from 'next/script';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { isProductionAnalyticsHost } from '@/lib/analytics/gtag';
+
+export default function GoogleAnalytics({ measurementId }: { measurementId: string }) {
+  const pathname = usePathname();
+  const [enabled, setEnabled] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    setEnabled(isProductionAnalyticsHost(window.location.hostname));
+  }, []);
+
+  useEffect(() => {
+    if (!enabled || !ready || typeof window.gtag !== 'function') return;
+
+    // OAuth code やエラー詳細などのクエリ文字列を GA に送らない。
+    window.gtag('event', 'page_view', {
+      page_path: pathname,
+      page_location: `${window.location.origin}${pathname}`,
+      page_title: document.title,
+      site_type: 'photo',
+    });
+  }, [enabled, pathname, ready]);
+
+  if (!enabled) return null;
+
+  return (
+    <>
+      <Script id="google-analytics-bootstrap" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          window.gtag = window.gtag || function(){window.dataLayer.push(arguments);};
+          window.gtag('js', new Date());
+          window.gtag('set', 'linker', {
+            domains: ['pokefuta.com', 'data.pokefuta.com'],
+            accept_incoming: true
+          });
+          window.gtag('config', ${JSON.stringify(measurementId)}, {
+            send_page_view: false,
+            anonymize_ip: true
+          });
+        `}
+      </Script>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+        onReady={() => setReady(true)}
+      />
+    </>
+  );
+}

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -23,6 +23,7 @@ export interface PokefutaEventParams extends GAEventParams {
   pokemon_ids?: string;    // カンマ区切り文字列 (GA4は配列非対応)
   is_logged_in?: boolean;
   source_app?: 'tracker' | 'map';
+  surface?: string;        // イベント発生箇所。GA予約語の source は使用しない
 }
 
 export interface ApiErrorEventParams extends GAEventParams {
@@ -55,8 +56,18 @@ function isClientSide(): boolean {
   return typeof window !== 'undefined';
 }
 
+const ANALYTICS_HOSTS = new Set(['pokefuta.com', 'www.pokefuta.com']);
+
+export function isProductionAnalyticsHost(hostname: string): boolean {
+  return ANALYTICS_HOSTS.has(hostname.toLowerCase());
+}
+
 function isGtagAvailable(): boolean {
-  return isClientSide() && typeof window.gtag === 'function';
+  return (
+    isClientSide() &&
+    isProductionAnalyticsHost(window.location.hostname) &&
+    typeof window.gtag === 'function'
+  );
 }
 
 // ==========================================
@@ -122,7 +133,7 @@ export function trackPageView(
   pageType?: string,
   isLoggedIn: boolean = false
 ): void {
-  trackEvent('p_page_view', {
+  trackEvent('page_view', {
     page_path: pagePath,
     page_title: pageTitle,
     page_type: pageType,
@@ -204,7 +215,7 @@ export const pokefutaEvents = {
   // --- 訪問記録系 ---
   visitRegister:       (p?: PokefutaEventParams) => trackEvent('p_visit_register', p),
   visitDelete:         (p?: PokefutaEventParams) => trackEvent('p_visit_delete', p),
-  /** 登録後の公開/非公開切り替え。params: is_public(切替後), source */
+  /** 登録後の公開/非公開切り替え。params: is_public(切替後), surface */
   visitVisibilityChange:    (p?: PokefutaEventParams) => trackEvent('p_visit_visibility_change', p),
   /** 非公開バナーのタップ。params: private_count */
   privateVisitsBannerClick: (p?: PokefutaEventParams) => trackEvent('p_private_visits_banner_click', p),
@@ -239,7 +250,7 @@ export const pokefutaEvents = {
 };
 
 // ==========================================
-// 内部エラー追跡 (prefix なし、内部用)
+// 内部エラー追跡。旧イベント名は GA4 でキーイベント登録されているため使用しない。
 // ==========================================
 
 export const errorEvents = {
@@ -250,7 +261,7 @@ export const errorEvents = {
     errorMessage?: string,
     additionalParams?: Pick<ApiErrorEventParams, 'is_logged_in' | 'page_type' | 'component'>
   ) =>
-    trackEvent('error_event', {
+    trackEvent('p_api_error', {
       error_type: 'api_error',
       api_path: endpoint,
       endpoint,
@@ -261,10 +272,10 @@ export const errorEvents = {
     } satisfies ApiErrorEventParams),
 
   auth: (errorCode: string) =>
-    trackEvent('auth_error', { error_code: errorCode }),
+    trackEvent('p_auth_error', { error_code: errorCode }),
 
   app: (errorCode: string, errorType: string = 'unknown') =>
-    trackEvent('app_error', { error_code: errorCode, error_type: errorType }),
+    trackEvent('p_app_error', { error_code: errorCode, error_type: errorType }),
 };
 
 // ==========================================

--- a/src/lib/analytics/gtag.ts
+++ b/src/lib/analytics/gtag.ts
@@ -133,7 +133,7 @@ export function trackPageView(
   pageType?: string,
   isLoggedIn: boolean = false
 ): void {
-  trackEvent('page_view', {
+  trackEvent('p_page_view', {
     page_path: pagePath,
     page_title: pageTitle,
     page_type: pageType,

--- a/tools/check-ga4-contract.js
+++ b/tools/check-ga4-contract.js
@@ -8,23 +8,39 @@ const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'u
 
 const analytics = read('src/lib/analytics/gtag.ts');
 const provider = read('src/components/GoogleAnalytics.tsx');
-const eventCallers = [
-  read('src/app/my-trip/page.tsx'),
-  read('src/app/manhole/[id]/ManholePage.tsx'),
-].join('\n');
+
+function sourceFiles(directory) {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) return sourceFiles(fullPath);
+    return /\.(ts|tsx)$/.test(entry.name) ? [fullPath] : [];
+  });
+}
+
+const analyticsCallers = sourceFiles(path.join(root, 'src'))
+  .map((file) => ({ file, text: fs.readFileSync(file, 'utf8') }))
+  .filter(({ text }) => /useAnalytics|analytics\/gtag/.test(text));
 
 const failures = [];
 const expect = (condition, message) => {
   if (!condition) failures.push(message);
 };
 
-expect(analytics.includes("new Set(['pokefuta.com', 'www.pokefuta.com'])"), 'production hostname allowlist is missing');
-expect(provider.includes("window.gtag('event', 'page_view'"), 'standard page_view tracking is missing');
-expect(analytics.includes("trackEvent('page_view'"), 'page-view helper must use the standard event name');
-expect(provider.includes('page_location: `${window.location.origin}${pathname}`'), 'page_location must exclude query parameters');
+const hostAllowlist = analytics.match(/ANALYTICS_HOSTS\s*=\s*new Set\(\[([^\]]+)\]\)/)?.[1] || '';
+expect(hostAllowlist.includes("'pokefuta.com'"), 'pokefuta.com is missing from the production hostname allowlist');
+expect(hostAllowlist.includes("'www.pokefuta.com'"), 'www.pokefuta.com is missing from the production hostname allowlist');
+expect(!/localhost|127\.0\.0\.1/.test(hostAllowlist), 'development hosts must not be in the production allowlist');
+expect(/window\.gtag!?\('event', 'page_view'/.test(provider), 'standard page_view tracking is missing');
+expect(analytics.includes("trackEvent('p_page_view'"), 'legacy helper must not emit another standard page_view');
+expect(provider.includes("'code'") && provider.includes("'access_token'"), 'sensitive query filtering is missing');
+expect(provider.includes("get('from') === 'data'"), 'data-site referral tracking is missing');
+expect(provider.includes("'p_data_referral'"), 'data-site referral event is missing');
+expect(provider.includes('page_location: analyticsPageLocation'), 'sanitized page_location must be configured globally');
 expect(!analytics.includes("trackEvent('error_event'"), 'legacy key event error_event must not be emitted');
 expect(!analytics.includes("trackEvent('auth_error'"), 'legacy key event auth_error must not be emitted');
-expect(!eventCallers.match(/\bsource\s*:/), 'analytics callers must use surface instead of GA reserved source');
+for (const { file, text } of analyticsCallers) {
+  expect(!text.match(/\bsource\s*:/), `${path.relative(root, file)} must use surface instead of GA reserved source`);
+}
 
 if (failures.length) {
   console.error(failures.map((failure) => `- ${failure}`).join('\n'));

--- a/tools/check-ga4-contract.js
+++ b/tools/check-ga4-contract.js
@@ -36,6 +36,11 @@ expect(provider.includes("'code'") && provider.includes("'access_token'"), 'sens
 expect(provider.includes("get('from') === 'data'"), 'data-site referral tracking is missing');
 expect(provider.includes("'p_data_referral'"), 'data-site referral event is missing');
 expect(provider.includes('page_location: analyticsPageLocation'), 'sanitized page_location must be configured globally');
+expect(provider.includes('(function() {'), 'analytics bootstrap must not leak variables to window');
+expect(
+  provider.includes("document.visibilityState === 'hidden'") && provider.includes('window.setTimeout(send, 0)'),
+  'hidden tabs must send page_view without waiting for requestAnimationFrame'
+);
 expect(!analytics.includes("trackEvent('error_event'"), 'legacy key event error_event must not be emitted');
 expect(!analytics.includes("trackEvent('auth_error'"), 'legacy key event auth_error must not be emitted');
 for (const { file, text } of analyticsCallers) {

--- a/tools/check-ga4-contract.js
+++ b/tools/check-ga4-contract.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const read = (relativePath) => fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const analytics = read('src/lib/analytics/gtag.ts');
+const provider = read('src/components/GoogleAnalytics.tsx');
+const eventCallers = [
+  read('src/app/my-trip/page.tsx'),
+  read('src/app/manhole/[id]/ManholePage.tsx'),
+].join('\n');
+
+const failures = [];
+const expect = (condition, message) => {
+  if (!condition) failures.push(message);
+};
+
+expect(analytics.includes("new Set(['pokefuta.com', 'www.pokefuta.com'])"), 'production hostname allowlist is missing');
+expect(provider.includes("window.gtag('event', 'page_view'"), 'standard page_view tracking is missing');
+expect(analytics.includes("trackEvent('page_view'"), 'page-view helper must use the standard event name');
+expect(provider.includes('page_location: `${window.location.origin}${pathname}`'), 'page_location must exclude query parameters');
+expect(!analytics.includes("trackEvent('error_event'"), 'legacy key event error_event must not be emitted');
+expect(!analytics.includes("trackEvent('auth_error'"), 'legacy key event auth_error must not be emitted');
+expect(!eventCallers.match(/\bsource\s*:/), 'analytics callers must use surface instead of GA reserved source');
+
+if (failures.length) {
+  console.error(failures.map((failure) => `- ${failure}`).join('\n'));
+  process.exit(1);
+}
+
+console.log('GA4 contract check passed');


### PR DESCRIPTION
## Summary
- Restore one standard GA4 `page_view` for initial loads and client-side navigation.
- Send analytics only from `pokefuta.com` / `www.pokefuta.com`, excluding localhost, K11, and preview hosts.
- Strip sensitive OAuth/token query parameters from `page_location` while preserving safe journey markers such as `from=data`.
- Rename event location parameter `source` to `surface` so custom events do not overwrite traffic attribution.
- Rename error events to `p_api_error`, `p_auth_error`, and `p_app_error`.
- Configure the GA4 linker with `data.pokefuta.com`.
- Record data-to-app journeys as `source_app=tracker` and `p_data_referral`.
- Add a GA4 contract check to the existing type-check command.

## Why
GA4 had `(not set)` landing pages because automatic page views were disabled without an active replacement. Custom event parameters named `source` also appeared as traffic sources such as `hero` and `back_btn`, while local and K11 traffic was mixed into production reporting.

The cross-domain linker is now the source of truth for sessions. Internal UTM parameters are intentionally not used; `from=data` is retained only as an explicit product-journey marker.

## Impact
Landing-page and acquisition reports should become more reliable, while signup, login, and photo-upload conversions retain their existing event names. Historical GA4 data is unchanged.

## Validation
- `npm run type-check`
- `npm run build` with loginless placeholder environment values
- GA4 contract check
- Verified production hostname allowlist, sensitive-query filtering, and `from=data` referral handling
