### PR TITLE
fix: デザインマンホール投稿を一時停止し、投稿画面で理由を告知する

### DIFF
--- a/src/app/api/design-manholes/route.ts
+++ b/src/app/api/design-manholes/route.ts
@@ -17,6 +17,11 @@ import {
   getDesignManholePublicationStatus,
   getOfficialManholeProximityDecision,
 } from '@/lib/design-manhole-proximity';
+import {
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED,
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED_CODE,
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE,
+} from '@/lib/design-manhole-submission-status';
 
 export const dynamic = 'force-dynamic';
 // supabase-js の PostgREST GET が Next の Data Cache に乗るのを防ぐ
@@ -74,9 +79,22 @@ function optionalText(value: FormDataEntryValue | null, maxLength: number): stri
  *       400: { description: バリデーションエラー }
  *       401: { description: 認証が必要 }
  *       409: { description: 50m以内に未確認の公式ポケふた候補がある }
- *       503: { description: 公式ポケふたとの照合を実行できない }
+ *       503: { description: 投稿受付を一時停止中、または公式ポケふたとの照合を実行できない }
  */
 export async function POST(request: NextRequest) {
+  // 受付停止中は何もせず閉じる。R2 に上げてから消す無駄も、
+  // 古いJSを掴んだクライアントへの誤った「時間をおいて」案内も避ける。
+  if (DESIGN_MANHOLE_SUBMISSION_SUSPENDED) {
+    return NextResponse.json(
+      {
+        success: false,
+        code: DESIGN_MANHOLE_SUBMISSION_SUSPENDED_CODE,
+        error: DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE,
+      },
+      { status: 503 }
+    );
+  }
+
   let uploadedStorageKey: string | null = null;
 
   try {

--- a/src/app/design-manholes/[id]/page.tsx
+++ b/src/app/design-manholes/[id]/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
-import { Plus, Share2 } from 'lucide-react';
+import { Share2 } from 'lucide-react';
 import MapSection from '../MapSection';
+import { SubmitCta } from '@/components/DesignManhole/SubmitCta';
+import { DESIGN_MANHOLE_SUBMISSION_SUSPENDED } from '@/lib/design-manhole-submission-status';
 import { loadDesignManholeForOgp } from '@/lib/design-manhole-ogp';
 import { buildXShareUrl, buildLineShareUrl, designManholeShareText } from '@/lib/share';
 import { formatDateJaJst } from '@/lib/date';
@@ -193,15 +195,11 @@ export default async function Page({ params }: Props) {
 
         <div className="mt-6 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-5 text-center">
           <p className="text-sm text-[#2A2A2A]/70">
-            あなたの街のデザインマンホールも投稿してみませんか？
+            {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
+              ? '不具合のため、デザインマンホールの投稿を一時停止しています。'
+              : 'あなたの街のデザインマンホールも投稿してみませんか？'}
           </p>
-          <Link
-            href="/design-manholes/new"
-            className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
-          >
-            <Plus className="h-4 w-4" />
-            投稿する
-          </Link>
+          <SubmitCta className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]" />
         </div>
       </main>
 

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -18,6 +18,10 @@ import {
   toOfficialManholeCandidate,
   type OfficialManholeCandidate,
 } from '@/lib/design-manhole-proximity';
+import {
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED,
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE,
+} from '@/lib/design-manhole-submission-status';
 
 type GpsSource = 'exif' | null;
 type ProximityCheckStatus = 'idle' | 'checking' | 'ready' | 'error';
@@ -226,17 +230,23 @@ export default function DesignManholeNewPage() {
     input.click();
   };
 
-  const canSubmit = isDesignManholeSubmissionReady({
-    hasFile: !!file,
-    hasCoordinates: lat != null && lng != null,
-    exifChecking,
-    submitting,
-    proximityCheckStatus,
-    nearbyOfficialManhole,
-    confirmedNearbyOfficialManholeId,
-  });
+  const canSubmit =
+    !DESIGN_MANHOLE_SUBMISSION_SUSPENDED &&
+    isDesignManholeSubmissionReady({
+      hasFile: !!file,
+      hasCoordinates: lat != null && lng != null,
+      exifChecking,
+      submitting,
+      proximityCheckStatus,
+      nearbyOfficialManhole,
+      confirmedNearbyOfficialManholeId,
+    });
 
   const handleSubmit = async () => {
+    if (DESIGN_MANHOLE_SUBMISSION_SUSPENDED) {
+      setError(DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE);
+      return;
+    }
     if (!file || lat == null || lng == null) return;
 
     setSubmitting(true);
@@ -373,6 +383,27 @@ export default function DesignManholeNewPage() {
     <div className="min-h-content safe-area-body bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
 
       <main className="mx-auto max-w-2xl px-4 pb-8 pt-5 sm:pt-8">
+        {DESIGN_MANHOLE_SUBMISSION_SUSPENDED && (
+          <div
+            role="status"
+            className="mb-4 flex items-start gap-2 rounded-lg border-2 border-[#B5483C]/40 bg-[#B5483C]/10 p-3 text-[#B5483C]"
+          >
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+            <div>
+              <p className="text-sm font-bold">
+                {DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE}
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-[#2A2A2A]/70">
+                ご迷惑をおかけします。ポケふた（ポケモンマンホール）の写真投稿は
+                <Link href="/upload" className="mx-0.5 underline hover:opacity-80">
+                  こちら
+                </Link>
+                から通常どおりご利用いただけます。
+              </p>
+            </div>
+          </div>
+        )}
+
         <p className="rounded-lg border border-[#7B63A8]/15 bg-white/70 p-3 text-sm leading-relaxed text-[#2A2A2A]/80">
           ポケふた以外の「オンリーワンなデザインマンホール」を見つけたら教えてください。
           写真1枚と位置情報が必須です。
@@ -619,14 +650,18 @@ export default function DesignManholeNewPage() {
             disabled={!canSubmit}
             className="w-full rounded-lg bg-[#7B63A8] py-3 text-sm font-bold text-white transition hover:bg-[#6A5299] disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {submitting
-              ? '投稿中...'
-              : nearbyOfficialManhole
-                ? '確認待ちで投稿する'
-                : '投稿する'}
+            {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
+              ? '投稿を一時停止中です'
+              : submitting
+                ? '投稿中...'
+                : nearbyOfficialManhole
+                  ? '確認待ちで投稿する'
+                  : '投稿する'}
           </button>
           <p className="mt-2 text-center text-xs text-[#2A2A2A]/50">
-            {nearbyOfficialManhole
+            {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
+              ? '復旧までしばらくお待ちください。'
+              : nearbyOfficialManhole
               ? '近くに公式ポケふたがある投稿は、確認が完了するまで公開されません。'
               : '投稿された写真と位置情報はすぐに公開されます。'}
           </p>

--- a/src/app/design-manholes/new/page.tsx
+++ b/src/app/design-manholes/new/page.tsx
@@ -230,23 +230,17 @@ export default function DesignManholeNewPage() {
     input.click();
   };
 
-  const canSubmit =
-    !DESIGN_MANHOLE_SUBMISSION_SUSPENDED &&
-    isDesignManholeSubmissionReady({
-      hasFile: !!file,
-      hasCoordinates: lat != null && lng != null,
-      exifChecking,
-      submitting,
-      proximityCheckStatus,
-      nearbyOfficialManhole,
-      confirmedNearbyOfficialManholeId,
-    });
+  const canSubmit = isDesignManholeSubmissionReady({
+    hasFile: !!file,
+    hasCoordinates: lat != null && lng != null,
+    exifChecking,
+    submitting,
+    proximityCheckStatus,
+    nearbyOfficialManhole,
+    confirmedNearbyOfficialManholeId,
+  });
 
   const handleSubmit = async () => {
-    if (DESIGN_MANHOLE_SUBMISSION_SUSPENDED) {
-      setError(DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE);
-      return;
-    }
     if (!file || lat == null || lng == null) return;
 
     setSubmitting(true);
@@ -379,31 +373,51 @@ export default function DesignManholeNewPage() {
     );
   }
 
+  // 停止中はフォームを出さない。写真選択・EXIF解析・近接API通信まで進ませてから
+  // 送信だけ弾くと、現地で撮った人の手間を無駄にする。
+  if (DESIGN_MANHOLE_SUBMISSION_SUSPENDED) {
+    return (
+      <div className="min-h-content safe-area-body bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
+        <main className="mx-auto max-w-2xl px-4 pb-8 pt-10">
+          <div
+            role="status"
+            className="rounded-xl border-2 border-[#B5483C]/40 bg-[#B5483C]/10 p-5 text-center"
+          >
+            <AlertCircle className="mx-auto h-10 w-10 text-[#B5483C]" />
+            <h1 className="mt-3 text-base font-bold text-[#B5483C]">
+              {DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE}
+            </h1>
+            <p className="mt-2 text-sm leading-relaxed text-[#2A2A2A]/70">
+              ご迷惑をおかけします。撮っていただいた写真は、復旧後にあらためて投稿してください。
+            </p>
+          </div>
+
+          <p className="mt-6 text-center text-sm text-[#2A2A2A]/70">
+            ポケふた（ポケモンマンホール）の写真投稿は通常どおりご利用いただけます。
+          </p>
+          <div className="mt-4 flex flex-wrap justify-center gap-3">
+            <Link
+              href="/upload"
+              className="rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
+            >
+              ポケふたの写真を投稿する
+            </Link>
+            <Link
+              href="/design-manholes"
+              className="rounded-lg border border-[#7B63A8] px-5 py-2.5 text-sm font-bold text-[#7B63A8] transition hover:bg-[#7B63A8]/10"
+            >
+              みんなのデザインマンホールを見る
+            </Link>
+          </div>
+        </main>
+      </div>
+    );
+  }
+
   return (
     <div className="min-h-content safe-area-body bg-[#F6EEDC] pb-nav-safe text-[#2A2A2A]">
 
       <main className="mx-auto max-w-2xl px-4 pb-8 pt-5 sm:pt-8">
-        {DESIGN_MANHOLE_SUBMISSION_SUSPENDED && (
-          <div
-            role="status"
-            className="mb-4 flex items-start gap-2 rounded-lg border-2 border-[#B5483C]/40 bg-[#B5483C]/10 p-3 text-[#B5483C]"
-          >
-            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
-            <div>
-              <p className="text-sm font-bold">
-                {DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE}
-              </p>
-              <p className="mt-1 text-xs leading-relaxed text-[#2A2A2A]/70">
-                ご迷惑をおかけします。ポケふた（ポケモンマンホール）の写真投稿は
-                <Link href="/upload" className="mx-0.5 underline hover:opacity-80">
-                  こちら
-                </Link>
-                から通常どおりご利用いただけます。
-              </p>
-            </div>
-          </div>
-        )}
-
         <p className="rounded-lg border border-[#7B63A8]/15 bg-white/70 p-3 text-sm leading-relaxed text-[#2A2A2A]/80">
           ポケふた以外の「オンリーワンなデザインマンホール」を見つけたら教えてください。
           写真1枚と位置情報が必須です。
@@ -650,18 +664,14 @@ export default function DesignManholeNewPage() {
             disabled={!canSubmit}
             className="w-full rounded-lg bg-[#7B63A8] py-3 text-sm font-bold text-white transition hover:bg-[#6A5299] disabled:cursor-not-allowed disabled:opacity-40"
           >
-            {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
-              ? '投稿を一時停止中です'
-              : submitting
-                ? '投稿中...'
-                : nearbyOfficialManhole
-                  ? '確認待ちで投稿する'
-                  : '投稿する'}
+            {submitting
+              ? '投稿中...'
+              : nearbyOfficialManhole
+                ? '確認待ちで投稿する'
+                : '投稿する'}
           </button>
           <p className="mt-2 text-center text-xs text-[#2A2A2A]/50">
-            {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
-              ? '復旧までしばらくお待ちください。'
-              : nearbyOfficialManhole
+            {nearbyOfficialManhole
               ? '近くに公式ポケふたがある投稿は、確認が完了するまで公開されません。'
               : '投稿された写真と位置情報はすぐに公開されます。'}
           </p>

--- a/src/app/design-manholes/page.tsx
+++ b/src/app/design-manholes/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import { Plus } from 'lucide-react';
 import MapSection from './MapSection';
 import { loadPublishedDesignManholes } from '@/lib/design-manhole-ogp';
 import { formatDateJaJst } from '@/lib/date';
 import { OGP_IMAGE_URL, SITE_NAME, SITE_URL } from '@/lib/constants';
+import { SubmitCta, SuspendedNotice } from '@/components/DesignManhole/SubmitCta';
+import { DESIGN_MANHOLE_SUBMISSION_SUSPENDED } from '@/lib/design-manhole-submission-status';
 import type { DesignManhole } from '@/types/database';
 
 // Amplify ではビルド時静的化で内容が凍結する事故があるため（/api/site-stats と同じ）、
@@ -63,13 +64,7 @@ function WantedSection() {
         ))}
       </ul>
       <div className="mt-4 text-center">
-        <Link
-          href="/design-manholes/new"
-          className="inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
-        >
-          <Plus className="h-4 w-4" />
-          投稿する
-        </Link>
+        <SubmitCta className="inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]" />
       </div>
     </section>
   );
@@ -116,14 +111,10 @@ export default async function DesignManholesPage() {
               ポケふた以外の、オンリーワンなデザインマンホールのコレクション
             </p>
           </div>
-          <Link
-            href="/design-manholes/new"
-            className="flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]"
-          >
-            <Plus className="h-4 w-4" />
-            投稿する
-          </Link>
+          <SubmitCta className="flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-4 py-2.5 text-sm font-bold text-white shadow-sm transition hover:bg-[#6A5299]" />
         </div>
+
+        <SuspendedNotice />
 
         {loadError ? (
           <p className="mt-5 rounded-lg border border-[#B5483C]/30 bg-[#B5483C]/10 p-3 text-sm text-[#B5483C]">
@@ -132,14 +123,11 @@ export default async function DesignManholesPage() {
         ) : designManholes.length === 0 ? (
           <div className="mt-5 rounded-lg border border-[#7B63A8]/15 bg-white/70 p-8 text-center">
             <p className="text-sm text-[#2A2A2A]/70">
-              まだ投稿がありません。最初の1枚を投稿してみませんか？
+              {DESIGN_MANHOLE_SUBMISSION_SUSPENDED
+                ? 'まだ投稿がありません。'
+                : 'まだ投稿がありません。最初の1枚を投稿してみませんか？'}
             </p>
-            <Link
-              href="/design-manholes/new"
-              className="mt-4 inline-block rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]"
-            >
-              投稿する
-            </Link>
+            <SubmitCta className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-[#7B63A8] px-5 py-2.5 text-sm font-bold text-white transition hover:bg-[#6A5299]" />
           </div>
         ) : (
           <>

--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -12,6 +12,7 @@ import { calculateDistance, isValidCoordinates, MAX_DISTANCE_KM } from '@/lib/lo
 import { createBrowserClient } from '@/lib/supabase/client';
 import { useAnalytics } from '@/lib/hooks/useAnalytics';
 import { pageTitle } from '@/lib/constants';
+import { DESIGN_MANHOLE_SUBMISSION_SUSPENDED } from '@/lib/design-manhole-submission-status';
 
 interface PhotoMetadata {
   latitude?: number;
@@ -659,9 +660,15 @@ function UploadPageInner() {
           実際の訪問を確認するため、GPS位置情報付きの写真（マンホール位置から50m以内）が必須です。
         </p>
         <p className="mt-2 text-right text-xs">
-          <Link href="/design-manholes/new" className="text-[#7B63A8] underline hover:opacity-80">
-            ポケふた以外のデザインマンホールの投稿はこちら →
-          </Link>
+          {DESIGN_MANHOLE_SUBMISSION_SUSPENDED ? (
+            <span className="text-[#2A2A2A]/50">
+              ポケふた以外のデザインマンホールの投稿は一時停止中です
+            </span>
+          ) : (
+            <Link href="/design-manholes/new" className="text-[#7B63A8] underline hover:opacity-80">
+              ポケふた以外のデザインマンホールの投稿はこちら →
+            </Link>
+          )}
         </p>
 
         {/* Hint Manhole Card */}
@@ -759,14 +766,19 @@ function UploadPageInner() {
           {selectedPhoto && !loading && selectedPhoto.error && (
             <div className="mt-2 text-xs text-[#B5483C]">
               <p>{selectedPhoto.error}</p>
-              {selectedPhoto.photoStatus === 'no_nearby_manhole' && (
-                <Link
-                  href="/design-manholes/new"
-                  className="mt-1 inline-block font-bold underline hover:opacity-80"
-                >
-                  ポケふた以外のマンホールなら → デザインマンホール投稿へ
-                </Link>
-              )}
+              {selectedPhoto.photoStatus === 'no_nearby_manhole' &&
+                (DESIGN_MANHOLE_SUBMISSION_SUSPENDED ? (
+                  <p className="mt-1 text-[#2A2A2A]/50">
+                    ポケふた以外のデザインマンホール投稿は現在一時停止中です。
+                  </p>
+                ) : (
+                  <Link
+                    href="/design-manholes/new"
+                    className="mt-1 inline-block font-bold underline hover:opacity-80"
+                  >
+                    ポケふた以外のマンホールなら → デザインマンホール投稿へ
+                  </Link>
+                ))}
             </div>
           )}
         </section>

--- a/src/components/DesignManhole/SubmitCta.tsx
+++ b/src/components/DesignManhole/SubmitCta.tsx
@@ -1,0 +1,51 @@
+import Link from 'next/link';
+import { AlertCircle, Plus } from 'lucide-react';
+import {
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED,
+  DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE,
+} from '@/lib/design-manhole-submission-status';
+
+/**
+ * デザインマンホール投稿への導線。
+ * 停止中に導線を出したままだと、ログインまで求めた末に停止を知らせることになるので、
+ * ボタンそのものを停止表示へ差し替える。
+ */
+export function SubmitCta({ className }: { className: string }) {
+  if (DESIGN_MANHOLE_SUBMISSION_SUSPENDED) {
+    return (
+      <span aria-disabled="true" className={`${className} cursor-not-allowed opacity-50`}>
+        <Plus className="h-4 w-4" />
+        投稿は一時停止中
+      </span>
+    );
+  }
+  return (
+    <Link href="/design-manholes/new" className={className}>
+      <Plus className="h-4 w-4" />
+      投稿する
+    </Link>
+  );
+}
+
+/** 停止中だけ出る告知。閲覧は止めていないことと、ポケふた側は使えることを伝える。 */
+export function SuspendedNotice({ className = 'mt-5' }: { className?: string }) {
+  if (!DESIGN_MANHOLE_SUBMISSION_SUSPENDED) return null;
+  return (
+    <div
+      role="status"
+      className={`${className} flex items-start gap-2 rounded-lg border-2 border-[#B5483C]/40 bg-[#B5483C]/10 p-3 text-[#B5483C]`}
+    >
+      <AlertCircle className="mt-0.5 h-5 w-5 shrink-0" />
+      <div>
+        <p className="text-sm font-bold">{DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE}</p>
+        <p className="mt-1 text-xs leading-relaxed text-[#2A2A2A]/70">
+          閲覧はそのままご利用いただけます。ポケふた（ポケモンマンホール）の写真投稿は
+          <Link href="/upload" className="mx-0.5 underline hover:opacity-80">
+            こちら
+          </Link>
+          から通常どおりどうぞ。
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/design-manhole-submission-status.ts
+++ b/src/lib/design-manhole-submission-status.ts
@@ -1,0 +1,20 @@
+/**
+ * デザインマンホール投稿の一時停止フラグ。
+ *
+ * 停止理由（2026-08-09）:
+ * `supabase/migrations/20260808000000_design_manhole_nearby_review.sql` が本番DBに
+ * 未適用のまま #198 のコードだけデプロイされ、`design_manhole` への INSERT が
+ * 存在しない列（nearby_official_manhole_*）を指すため必ず失敗する。
+ * 利用者には「投稿に失敗しました。時間をおいて再度お試しください」としか出ず、
+ * 時間をおいても直らないので、原因が直るまで受付自体を止めて正直に告知する。
+ *
+ * 本番DBにマイグレーションを適用したら `false` に戻すこと。
+ * ポケふた（/upload）側は同じ列を使わないため影響がなく、停止対象に含めない。
+ */
+export const DESIGN_MANHOLE_SUBMISSION_SUSPENDED = true;
+
+export const DESIGN_MANHOLE_SUBMISSION_SUSPENDED_CODE =
+  'DESIGN_MANHOLE_SUBMISSION_SUSPENDED';
+
+export const DESIGN_MANHOLE_SUBMISSION_SUSPENDED_MESSAGE =
+  '不具合のため、デザインマンホールの投稿を一時停止しています。復旧までしばらくお待ちください。';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { createServerClient } from '@supabase/ssr';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { authCookieOptions } from '@/lib/supabase/cookies';
+import { DESIGN_MANHOLE_SUBMISSION_SUSPENDED } from '@/lib/design-manhole-submission-status';
 
 export async function middleware(req: NextRequest) {
   const res = NextResponse.next();
@@ -38,7 +39,11 @@ export async function middleware(req: NextRequest) {
     // 認証が必要なページへのアクセス
     // upload ページは認証必須
     // visits ページはプレビューモードがあるため未認証でもアクセス可能
-    const protectedPaths = ['/upload', '/design-manholes/new'];
+    // デザインマンホール投稿が停止中は、ログインを求める前に停止案内を見せる
+    // （ログインさせた先が「投稿できません」では意味がない）
+    const protectedPaths = DESIGN_MANHOLE_SUBMISSION_SUSPENDED
+      ? ['/upload']
+      : ['/upload', '/design-manholes/new'];
     const isProtectedPath = protectedPaths.some(path => req.nextUrl.pathname.startsWith(path));
 
     if (!session && isProtectedPath) {


### PR DESCRIPTION
## 何が起きているか

デザインマンホールの投稿が **100% 失敗**しています。画面には「投稿に失敗しました。時間をおいて再度お試しください」と出ますが、**時間をおいても直りません**。

原因は #198 のコードだけが本番に出て、対になる DB マイグレーションが本番に適用されていないことです。

- `supabase/migrations/20260808000000_design_manhole_nearby_review.sql` は存在する
- 本番 Supabase の `supabase_migrations` は `20260718000000_prod_baseline` のみ
- `.github/workflows/` にマイグレーション適用の CI はなく、手動 `db push` 運用

本番の `design_manhole` は #198 以前のままです（実DB確認済み）:

| 期待 | 本番の実状 |
|---|---|
| `nearby_official_manhole_id` / `_distance_m` / `_confirmed_at` | 3列とも無い |
| status CHECK に `needs_review` | `published`, `hidden` のみ |
| RLS insert が `status IN ('published','needs_review')` | `status = 'published'` のみ |
| BEFORE INSERT トリガ | 無し |

`src/app/api/design-manholes/route.ts` の insert は存在しない3列を必ず含めるため PostgREST が `PGRST204` を返し、catch が 500 とあの文言を返していました。近くに公式ポケふたがあるかに関係なく全投稿が落ちます。実データでも `design_manhole` の最終投稿は 2026-08-07 00:25 UTC で、以降ゼロ件です。

## このPRでやること

**根本原因（マイグレーション適用）は別対応**です。本PRは、直るまでの間ユーザーに嘘の案内を出さないための暫定対応です。

- 投稿画面の先頭に停止中バナーを出し、送信ボタンを無効化
- API POST は 503 + `DESIGN_MANHOLE_SUBMISSION_SUSPENDED` で即座に閉じる（R2 に上げてから消す無駄と、古い JS を掴んだクライアントへの誤案内を防ぐ）
- 停止フラグは `src/lib/design-manhole-submission-status.ts` の定数1つ。**マイグレーション適用後に `false` に戻すだけ**で復帰

## ポケふた側は無事

`/upload` が insert する `visit` / `photo` の列は本番にすべて存在し、未適用マイグレーションは `design_manhole` にしか触れていません。実データでも直近3日で77件、最新は 2026-08-09 00:53 UTC に成功しています。バナーからも `/upload` へ導線を残しました。

## 検証

- `npm run type-check` 通過
- dev サーバで `POST /api/design-manholes` が 503 と停止メッセージを返すことを確認
- `npm run test:design-manhole` は `tsx` が未インストールでローカル実行不可

🤖 Generated with [Claude Code](https://claude.com/claude-code)