### PR TITLE
Prevent official Pokéfuta from being submitted as design manholes

### DIFF
--- a/.github/workflows/ogp-linux.yml
+++ b/.github/workflows/ogp-linux.yml
@@ -27,6 +27,7 @@ jobs:
           node-version: 20
           cache: npm
       - run: npm ci
+      - run: npm run test:design-manhole
       - run: npm run type-check
       - run: npm run build
       - run: npm run verify:ogp-linux

--- a/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
+++ b/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
@@ -42,7 +42,7 @@
 - `POST /api/design-manholes` でも、ストレージへのアップロード前に公式ポケふたとの距離を検証する。
 - 公式候補が近い場合は `409 OFFICIAL_MANHOLE_NEARBY` と候補情報、訪問投稿URLを返す。
 - UIを迂回した直接リクエストでも自動公開できないことを保証する。
-- 近接する別デザインの蓋も存在するため、50m以内を一律削除・拒否しない。明示確認された投稿は将来的にレビュー待ち状態へ送る。
+- 近接する別デザインの蓋も存在するため、50m以内を一律削除・拒否しない。明示確認された投稿はレビュー待ち状態へ送る。
 
 ### DB・権限
 
@@ -66,11 +66,79 @@
 - APIはストレージアップロード前に公式データを再照合する。未確認または候補IDと異なる確認は `409 OFFICIAL_MANHOLE_NEARBY` にする。
 - 公式データを取得できない場合は `503 OFFICIAL_MANHOLE_CHECK_UNAVAILABLE` とし、照合できない状態では投稿を受け付けない。
 - APIの成功レスポンスは `official_manhole_check.result` で、50m超の通常投稿 (`clear`) と確認済みの近接する別デザイン蓋 (`confirmed_different`) を区別する。
-- 今回は既存の公開フローを維持し、DB migration・RLS変更は追加しない。レビュー待ち状態とPostgREST直接INSERTの制限は、モデレーション設計と合わせて別途検討する。
+- 近接確認済みの投稿は `pending` または `needs_review` として永続化し、公開一覧から除外する。
+- PostgREST直接INSERTでこの制約を迂回できないよう、限定RPCまたはDBトリガーへ検証を集約する。
+
+## PR #198 レビューでの追加修正（マージ前に必須）
+
+1. **近接確認済み投稿を即時公開しない**
+   - `confirmed_different` をレスポンスに返すだけでなくDBへ保存する。
+   - 50m以内の投稿は `pending` / `needs_review` として永続化し、公開一覧から除外する。
+   - APIを迂回した直接INSERTでも即時公開できないよう、限定RPCまたはDBトリガーで保証する。
+2. **写真差替え時の古いEXIF結果を破棄する**
+   - `onDrop` 冒頭で世代IDを採番する。
+   - EXIF解析後、近接検索後、`finally` の状態更新を同じ世代IDでガードし、古い写真の座標や判定で新しい写真を上書きしない。
+3. **追加テストをNode 20のCIで実行する**
+   - Node 22.6以降専用の `--experimental-strip-types` に依存しない実行方法へ変更する。
+   - GitHub Actionsで `npm run test:design-manhole` を実行し、CIの緑が追加テストの成功も保証するようにする。
+
+修正後は、追加テスト、type-check、buildを実行し、PR #198へpushして再レビューを依頼する。
+
+## PR #198 レビュー指摘への対応結果
+
+- `design_manhole.status` に `needs_review` を追加し、近接候補ID・距離・明示確認日時を永続化するmigrationを追加した。
+- `public.manhole.location` を使う `BEFORE INSERT` トリガーで50m以内を再計算し、`published` の直接INSERTも `needs_review` へ強制する。RLSは本人名義の `published` / `needs_review` のみ許可する。
+- APIは `confirmed_different` を `needs_review` でINSERTし、成功画面も「確認待ち」表示にして、公開前の詳細ページやX共有へ誘導しない。
+- 写真選択ごとの世代IDを `onDrop` 冒頭で採番し、EXIF解析後、近接検索後、例外処理、`finally` の全更新を同じ世代でガードした。
+- テスト実行を `tsx --test` へ変更し、Node 20の既存GitHub Actionsに `npm run test:design-manhole` を追加した。
+- 検証: Node 20.20.2を含む自動テスト12件、`npm run type-check`、CI相当のダミー環境変数を使った `npm run build` が成功した。
+- migrationの追加のみで、本番DBへの適用・デプロイ・マージは行っていない。
+
+## tracker Draft PR #394 の敵対的レビュー
+
+対象: https://github.com/nishiokya/pokefuta-tracker/pull/394
+
+結論: 近接候補を公開データから外す方向は正しい。ただし、以下2点を直すまでは Draft のままにする。
+
+### [P1] 公開抽出を fail-closed にする
+
+`select_public_records()` は現在 `review_status != "needs_review"` だけで抽出している。このdenylist方式では、`status="pending"` / `hidden` の行や、将来追加された未知のレビュー状態が `docs/design_manholes.ndjson` に入る。地図側が `status == "active"` で再度絞っていても、NDJSON自体は公開・配布されるため境界として不十分。
+
+公開条件は少なくとも次の両方を満たすallowlistにする。
+
+- `status == "active"`
+- `review_status` が公開を許可した既知の状態である（または最低限 `needs_review` でないことを追加条件にする）
+
+テストには `pending`、`hidden`、未知の `review_status` が公開出力へ入らないケースを追加する。
+
+### [P1] 非公開にした候補をレビューキューへ残す
+
+現在の `normalized_records` はメモリ上にしか存在せず、`needs_review` 行は `docs/design_manholes.ndjson` から消える。ステージされるraw snapshotには投稿ID・座標はあるが、`nearby_refs`、距離、候補名、レビュー理由がない。そのためFamily BのPRを人が見ても、何と重複しそうなのか、どのoverrideを追加すべきか判断できない。
+
+公開出力とは別に、例えば `dataset/design_manhole_review_queue.ndjson` を生成・ステージし、少なくとも次を残す。
+
+- `source_id`
+- `nearby_refs`（ref、距離、候補名）
+- `review_status`
+- `status`
+- 投稿写真・投稿詳細へのURL
+
+テストには「ID 157は公開NDJSONへ入らないが、レビューキューには `pokefuta:157` と約1mで残る」ことを追加する。
+
+### pokefuta #198 との引き渡し条件
+
+pokefuta #198 の `confirmed_different` は、現行差分ではPOST成功レスポンス上の区別に留まり、DBや公開GET APIへ永続化されていない。したがって、公式ポケふた50m以内の正当な別デザイン蓋もtrackerでは `needs_review` になる。これは安全側の挙動として許容できるが、上記レビューキューがないと正当投稿を復帰させる運用が成立しない。
+
+### マージ判断
+
+- ID 157を公開対象から外す回帰テストは妥当。
+- `create-pull-request` の無条件実行、concurrency、timeout追加も妥当。
+- 上記2件を修正し、公開データとレビューキューの両方を統合テストした後にマージする。
 
 ## 関連
 
 - pokefuta-tracker PR: https://github.com/nishiokya/pokefuta-tracker/pull/392
+- pokefuta-tracker 再発防止 Draft PR: https://github.com/nishiokya/pokefuta-tracker/pull/394
 - 投稿API: `src/app/api/design-manholes/route.ts`
 - 投稿UI: `src/app/design-manholes/new/page.tsx`
 - 訪問写真API: `src/app/api/image-upload/route.ts`

--- a/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
+++ b/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
@@ -135,6 +135,24 @@ pokefuta #198 の `confirmed_different` は、現行差分ではPOST成功レス
 - `create-pull-request` の無条件実行、concurrency、timeout追加も妥当。
 - 上記2件を修正し、公開データとレビューキューの両方を統合テストした後にマージする。
 
+## 相互監視・最終確認結果
+
+### pokefuta-tracker
+
+- PR #394 は、公開抽出を `status == "active"` かつ既知の公開許可 `review_status` に限定するallowlist方式へ修正した。
+- 非公開候補は `dataset/design_manhole_review_queue.ndjson` へ残し、投稿ID、近接候補、距離、レビュー状態、投稿URLを確認できるようにした。
+- ID 157が公開NDJSONへ入らず、レビューキューへ `pokefuta:157` と約1mで残る回帰テストを含む14テストとGitHub CIが成功した。
+- PR #394 は最終HEAD `9f42fcb84378e8944a1025d4fe16625d40d4fdfd`、merge commit `b44d88b80274b795661e0eedc49944a5b4d38c8b` で2026-08-08にsquash merge済み。上記の敵対的レビュー指摘は解消済み。
+- 後続の日次データPR #395も成功し、2026-08-08にmerge済み。PR #392は誤投稿を含む旧PRとしてclosed・未mergeのまま。
+
+### pokefuta PR #198
+
+- 最新実装HEAD `4cdfd76eb28e6b03c1ccc3924f885760e48b5b36` を再レビューし、追加の品質問題は見つからなかった。
+- 近接確認済み投稿の `needs_review` 永続化、公開API・写真APIからの除外、50m以内の直接INSERTを抑止するDBトリガーとRLSを確認した。
+- 写真差替え時のEXIF解析・近接検索・例外処理・`finally` は同じ写真世代でガードされ、古い非同期結果が新しい写真へ反映されないことを確認した。
+- GitHub ActionsはNode 20で `npm run test:design-manhole` を実行し、追加テストを含めて成功。PRは競合なし・mergeableであり、Draft解除とsquash mergeへ進めてよい。
+- 本番DBへのmigration適用とデプロイは、このPRのマージ作業には含めない。
+
 ## 関連
 
 - pokefuta-tracker PR: https://github.com/nishiokya/pokefuta-tracker/pull/392

--- a/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
+++ b/docs/inbox/2026-08-08-design-manhole-official-duplicate.md
@@ -1,0 +1,77 @@
+# 公式ポケふたのデザインマンホール誤投稿を防ぐ
+
+## 状況
+
+- 対象投稿: `d4864c49-5170-4dc0-a524-a7fbf92be958`
+- 投稿者表示名: `おさかな`
+- 投稿座標: `40.5379444444444, 141.558027777778`
+- 公式ポケふた: `pokefuta:157`（青森県/八戸市、イシツブテ・キャモメ）
+- 公式座標との差: 約1m
+- tracker: PR #392 で `nearby_ref=pokefuta:157`、`review_status=needs_review`
+
+写真と座標が公式ポケふた ID 157 と一致するため、訪問写真をデザインマンホールとして登録した誤投稿と判断した。
+
+## 2026-08-08 の対応
+
+- pokefuta本番DBの対象行を `published` から `hidden` に変更した。
+- キャッシュを避けた公開確認で、一覧に対象IDが含まれないことを確認した。
+- 詳細ページと写真APIがともに `404` になることを確認した。
+- 写真オブジェクトとDB行は削除していない。`hidden` 化のみのため復元可能。
+- tracker側のPR・データ補正は別途手動で対応する。
+
+## 原因
+
+- `/design-manholes/new` はEXIF座標を読み取るが、公式ポケふたとの照合を行わない。
+- UIに「登録済みマンホールとの照合はないため、どの場所でも投稿できます」と表示している。
+- `POST /api/design-manholes` は認証、画像、国内座標のみを検証し、公式マンホールとの距離を検証しない。
+- `design_manhole.status` は初期値が `published` で、投稿直後に公開される。
+- デザインマンホール投稿の自動テストがない。
+
+## 対応方針
+
+### UI
+
+- 写真のEXIF座標を取得した時点で、50m以内の公式ポケふた候補を検索する。
+- 候補があれば公式名、登場ポケモン、距離を表示する。
+- 主ボタンを「訪問写真として登録」にし、`/upload?manhole_id=<id>` へ誘導する。
+- 「別のマンホールです」は副導線にする。
+- 「登録済みマンホールとの照合はないため、どの場所でも投稿できます」という文言を削除する。
+
+### サーバー
+
+- `POST /api/design-manholes` でも、ストレージへのアップロード前に公式ポケふたとの距離を検証する。
+- 公式候補が近い場合は `409 OFFICIAL_MANHOLE_NEARBY` と候補情報、訪問投稿URLを返す。
+- UIを迂回した直接リクエストでも自動公開できないことを保証する。
+- 近接する別デザインの蓋も存在するため、50m以内を一律削除・拒否しない。明示確認された投稿は将来的にレビュー待ち状態へ送る。
+
+### DB・権限
+
+- `pending` または `needs_review` 状態の追加を検討する。
+- 認証ユーザーによるテーブル直接INSERTで距離検証を迂回できないよう、限定RPCまたはDBトリガーへ検証を集約する。
+- anon/authenticated に公開している `created_by`、`storage_key` などの列権限も見直す。
+
+## 受け入れ条件
+
+- 公式ポケふたから約1mの写真はデザインマンホールとして即時公開されない。
+- 近接候補が表示され、訪問写真投稿へ1操作で移動できる。
+- 近接する別の蓋は、ユーザー確認後にレビュー対象として扱える。
+- 50mより離れた通常のデザインマンホール投稿は従来どおり登録できる。
+- APIを直接呼んでも同じ判定になる。
+- 上記ケースの自動テストが追加されている。
+
+## 実装PRでの対応
+
+- UIと投稿APIで共通の50m判定を使い、公式候補の名称・ポケモン・距離を表示する。
+- 公式候補がある場合の主導線を `/upload?manhole_id=<id>` にし、「別のマンホールです」の明示確認を副導線にする。
+- APIはストレージアップロード前に公式データを再照合する。未確認または候補IDと異なる確認は `409 OFFICIAL_MANHOLE_NEARBY` にする。
+- 公式データを取得できない場合は `503 OFFICIAL_MANHOLE_CHECK_UNAVAILABLE` とし、照合できない状態では投稿を受け付けない。
+- APIの成功レスポンスは `official_manhole_check.result` で、50m超の通常投稿 (`clear`) と確認済みの近接する別デザイン蓋 (`confirmed_different`) を区別する。
+- 今回は既存の公開フローを維持し、DB migration・RLS変更は追加しない。レビュー待ち状態とPostgREST直接INSERTの制限は、モデレーション設計と合わせて別途検討する。
+
+## 関連
+
+- pokefuta-tracker PR: https://github.com/nishiokya/pokefuta-tracker/pull/392
+- 投稿API: `src/app/api/design-manholes/route.ts`
+- 投稿UI: `src/app/design-manholes/new/page.tsx`
+- 訪問写真API: `src/app/api/image-upload/route.ts`
+- RLS: `database/migrations/archive/019_design_manhole_rls_policies.sql`

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
         "eslint-config-next": "^14.0.0",
         "playwright": "^1.60.0",
         "puppeteer": "^24.15.0",
-        "supabase": "^2.109.1"
+        "supabase": "^2.109.1",
+        "tsx": "^4.23.11"
       },
       "engines": {
         "node": ">=18.0.0"
@@ -2567,6 +2568,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7726,6 +8169,48 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {
@@ -13872,6 +14357,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.11",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.11.tgz",
+      "integrity": "sha512-Ry2oTEUnhBdeEdWIztY8kf3/nBGnPnjMLVGL0YfdRXMORuPER5NlKmayqxtxRxwB1xBN+RivRaJfe7PM1rtiyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "type-check": "tsc --noEmit && node tools/check-public-display-name-source.js && node tools/check-ga4-contract.js",
     "verify:analytics": "node tools/check-ga4-contract.js",
-    "test:design-manhole": "node --experimental-strip-types --test tests/design-manhole-proximity.test.ts",
+    "test:design-manhole": "tsx --test tests/design-manhole-*.test.ts",
     "verify:ogp-linux": "node tools/verify-ogp-linux.js",
     "capture": "node tools/capture/capture.js"
   },
@@ -52,7 +52,8 @@
     "eslint-config-next": "^14.0.0",
     "playwright": "^1.60.0",
     "puppeteer": "^24.15.0",
-    "supabase": "^2.109.1"
+    "supabase": "^2.109.1",
+    "tsx": "^4.23.11"
   },
   "engines": {
     "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "next start",
     "lint": "next lint",
     "type-check": "tsc --noEmit && node tools/check-public-display-name-source.js",
+    "test:design-manhole": "node --experimental-strip-types --test tests/design-manhole-proximity.test.ts",
     "verify:ogp-linux": "node tools/verify-ogp-linux.js",
     "capture": "node tools/capture/capture.js"
   },

--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -10,6 +10,12 @@ import {
   deriveDesignSmallKey,
 } from '@/lib/storage';
 import { isValidCoordinates } from '@/lib/location';
+import { fetchManholeSnapshot } from '@/lib/manhole-snapshot';
+import {
+  buildOfficialManholeConflict,
+  findNearbyOfficialManhole,
+  getOfficialManholeProximityDecision,
+} from '@/lib/design-manhole-proximity';
 
 export const dynamic = 'force-dynamic';
 // supabase-js の PostgREST GET が Next の Data Cache に乗るのを防ぐ
@@ -59,10 +65,15 @@ function optionalText(value: FormDataEntryValue | null, maxLength: number): stri
  *               description: { type: string, maxLength: 1000 }
  *               submitterName: { type: string, maxLength: 50 }
  *               exif: { type: string, description: JSON string }
+ *               confirmedNearbyOfficialManholeId:
+ *                 type: integer
+ *                 description: 近接する公式ポケふたとは別の蓋であることを確認した場合の候補ID
  *     responses:
  *       201: { description: 投稿成功 }
  *       400: { description: バリデーションエラー }
  *       401: { description: 認証が必要 }
+ *       409: { description: 50m以内に未確認の公式ポケふた候補がある }
+ *       503: { description: 公式ポケふたとの照合を実行できない }
  */
 export async function POST(request: NextRequest) {
   let uploadedStorageKey: string | null = null;
@@ -123,7 +134,42 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 4. テキスト項目（すべて任意・長さ上限で切り詰め）
+    // 4. 公式ポケふたとの近接判定。失敗時はアップロード前に閉じる。
+    const snapshot = await fetchManholeSnapshot();
+    if (!snapshot?.manholes) {
+      return NextResponse.json(
+        {
+          success: false,
+          code: 'OFFICIAL_MANHOLE_CHECK_UNAVAILABLE',
+          error: '公式ポケふたとの照合に失敗しました。時間をおいて再度お試しください',
+        },
+        { status: 503 }
+      );
+    }
+
+    const nearbyOfficialManhole = findNearbyOfficialManhole(snapshot.manholes, lat, lng);
+    const confirmationRaw = formData.get('confirmedNearbyOfficialManholeId');
+    const confirmedNearbyOfficialManholeId =
+      typeof confirmationRaw === 'string' && /^\d+$/.test(confirmationRaw)
+        ? Number(confirmationRaw)
+        : null;
+    const proximityDecision = getOfficialManholeProximityDecision(
+      nearbyOfficialManhole,
+      confirmedNearbyOfficialManholeId
+    );
+
+    if (proximityDecision.result === 'conflict') {
+      return NextResponse.json(
+        {
+          success: false,
+          error: '近くに公式ポケふたがあります。訪問写真として登録するか、別のマンホールであることを確認してください',
+          ...buildOfficialManholeConflict(proximityDecision.official_manhole),
+        },
+        { status: 409 }
+      );
+    }
+
+    // 5. テキスト項目（すべて任意・長さ上限で切り詰め）
     const title = optionalText(formData.get('title'), MAX_TITLE_LENGTH);
     const description = optionalText(formData.get('description'), MAX_DESCRIPTION_LENGTH);
     const submitterName =
@@ -143,7 +189,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 5. R2 アップロード + サムネイル生成
+    // 6. R2 アップロード + サムネイル生成
     const arrayBuffer = await file.arrayBuffer();
     const buffer = Buffer.from(arrayBuffer);
     const storageKey = generateDesignManholeStorageKey(file.type);
@@ -182,7 +228,7 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 6. DB 挿入（ユーザーセッションで実行。RLS が created_by = auth.uid() を担保。
+    // 7. DB 挿入（ユーザーセッションで実行。RLS が created_by = auth.uid() を担保。
     //    失敗時はアップロード済みオブジェクトを掃除）
     const { data: inserted, error: insertError } = await supabase
       .from('design_manhole')
@@ -209,7 +255,11 @@ export async function POST(request: NextRequest) {
     }
 
     return NextResponse.json(
-      { success: true, design_manhole: inserted },
+      {
+        success: true,
+        design_manhole: inserted,
+        official_manhole_check: proximityDecision,
+      },
       { status: 201 }
     );
   } catch (error: any) {

--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -14,6 +14,7 @@ import { fetchManholeSnapshot } from '@/lib/manhole-snapshot';
 import {
   buildOfficialManholeConflict,
   findNearbyOfficialManhole,
+  getDesignManholePublicationStatus,
   getOfficialManholeProximityDecision,
 } from '@/lib/design-manhole-proximity';
 
@@ -47,7 +48,7 @@ function optionalText(value: FormDataEntryValue | null, maxLength: number): stri
  *   post:
  *     summary: デザインマンホールを投稿
  *     tags: [design-manholes]
- *     description: ポケふた以外のデザインマンホールを写真+位置情報付きで投稿します。要ログイン。
+ *     description: ポケふた以外のデザインマンホールを写真+位置情報付きで投稿します。公式ポケふた50m以内で別の蓋と確認された投稿はneeds_reviewになります。要ログイン。
  *     security:
  *       - cookieAuth: []
  *     requestBody:
@@ -168,6 +169,7 @@ export async function POST(request: NextRequest) {
         { status: 409 }
       );
     }
+    const publicationStatus = getDesignManholePublicationStatus(proximityDecision);
 
     // 5. テキスト項目（すべて任意・長さ上限で切り詰め）
     const title = optionalText(formData.get('title'), MAX_TITLE_LENGTH);
@@ -228,7 +230,8 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    // 7. DB 挿入（ユーザーセッションで実行。RLS が created_by = auth.uid() を担保。
+    // 7. DB 挿入（ユーザーセッションで実行。RLS が本人名義と許可statusを担保し、
+    //    DBトリガーも50m以内をneeds_reviewへ強制する。
     //    失敗時はアップロード済みオブジェクトを掃除）
     const { data: inserted, error: insertError } = await supabase
       .from('design_manhole')
@@ -245,9 +248,18 @@ export async function POST(request: NextRequest) {
         width,
         height,
         exif,
+        status: publicationStatus,
+        nearby_official_manhole_id:
+          proximityDecision.official_manhole?.id ?? null,
+        nearby_official_manhole_distance_m:
+          proximityDecision.official_manhole?.distance_m ?? null,
+        nearby_official_manhole_confirmed_at:
+          proximityDecision.result === 'confirmed_different'
+            ? new Date().toISOString()
+            : null,
         created_by: userId,
       })
-      .select('id, title, latitude, longitude, created_at')
+      .select('id, title, latitude, longitude, status, created_at')
       .single();
 
     if (insertError || !inserted) {

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -1,19 +1,27 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useDropzone } from 'react-dropzone';
 import exifr from 'exifr';
 import imageCompression from 'browser-image-compression';
-import { AlertCircle, Camera, CheckCircle, Share2, Upload } from 'lucide-react';
+import { AlertCircle, Camera, CheckCircle, MapPin, RefreshCw, Share2, Upload } from 'lucide-react';
 import Header from '@/components/Header';
 import BottomNav from '@/components/BottomNav';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { isValidCoordinates } from '@/lib/location';
 import { buildXShareUrl, designManholeShareText } from '@/lib/share';
 import { SITE_URL } from '@/lib/constants';
+import {
+  OFFICIAL_MANHOLE_NEARBY_CODE,
+  OFFICIAL_MANHOLE_NEARBY_RADIUS_KM,
+  isDesignManholeSubmissionReady,
+  toOfficialManholeCandidate,
+  type OfficialManholeCandidate,
+} from '@/lib/design-manhole-proximity';
 
 type GpsSource = 'exif' | null;
+type ProximityCheckStatus = 'idle' | 'checking' | 'ready' | 'error';
 
 export default function DesignManholeNewPage() {
   const [file, setFile] = useState<File | null>(null);
@@ -22,6 +30,13 @@ export default function DesignManholeNewPage() {
   const [lng, setLng] = useState<number | null>(null);
   const [gpsSource, setGpsSource] = useState<GpsSource>(null);
   const [exifChecking, setExifChecking] = useState(false);
+  const [nearbyOfficialManhole, setNearbyOfficialManhole] =
+    useState<OfficialManholeCandidate | null>(null);
+  const [confirmedNearbyOfficialManholeId, setConfirmedNearbyOfficialManholeId] =
+    useState<number | null>(null);
+  const [proximityCheckStatus, setProximityCheckStatus] =
+    useState<ProximityCheckStatus>('idle');
+  const proximityCheckSequenceRef = useRef(0);
 
   // プレビューURLは差し替え時・アンマウント時に解放する
   useEffect(() => {
@@ -65,12 +80,57 @@ export default function DesignManholeNewPage() {
     };
   }, []);
 
+  const checkNearbyOfficialManhole = useCallback(async (
+    latitude: number,
+    longitude: number
+  ) => {
+    const sequence = ++proximityCheckSequenceRef.current;
+    setProximityCheckStatus('checking');
+    setNearbyOfficialManhole(null);
+    setConfirmedNearbyOfficialManholeId(null);
+
+    try {
+      const params = new URLSearchParams({
+        lat: String(latitude),
+        lng: String(longitude),
+        radius: String(OFFICIAL_MANHOLE_NEARBY_RADIUS_KM),
+        limit: '1',
+      });
+      const response = await fetch(`/api/manholes?${params}`);
+      if (!response.ok) throw new Error('official manhole lookup failed');
+
+      const data = await response.json();
+      const nearest = data?.manholes?.[0];
+      const candidate = nearest && typeof nearest.distance === 'number'
+        ? toOfficialManholeCandidate(nearest, nearest.distance)
+        : null;
+
+      if (sequence !== proximityCheckSequenceRef.current) return;
+      setNearbyOfficialManhole(candidate);
+      setProximityCheckStatus('ready');
+    } catch (lookupError) {
+      console.error('Official manhole proximity check failed:', lookupError);
+      if (sequence !== proximityCheckSequenceRef.current) return;
+      setNearbyOfficialManhole(null);
+      setProximityCheckStatus('error');
+      setError('近くの公式ポケふたを確認できませんでした。再確認してください');
+    }
+  }, []);
+
+  const resetProximityCheck = useCallback(() => {
+    proximityCheckSequenceRef.current += 1;
+    setNearbyOfficialManhole(null);
+    setConfirmedNearbyOfficialManholeId(null);
+    setProximityCheckStatus('idle');
+  }, []);
+
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     const selected = acceptedFiles[0];
     if (!selected) return;
 
     setFile(selected);
     setError(null);
+    resetProximityCheck();
     // プレビューURLの解放は useEffect クリーンアップが行う
     setPreviewUrl(URL.createObjectURL(selected));
 
@@ -84,6 +144,7 @@ export default function DesignManholeNewPage() {
         setLat(raw.latitude);
         setLng(raw.longitude);
         setGpsSource('exif');
+        await checkNearbyOfficialManhole(raw.latitude, raw.longitude);
       } else {
         // 前の写真のEXIF座標を引きずらない
         setLat(null);
@@ -111,7 +172,7 @@ export default function DesignManholeNewPage() {
     } finally {
       setExifChecking(false);
     }
-  }, []);
+  }, [checkNearbyOfficialManhole, resetProximityCheck]);
 
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     onDrop,
@@ -142,7 +203,15 @@ export default function DesignManholeNewPage() {
     input.click();
   };
 
-  const canSubmit = !!file && lat != null && lng != null && !exifChecking && !submitting;
+  const canSubmit = isDesignManholeSubmissionReady({
+    hasFile: !!file,
+    hasCoordinates: lat != null && lng != null,
+    exifChecking,
+    submitting,
+    proximityCheckStatus,
+    nearbyOfficialManhole,
+    confirmedNearbyOfficialManholeId,
+  });
 
   const handleSubmit = async () => {
     if (!file || lat == null || lng == null) return;
@@ -171,6 +240,12 @@ export default function DesignManholeNewPage() {
       if (description.trim()) formData.append('description', description.trim());
       if (submitterName.trim()) formData.append('submitterName', submitterName.trim());
       if (exifPayload) formData.append('exif', JSON.stringify(exifPayload));
+      if (confirmedNearbyOfficialManholeId != null) {
+        formData.append(
+          'confirmedNearbyOfficialManholeId',
+          String(confirmedNearbyOfficialManholeId)
+        );
+      }
 
       const res = await fetch('/api/design-manholes', {
         method: 'POST',
@@ -180,6 +255,18 @@ export default function DesignManholeNewPage() {
 
       if (res.status === 401) {
         throw new Error('セッションが切れました。ログインし直してください');
+      }
+      if (
+        res.status === 409 &&
+        data?.code === OFFICIAL_MANHOLE_NEARBY_CODE &&
+        data?.official_manhole
+      ) {
+        setNearbyOfficialManhole(data.official_manhole);
+        setConfirmedNearbyOfficialManholeId(null);
+        setProximityCheckStatus('ready');
+        throw new Error(
+          '近くに公式ポケふたがあります。訪問写真として登録するか、別のマンホールであることを確認してください'
+        );
       }
       if (!res.ok) {
         throw new Error(data?.error || '投稿に失敗しました。時間をおいて再度お試しください');
@@ -336,6 +423,75 @@ export default function DesignManholeNewPage() {
               写真に位置情報がありません。位置情報（GPS）付きの写真を選んでください。
             </p>
           )}
+
+          {lat != null && lng != null && proximityCheckStatus === 'checking' && (
+            <p className="mt-3 flex items-center gap-1.5 text-xs text-[#2A2A2A]/60">
+              <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+              近くの公式ポケふたを確認中...
+            </p>
+          )}
+
+          {lat != null && lng != null && proximityCheckStatus === 'error' && (
+            <div className="mt-3 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
+              <p>近くの公式ポケふたを確認できませんでした。</p>
+              <button
+                type="button"
+                onClick={() => {
+                  setError(null);
+                  void checkNearbyOfficialManhole(lat, lng);
+                }}
+                className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[#B5483C]/40 bg-white/60 px-3 py-1.5 text-xs font-bold"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+                再確認する
+              </button>
+            </div>
+          )}
+
+          {nearbyOfficialManhole && proximityCheckStatus === 'ready' && (
+            <div className="mt-4 rounded-xl border-2 border-[#7B63A8]/40 bg-white p-4 shadow-sm">
+              <div className="flex items-start gap-2">
+                <MapPin className="mt-0.5 h-5 w-5 shrink-0 text-[#7B63A8]" />
+                <div>
+                  <p className="text-sm font-bold text-[#7B63A8]">
+                    近くに公式ポケふたがあります
+                  </p>
+                  <p className="mt-1 text-sm font-bold">{nearbyOfficialManhole.title}</p>
+                  <p className="mt-0.5 text-xs text-[#2A2A2A]/65">
+                    {nearbyOfficialManhole.pokemons.join('・') || 'ポケモンマンホール'}
+                    {' ・ '}写真の位置から約{nearbyOfficialManhole.distance_m}m
+                  </p>
+                </div>
+              </div>
+
+              <Link
+                href={`/upload?manhole_id=${nearbyOfficialManhole.id}`}
+                className="mt-4 flex w-full items-center justify-center rounded-lg bg-[#7B63A8] px-4 py-3 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+              >
+                このポケふたの訪問写真として登録
+              </Link>
+
+              <label className="mt-4 flex cursor-pointer items-start gap-2 rounded-lg border border-[#2A2A2A]/15 bg-[#F6EEDC]/70 p-3">
+                <input
+                  type="checkbox"
+                  checked={confirmedNearbyOfficialManholeId === nearbyOfficialManhole.id}
+                  onChange={(event) => {
+                    setConfirmedNearbyOfficialManholeId(
+                      event.target.checked ? nearbyOfficialManhole.id : null
+                    );
+                    setError(null);
+                  }}
+                  className="mt-0.5 h-4 w-4 accent-[#7B63A8]"
+                />
+                <span>
+                  <span className="block text-sm font-bold">別のマンホールです</span>
+                  <span className="mt-1 block text-xs leading-relaxed text-[#2A2A2A]/60">
+                    写真が上の公式ポケふたではなく、近くにある別のデザイン蓋だと確認した場合だけ選択してください。
+                  </span>
+                </span>
+              </label>
+            </div>
+          )}
         </section>
 
         {/* 撮影のコツ（/upload と同じガイド） */}
@@ -369,7 +525,7 @@ export default function DesignManholeNewPage() {
           </div>
 
           <p className="mt-2 text-xs text-[#2A2A2A]/60">
-            📍 <strong>位置情報（GPS）付きの写真が必要です。</strong> 設置場所は写真のEXIFから自動で読み取ります。ポケふた投稿と異なり登録済みマンホールとの照合はないため、どの場所のマンホールでも投稿できます。
+            📍 <strong>位置情報（GPS）付きの写真が必要です。</strong> 設置場所は写真のEXIFから自動で読み取ります。近くに公式ポケふたがある場合は、訪問写真の登録をご案内します。
           </p>
         </details>
 

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -12,6 +12,7 @@ import { createBrowserClient } from '@/lib/supabase/client';
 import { isValidCoordinates } from '@/lib/location';
 import { buildXShareUrl, designManholeShareText } from '@/lib/share';
 import { SITE_URL } from '@/lib/constants';
+import { createLatestGenerationGuard } from '@/lib/latest-generation';
 import {
   OFFICIAL_MANHOLE_NEARBY_CODE,
   OFFICIAL_MANHOLE_NEARBY_RADIUS_KM,
@@ -37,6 +38,7 @@ export default function DesignManholeNewPage() {
   const [proximityCheckStatus, setProximityCheckStatus] =
     useState<ProximityCheckStatus>('idle');
   const proximityCheckSequenceRef = useRef(0);
+  const photoGenerationGuardRef = useRef(createLatestGenerationGuard());
 
   // プレビューURLは差し替え時・アンマウント時に解放する
   useEffect(() => {
@@ -52,6 +54,7 @@ export default function DesignManholeNewPage() {
   const [done, setDone] = useState(false);
   const [postedId, setPostedId] = useState<string | null>(null);
   const [postedTitle, setPostedTitle] = useState<string | null>(null);
+  const [postedNeedsReview, setPostedNeedsReview] = useState(false);
 
   // ニックネーム初期値はログインユーザーの表示名（ページ自体は middleware が保護）
   useEffect(() => {
@@ -82,8 +85,10 @@ export default function DesignManholeNewPage() {
 
   const checkNearbyOfficialManhole = useCallback(async (
     latitude: number,
-    longitude: number
+    longitude: number,
+    photoGeneration: number
   ) => {
+    if (!photoGenerationGuardRef.current.isCurrent(photoGeneration)) return;
     const sequence = ++proximityCheckSequenceRef.current;
     setProximityCheckStatus('checking');
     setNearbyOfficialManhole(null);
@@ -105,12 +110,18 @@ export default function DesignManholeNewPage() {
         ? toOfficialManholeCandidate(nearest, nearest.distance)
         : null;
 
-      if (sequence !== proximityCheckSequenceRef.current) return;
+      if (
+        sequence !== proximityCheckSequenceRef.current ||
+        !photoGenerationGuardRef.current.isCurrent(photoGeneration)
+      ) return;
       setNearbyOfficialManhole(candidate);
       setProximityCheckStatus('ready');
     } catch (lookupError) {
       console.error('Official manhole proximity check failed:', lookupError);
-      if (sequence !== proximityCheckSequenceRef.current) return;
+      if (
+        sequence !== proximityCheckSequenceRef.current ||
+        !photoGenerationGuardRef.current.isCurrent(photoGeneration)
+      ) return;
       setNearbyOfficialManhole(null);
       setProximityCheckStatus('error');
       setError('近くの公式ポケふたを確認できませんでした。再確認してください');
@@ -127,10 +138,15 @@ export default function DesignManholeNewPage() {
   const onDrop = useCallback(async (acceptedFiles: File[]) => {
     const selected = acceptedFiles[0];
     if (!selected) return;
+    const photoGeneration = photoGenerationGuardRef.current.begin();
 
     setFile(selected);
     setError(null);
     resetProximityCheck();
+    setLat(null);
+    setLng(null);
+    setGpsSource(null);
+    setExifPayload(null);
     // プレビューURLの解放は useEffect クリーンアップが行う
     setPreviewUrl(URL.createObjectURL(selected));
 
@@ -140,11 +156,17 @@ export default function DesignManholeNewPage() {
       const raw = await exifr.parse(selected, {
         gps: true, tiff: true, exif: true, xmp: false, icc: false, iptc: false,
       });
+      if (!photoGenerationGuardRef.current.isCurrent(photoGeneration)) return;
       if (isValidCoordinates(raw?.latitude, raw?.longitude)) {
         setLat(raw.latitude);
         setLng(raw.longitude);
         setGpsSource('exif');
-        await checkNearbyOfficialManhole(raw.latitude, raw.longitude);
+        await checkNearbyOfficialManhole(
+          raw.latitude,
+          raw.longitude,
+          photoGeneration
+        );
+        if (!photoGenerationGuardRef.current.isCurrent(photoGeneration)) return;
       } else {
         // 前の写真のEXIF座標を引きずらない
         setLat(null);
@@ -165,12 +187,15 @@ export default function DesignManholeNewPage() {
         setExifPayload(null);
       }
     } catch {
+      if (!photoGenerationGuardRef.current.isCurrent(photoGeneration)) return;
       setExifPayload(null);
       setLat(null);
       setLng(null);
       setGpsSource(null);
     } finally {
-      setExifChecking(false);
+      if (photoGenerationGuardRef.current.isCurrent(photoGeneration)) {
+        setExifChecking(false);
+      }
     }
   }, [checkNearbyOfficialManhole, resetProximityCheck]);
 
@@ -274,6 +299,7 @@ export default function DesignManholeNewPage() {
 
       setPostedId(data?.design_manhole?.id ?? null);
       setPostedTitle(data?.design_manhole?.title ?? null);
+      setPostedNeedsReview(data?.design_manhole?.status === 'needs_review');
       setDone(true);
     } catch (err: any) {
       setError(err?.message || '投稿に失敗しました');
@@ -300,20 +326,25 @@ export default function DesignManholeNewPage() {
           <CheckCircle className="mx-auto h-14 w-14 text-[#4C9A57]" />
           <h1 className="mt-4 text-xl font-bold">投稿ありがとうございます！</h1>
           <p className="mt-2 text-sm text-[#2A2A2A]/70">
-            投稿されたデザインマンホールは公開されました。
-            翌日には <a href="https://data.pokefuta.com/gmanhole_map.html" target="_blank" rel="noopener noreferrer" className="text-[#7B63A8] underline hover:opacity-80">キャラマンホールマップ</a> にも掲載されます。
+            {postedNeedsReview ? (
+              <>近くの公式ポケふたとは別の蓋として、確認待ちで受け付けました。確認後に公開されます。</>
+            ) : (
+              <>投稿されたデザインマンホールは公開されました。翌日には <a href="https://data.pokefuta.com/gmanhole_map.html" target="_blank" rel="noopener noreferrer" className="text-[#7B63A8] underline hover:opacity-80">キャラマンホールマップ</a> にも掲載されます。</>
+            )}
           </p>
-          <a
-            href={shareUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-6 inline-flex items-center gap-1.5 rounded-lg bg-[#2A2A2A] px-6 py-3 text-sm font-bold text-white transition hover:bg-[#444444]"
-          >
-            <Share2 className="h-4 w-4" />
-            Xでシェアする
-          </a>
+          {!postedNeedsReview && (
+            <a
+              href={shareUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-6 inline-flex items-center gap-1.5 rounded-lg bg-[#2A2A2A] px-6 py-3 text-sm font-bold text-white transition hover:bg-[#444444]"
+            >
+              <Share2 className="h-4 w-4" />
+              Xでシェアする
+            </a>
+          )}
           <div className="mt-4 flex justify-center gap-3">
-            {postedId ? (
+            {postedId && !postedNeedsReview ? (
               <Link
                 href={`/design-manholes/${postedId}`}
                 className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
@@ -438,7 +469,11 @@ export default function DesignManholeNewPage() {
                 type="button"
                 onClick={() => {
                   setError(null);
-                  void checkNearbyOfficialManhole(lat, lng);
+                  void checkNearbyOfficialManhole(
+                    lat,
+                    lng,
+                    photoGenerationGuardRef.current.current()
+                  );
                 }}
                 className="mt-2 inline-flex items-center gap-1.5 rounded-md border border-[#B5483C]/40 bg-white/60 px-3 py-1.5 text-xs font-bold"
               >
@@ -589,10 +624,16 @@ export default function DesignManholeNewPage() {
             disabled={!canSubmit}
             className="w-full rounded-lg bg-[#7B63A8] py-3 text-sm font-bold text-white transition hover:bg-[#6A5299] disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {submitting ? '投稿中...' : '投稿する'}
+            {submitting
+              ? '投稿中...'
+              : nearbyOfficialManhole
+                ? '確認待ちで投稿する'
+                : '投稿する'}
           </button>
           <p className="mt-2 text-center text-xs text-[#2A2A2A]/50">
-            投稿された写真と位置情報はすぐに公開されます。
+            {nearbyOfficialManhole
+              ? '近くに公式ポケふたがある投稿は、確認が完了するまで公開されません。'
+              : '投稿された写真と位置情報はすぐに公開されます。'}
           </p>
         </section>
       </main>

--- a/src/lib/design-manhole-proximity.ts
+++ b/src/lib/design-manhole-proximity.ts
@@ -25,6 +25,8 @@ export type OfficialManholeProximityDecision =
   | { result: 'conflict'; official_manhole: OfficialManholeCandidate }
   | { result: 'confirmed_different'; official_manhole: OfficialManholeCandidate };
 
+export type DesignManholePublicationStatus = 'published' | 'needs_review';
+
 interface SubmissionGateInput {
   hasFile: boolean;
   hasCoordinates: boolean;
@@ -123,6 +125,14 @@ export function getOfficialManholeProximityDecision(
     return { result: 'confirmed_different', official_manhole: candidate };
   }
   return { result: 'conflict', official_manhole: candidate };
+}
+
+export function getDesignManholePublicationStatus(
+  decision: OfficialManholeProximityDecision
+): DesignManholePublicationStatus {
+  return decision.result === 'confirmed_different'
+    ? 'needs_review'
+    : 'published';
 }
 
 export function isDesignManholeSubmissionReady(input: SubmissionGateInput): boolean {

--- a/src/lib/design-manhole-proximity.ts
+++ b/src/lib/design-manhole-proximity.ts
@@ -1,0 +1,140 @@
+import type { SnapshotManhole } from './manhole-snapshot';
+
+export const OFFICIAL_MANHOLE_NEARBY_CODE = 'OFFICIAL_MANHOLE_NEARBY';
+export const OFFICIAL_MANHOLE_NEARBY_RADIUS_KM = 0.05;
+
+export interface OfficialManholeCandidate {
+  id: number;
+  title: string;
+  prefecture: string;
+  municipality: string | null;
+  pokemons: string[];
+  latitude: number;
+  longitude: number;
+  distance_m: number;
+}
+
+export interface OfficialManholeConflict {
+  code: typeof OFFICIAL_MANHOLE_NEARBY_CODE;
+  official_manhole: OfficialManholeCandidate;
+  visit_upload_url: string;
+}
+
+export type OfficialManholeProximityDecision =
+  | { result: 'clear'; official_manhole: null }
+  | { result: 'conflict'; official_manhole: OfficialManholeCandidate }
+  | { result: 'confirmed_different'; official_manhole: OfficialManholeCandidate };
+
+interface SubmissionGateInput {
+  hasFile: boolean;
+  hasCoordinates: boolean;
+  exifChecking: boolean;
+  submitting: boolean;
+  proximityCheckStatus: 'idle' | 'checking' | 'ready' | 'error';
+  nearbyOfficialManhole: OfficialManholeCandidate | null;
+  confirmedNearbyOfficialManholeId: number | null;
+}
+
+function calculateDistanceKm(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  const earthRadiusKm = 6371;
+  const toRadians = (degrees: number) => degrees * Math.PI / 180;
+  const deltaLat = toRadians(lat2 - lat1);
+  const deltaLng = toRadians(lng2 - lng1);
+  const a =
+    Math.sin(deltaLat / 2) ** 2 +
+    Math.cos(toRadians(lat1)) * Math.cos(toRadians(lat2)) *
+    Math.sin(deltaLng / 2) ** 2;
+
+  return earthRadiusKm * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export function toOfficialManholeCandidate(
+  manhole: Pick<SnapshotManhole, 'id' | 'title' | 'prefecture' | 'municipality' | 'pokemons' | 'latitude' | 'longitude'>,
+  distanceKm: number
+): OfficialManholeCandidate {
+  return {
+    id: manhole.id,
+    title: manhole.title,
+    prefecture: manhole.prefecture,
+    municipality: manhole.municipality,
+    pokemons: manhole.pokemons,
+    latitude: manhole.latitude,
+    longitude: manhole.longitude,
+    distance_m: Math.round(distanceKm * 1000),
+  };
+}
+
+export function findNearbyOfficialManhole(
+  manholes: SnapshotManhole[],
+  latitude: number,
+  longitude: number,
+  radiusKm: number = OFFICIAL_MANHOLE_NEARBY_RADIUS_KM
+): OfficialManholeCandidate | null {
+  let nearest: { manhole: SnapshotManhole; distanceKm: number } | null = null;
+
+  for (const manhole of manholes) {
+    const distanceKm = calculateDistanceKm(
+      latitude,
+      longitude,
+      manhole.latitude,
+      manhole.longitude
+    );
+    if (distanceKm > radiusKm) continue;
+    if (!nearest || distanceKm < nearest.distanceKm) {
+      nearest = { manhole, distanceKm };
+    }
+  }
+
+  return nearest
+    ? toOfficialManholeCandidate(nearest.manhole, nearest.distanceKm)
+    : null;
+}
+
+export function buildOfficialManholeConflict(
+  candidate: OfficialManholeCandidate
+): OfficialManholeConflict {
+  return {
+    code: OFFICIAL_MANHOLE_NEARBY_CODE,
+    official_manhole: candidate,
+    visit_upload_url: `/upload?manhole_id=${candidate.id}`,
+  };
+}
+
+export function hasConfirmedDifferentManhole(
+  candidate: OfficialManholeCandidate | null,
+  confirmedNearbyOfficialManholeId: number | null
+): boolean {
+  return candidate === null || confirmedNearbyOfficialManholeId === candidate.id;
+}
+
+export function getOfficialManholeProximityDecision(
+  candidate: OfficialManholeCandidate | null,
+  confirmedNearbyOfficialManholeId: number | null
+): OfficialManholeProximityDecision {
+  if (!candidate) {
+    return { result: 'clear', official_manhole: null };
+  }
+  if (confirmedNearbyOfficialManholeId === candidate.id) {
+    return { result: 'confirmed_different', official_manhole: candidate };
+  }
+  return { result: 'conflict', official_manhole: candidate };
+}
+
+export function isDesignManholeSubmissionReady(input: SubmissionGateInput): boolean {
+  return (
+    input.hasFile &&
+    input.hasCoordinates &&
+    !input.exifChecking &&
+    !input.submitting &&
+    input.proximityCheckStatus === 'ready' &&
+    hasConfirmedDifferentManhole(
+      input.nearbyOfficialManhole,
+      input.confirmedNearbyOfficialManholeId
+    )
+  );
+}

--- a/src/lib/latest-generation.ts
+++ b/src/lib/latest-generation.ts
@@ -1,0 +1,22 @@
+export interface LatestGenerationGuard {
+  begin(): number;
+  current(): number;
+  isCurrent(generation: number): boolean;
+}
+
+export function createLatestGenerationGuard(): LatestGenerationGuard {
+  let currentGeneration = 0;
+
+  return {
+    begin() {
+      currentGeneration += 1;
+      return currentGeneration;
+    },
+    current() {
+      return currentGeneration;
+    },
+    isCurrent(generation: number) {
+      return generation === currentGeneration;
+    },
+  };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -352,7 +352,10 @@ export interface Database {
           width: number | null;
           height: number | null;
           exif: Record<string, any> | null;
-          status: 'published' | 'hidden';
+          status: 'published' | 'needs_review' | 'hidden';
+          nearby_official_manhole_id: number | null;
+          nearby_official_manhole_distance_m: number | null;
+          nearby_official_manhole_confirmed_at: string | null;
           created_by: string;
           created_at: string;
           updated_at: string;
@@ -371,13 +374,19 @@ export interface Database {
           width?: number | null;
           height?: number | null;
           exif?: Record<string, any> | null;
-          status?: 'published' | 'hidden';
+          status?: 'published' | 'needs_review' | 'hidden';
+          nearby_official_manhole_id?: number | null;
+          nearby_official_manhole_distance_m?: number | null;
+          nearby_official_manhole_confirmed_at?: string | null;
           created_by: string;
         };
         Update: {
           title?: string | null;
           description?: string | null;
-          status?: 'published' | 'hidden';
+          status?: 'published' | 'needs_review' | 'hidden';
+          nearby_official_manhole_id?: number | null;
+          nearby_official_manhole_distance_m?: number | null;
+          nearby_official_manhole_confirmed_at?: string | null;
           updated_at?: string;
         };
         Relationships: [];

--- a/supabase/migrations/20260808000000_design_manhole_nearby_review.sql
+++ b/supabase/migrations/20260808000000_design_manhole_nearby_review.sql
@@ -1,0 +1,96 @@
+-- Official Pokefuta proximity is a publication boundary, not only an API hint.
+-- A BEFORE INSERT trigger recomputes the nearest active official manhole so a
+-- direct PostgREST insert cannot publish a row within 50 metres.
+
+ALTER TABLE public.design_manhole
+  DROP CONSTRAINT IF EXISTS design_manhole_status_check;
+
+ALTER TABLE public.design_manhole
+  ADD CONSTRAINT design_manhole_status_check
+  CHECK (status IN ('published', 'needs_review', 'hidden'));
+
+ALTER TABLE public.design_manhole
+  ADD COLUMN IF NOT EXISTS nearby_official_manhole_id INTEGER
+    REFERENCES public.manhole(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS nearby_official_manhole_distance_m INTEGER,
+  ADD COLUMN IF NOT EXISTS nearby_official_manhole_confirmed_at TIMESTAMPTZ;
+
+ALTER TABLE public.design_manhole
+  DROP CONSTRAINT IF EXISTS design_manhole_nearby_distance_nonnegative;
+
+ALTER TABLE public.design_manhole
+  ADD CONSTRAINT design_manhole_nearby_distance_nonnegative
+  CHECK (
+    nearby_official_manhole_distance_m IS NULL
+    OR nearby_official_manhole_distance_m >= 0
+  );
+
+CREATE OR REPLACE FUNCTION public.enforce_design_manhole_nearby_review()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  candidate_id INTEGER;
+  candidate_distance_m DOUBLE PRECISION;
+  submitted_location extensions.geography;
+BEGIN
+  submitted_location := extensions.ST_SetSRID(
+    extensions.ST_MakePoint(NEW.longitude, NEW.latitude),
+    4326
+  )::extensions.geography;
+
+  SELECT m.id, extensions.ST_Distance(m.location, submitted_location)
+    INTO candidate_id, candidate_distance_m
+  FROM public.manhole AS m
+  WHERE m.is_active = TRUE
+    AND extensions.ST_DWithin(m.location, submitted_location, 50)
+  ORDER BY extensions.ST_Distance(m.location, submitted_location), m.id
+  LIMIT 1;
+
+  IF candidate_id IS NOT NULL THEN
+    NEW.nearby_official_manhole_id := candidate_id;
+    NEW.nearby_official_manhole_distance_m := ROUND(candidate_distance_m)::INTEGER;
+    IF NEW.status = 'published' THEN
+      NEW.status := 'needs_review';
+    END IF;
+  ELSE
+    NEW.nearby_official_manhole_id := NULL;
+    NEW.nearby_official_manhole_distance_m := NULL;
+    NEW.nearby_official_manhole_confirmed_at := NULL;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.enforce_design_manhole_nearby_review() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS enforce_design_manhole_nearby_review_on_insert
+  ON public.design_manhole;
+CREATE TRIGGER enforce_design_manhole_nearby_review_on_insert
+  BEFORE INSERT ON public.design_manhole
+  FOR EACH ROW
+  EXECUTE FUNCTION public.enforce_design_manhole_nearby_review();
+
+-- The trigger runs before this RLS WITH CHECK. A nearby row submitted as
+-- published is rewritten to needs_review and is still persisted for moderation.
+DROP POLICY IF EXISTS design_manhole_users_insert_own ON public.design_manhole;
+CREATE POLICY design_manhole_users_insert_own ON public.design_manhole
+  FOR INSERT TO authenticated
+  WITH CHECK (
+    created_by = auth.uid()
+    AND status IN ('published', 'needs_review')
+  );
+
+GRANT SELECT (
+  nearby_official_manhole_id,
+  nearby_official_manhole_distance_m,
+  nearby_official_manhole_confirmed_at
+) ON public.design_manhole TO authenticated;
+
+COMMENT ON COLUMN public.design_manhole.nearby_official_manhole_id IS
+  'Nearest active official Pokefuta within 50m, recomputed by DB trigger.';
+COMMENT ON COLUMN public.design_manhole.nearby_official_manhole_confirmed_at IS
+  'User explicitly confirmed this is a different lid; row still requires review.';

--- a/tests/design-manhole-db-policy.test.ts
+++ b/tests/design-manhole-db-policy.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const migrationUrl = new URL(
+  '../supabase/migrations/20260808000000_design_manhole_nearby_review.sql',
+  import.meta.url
+);
+const migration = readFileSync(fileURLToPath(migrationUrl), 'utf8');
+
+test('DB policy: 50m以内の直接INSERTをneeds_reviewへ強制する', () => {
+  assert.match(migration, /BEFORE INSERT ON public\.design_manhole/);
+  assert.match(
+    migration,
+    /extensions\.ST_DWithin\(m\.location, submitted_location, 50\)/
+  );
+  assert.match(migration, /NEW\.status := 'needs_review'/);
+});
+
+test('DB policy: needs_reviewを永続化でき、公開status制約に含める', () => {
+  assert.match(
+    migration,
+    /status IN \('published', 'needs_review', 'hidden'\)/
+  );
+  assert.match(
+    migration,
+    /status IN \('published', 'needs_review'\)/
+  );
+  assert.match(migration, /nearby_official_manhole_confirmed_at/);
+});

--- a/tests/design-manhole-generation.test.ts
+++ b/tests/design-manhole-generation.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createLatestGenerationGuard } from '../src/lib/latest-generation.ts';
+
+test('UI race: 古い写真の非同期結果は新しい写真を上書きしない', async () => {
+  const guard = createLatestGenerationGuard();
+  const applied: string[] = [];
+
+  const firstGeneration = guard.begin();
+  const first = Promise.resolve().then(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    if (guard.isCurrent(firstGeneration)) applied.push('old-photo');
+  });
+
+  const secondGeneration = guard.begin();
+  const second = Promise.resolve().then(() => {
+    if (guard.isCurrent(secondGeneration)) applied.push('new-photo');
+  });
+
+  await Promise.all([first, second]);
+
+  assert.deepEqual(applied, ['new-photo']);
+  assert.equal(guard.isCurrent(firstGeneration), false);
+  assert.equal(guard.isCurrent(secondGeneration), true);
+});
+
+test('UI race: finallyも現在世代だけがEXIF確認中を解除できる', () => {
+  const guard = createLatestGenerationGuard();
+  const oldGeneration = guard.begin();
+  const currentGeneration = guard.begin();
+
+  assert.equal(guard.isCurrent(oldGeneration), false);
+  assert.equal(guard.isCurrent(currentGeneration), true);
+});

--- a/tests/design-manhole-proximity.test.ts
+++ b/tests/design-manhole-proximity.test.ts
@@ -4,6 +4,7 @@ import {
   OFFICIAL_MANHOLE_NEARBY_CODE,
   buildOfficialManholeConflict,
   findNearbyOfficialManhole,
+  getDesignManholePublicationStatus,
   getOfficialManholeProximityDecision,
   hasConfirmedDifferentManhole,
   isDesignManholeSubmissionReady,
@@ -64,13 +65,18 @@ test('API policy: サーバーが検出した候補IDの明示確認だけを許
 });
 
 test('API policy: 通常投稿と確認済みの近接する別デザイン蓋を区別する', () => {
-  assert.equal(
-    getOfficialManholeProximityDecision(null, null).result,
-    'clear'
+  const clear = getOfficialManholeProximityDecision(null, null);
+  const confirmedDifferent = getOfficialManholeProximityDecision(
+    nearbyCandidate,
+    157
   );
+
+  assert.equal(clear.result, 'clear');
+  assert.equal(getDesignManholePublicationStatus(clear), 'published');
+  assert.equal(confirmedDifferent.result, 'confirmed_different');
   assert.equal(
-    getOfficialManholeProximityDecision(nearbyCandidate, 157).result,
-    'confirmed_different'
+    getDesignManholePublicationStatus(confirmedDifferent),
+    'needs_review'
   );
   assert.equal(
     getOfficialManholeProximityDecision(nearbyCandidate, null).result,

--- a/tests/design-manhole-proximity.test.ts
+++ b/tests/design-manhole-proximity.test.ts
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  OFFICIAL_MANHOLE_NEARBY_CODE,
+  buildOfficialManholeConflict,
+  findNearbyOfficialManhole,
+  getOfficialManholeProximityDecision,
+  hasConfirmedDifferentManhole,
+  isDesignManholeSubmissionReady,
+  type OfficialManholeCandidate,
+} from '../src/lib/design-manhole-proximity.ts';
+import type { SnapshotManhole } from '../src/lib/manhole-snapshot.ts';
+
+const official157: SnapshotManhole = {
+  id: 157,
+  title: '青森県/八戸市',
+  name: '青森県/八戸市',
+  prefecture: '青森県',
+  municipality: '八戸市',
+  city: '八戸市',
+  latitude: 40.537937,
+  longitude: 141.558034,
+  pokemons: ['イシツブテ', 'キャモメ'],
+  is_visited: false,
+  last_visit: null,
+  photo_count: 0,
+};
+
+const nearbyCandidate: OfficialManholeCandidate = {
+  id: 157,
+  title: '青森県/八戸市',
+  prefecture: '青森県',
+  municipality: '八戸市',
+  pokemons: ['イシツブテ', 'キャモメ'],
+  latitude: 40.537937,
+  longitude: 141.558034,
+  distance_m: 1,
+};
+
+test('API policy: 約1mの公式ポケふたを50m以内の候補として返す', () => {
+  const candidate = findNearbyOfficialManhole(
+    [official157],
+    40.5379444444444,
+    141.558027777778
+  );
+
+  assert.equal(candidate?.id, 157);
+  assert.equal(candidate?.distance_m, 1);
+});
+
+test('API policy: 50mを超える投稿は通常投稿として扱う', () => {
+  const candidate = findNearbyOfficialManhole([official157], 40.539, 141.56);
+  assert.equal(candidate, null);
+  assert.equal(hasConfirmedDifferentManhole(candidate, null), true);
+});
+
+test('API policy: 未確認または別IDの確認では近接投稿を許可しない', () => {
+  assert.equal(hasConfirmedDifferentManhole(nearbyCandidate, null), false);
+  assert.equal(hasConfirmedDifferentManhole(nearbyCandidate, 999), false);
+});
+
+test('API policy: サーバーが検出した候補IDの明示確認だけを許可する', () => {
+  assert.equal(hasConfirmedDifferentManhole(nearbyCandidate, 157), true);
+});
+
+test('API policy: 通常投稿と確認済みの近接する別デザイン蓋を区別する', () => {
+  assert.equal(
+    getOfficialManholeProximityDecision(null, null).result,
+    'clear'
+  );
+  assert.equal(
+    getOfficialManholeProximityDecision(nearbyCandidate, 157).result,
+    'confirmed_different'
+  );
+  assert.equal(
+    getOfficialManholeProximityDecision(nearbyCandidate, null).result,
+    'conflict'
+  );
+});
+
+test('API response: 409用payloadに候補情報と訪問投稿URLを含める', () => {
+  const conflict = buildOfficialManholeConflict(nearbyCandidate);
+  assert.equal(conflict.code, OFFICIAL_MANHOLE_NEARBY_CODE);
+  assert.equal(conflict.official_manhole.id, 157);
+  assert.equal(conflict.visit_upload_url, '/upload?manhole_id=157');
+});
+
+test('UI gate: 照合中・照合失敗・未確認の近接投稿では送信できない', () => {
+  const base = {
+    hasFile: true,
+    hasCoordinates: true,
+    exifChecking: false,
+    submitting: false,
+    nearbyOfficialManhole: nearbyCandidate,
+    confirmedNearbyOfficialManholeId: null,
+  };
+
+  assert.equal(isDesignManholeSubmissionReady({ ...base, proximityCheckStatus: 'checking' }), false);
+  assert.equal(isDesignManholeSubmissionReady({ ...base, proximityCheckStatus: 'error' }), false);
+  assert.equal(isDesignManholeSubmissionReady({ ...base, proximityCheckStatus: 'ready' }), false);
+});
+
+test('UI gate: 候補なし、または同じ候補IDを確認済みなら送信できる', () => {
+  const base = {
+    hasFile: true,
+    hasCoordinates: true,
+    exifChecking: false,
+    submitting: false,
+    proximityCheckStatus: 'ready' as const,
+  };
+
+  assert.equal(isDesignManholeSubmissionReady({
+    ...base,
+    nearbyOfficialManhole: null,
+    confirmedNearbyOfficialManholeId: null,
+  }), true);
+  assert.equal(isDesignManholeSubmissionReady({
+    ...base,
+    nearbyOfficialManhole: nearbyCandidate,
+    confirmedNearbyOfficialManholeId: 157,
+  }), true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",


### PR DESCRIPTION
## Summary

- Detect official Pokéfuta within 50m in the design-manhole UI and make the visit-photo upload the primary action.
- Require explicit “different manhole” confirmation before continuing, and repeat the same fail-closed check in the POST API before storage upload.
- Persist confirmed nearby submissions as `needs_review`, exclude them from public list/photo APIs, and add a database trigger plus RLS policy so direct PostgREST inserts cannot bypass review.
- Guard EXIF/proximity state by photo generation so stale async results cannot overwrite a newly selected photo.
- Add Node 20-compatible automated coverage and run it in GitHub Actions.

## Verification

- `npm run test:design-manhole` — 12 tests passed
- `npm run type-check` — passed
- `npm run build` with CI-equivalent placeholder environment — passed
- Node 20.20.2 test run — passed
- GitHub Actions `verify-ogp-linux` — passed on implementation HEAD

## Coordination

- Cross-repository review and handoff are recorded in `docs/inbox/2026-08-08-design-manhole-official-duplicate.md`.
- pokefuta-tracker PR #394 merged as `b44d88b`; follow-up daily dataset PR #395 also merged successfully.

## Deployment note

- This PR adds a migration, but does not apply it to production and does not deploy the application.
